### PR TITLE
Restyle center player controls

### DIFF
--- a/app/src/main/java/com/brouken/player/PlayerActivity.java
+++ b/app/src/main/java/com/brouken/player/PlayerActivity.java
@@ -3738,7 +3738,8 @@ public class PlayerActivity extends Activity {
 
     private void updateLoading(final boolean enableLoading) {
         if (enableLoading) {
-            exoPlayPause.setVisibility(View.GONE);
+            // INVISIBLE (not GONE): keep the 90dp slot so the row doesn't resize while the spinner shows over it.
+            exoPlayPause.setVisibility(View.INVISIBLE);
             loadingProgressBar.setVisibility(View.VISIBLE);
         } else {
             loadingProgressBar.setVisibility(View.GONE);

--- a/app/src/main/res/drawable/exo_styled_controls_pause.xml
+++ b/app/src/main/res/drawable/exo_styled_controls_pause.xml
@@ -1,13 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<layer-list xmlns:tools="http://schemas.android.com/tools"
-    xmlns:android="http://schemas.android.com/apk/res/android"
-    tools:keep="@drawable/exo_styled_controls_pause">
-    <item android:drawable="@drawable/controls_gradient"/>
-    <item
-        android:drawable="@drawable/exo_ic_pause_circle_filled"
-        android:top="3dp"
-        android:left="3dp"
-        android:right="3dp"
-        android:bottom="3dp">
-    </item>
-</layer-list>
+<inset xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    tools:keep="@drawable/exo_styled_controls_pause"
+    android:drawable="@drawable/ic_pause_24dp"
+    android:inset="24dp"/>

--- a/app/src/main/res/drawable/exo_styled_controls_play.xml
+++ b/app/src/main/res/drawable/exo_styled_controls_play.xml
@@ -1,13 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<layer-list xmlns:tools="http://schemas.android.com/tools"
-    xmlns:android="http://schemas.android.com/apk/res/android"
-    tools:keep="@drawable/exo_styled_controls_play">
-    <item android:drawable="@drawable/controls_gradient"/>
-    <item
-        android:drawable="@drawable/exo_ic_play_circle_filled"
-        android:top="3dp"
-        android:left="3dp"
-        android:right="3dp"
-        android:bottom="3dp">
-    </item>
-</layer-list>
+<inset xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    tools:keep="@drawable/exo_styled_controls_play"
+    android:drawable="@drawable/ic_play_arrow_24dp"
+    android:inset="24dp"/>

--- a/app/src/main/res/drawable/spinner_ring.xml
+++ b/app/src/main/res/drawable/spinner_ring.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Thin ~270° brand arc; the "ring" group is spun by spinner_ring_anim.xml. -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="48dp"
+    android:height="48dp"
+    android:viewportWidth="48"
+    android:viewportHeight="48">
+  <group
+      android:name="ring"
+      android:pivotX="24"
+      android:pivotY="24">
+    <path
+        android:pathData="M24,3 A21,21 0 1 1 3,24"
+        android:strokeColor="@color/brand"
+        android:strokeWidth="3"
+        android:strokeLineCap="round"
+        android:fillColor="#00000000"/>
+  </group>
+</vector>

--- a/app/src/main/res/drawable/spinner_ring_anim.xml
+++ b/app/src/main/res/drawable/spinner_ring_anim.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Spins the ring continuously; AnimatedVectorDrawable (native API 21+), started by the ProgressBar. -->
+<animated-vector xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:aapt="http://schemas.android.com/aapt"
+    android:drawable="@drawable/spinner_ring">
+  <target android:name="ring">
+    <aapt:attr name="android:animation">
+      <objectAnimator
+          android:propertyName="rotation"
+          android:valueFrom="0"
+          android:valueTo="360"
+          android:duration="900"
+          android:repeatCount="-1"
+          android:interpolator="@android:anim/linear_interpolator"/>
+    </aapt:attr>
+  </target>
+</animated-vector>

--- a/app/src/main/res/layout/exo_player_control_view.xml
+++ b/app/src/main/res/layout/exo_player_control_view.xml
@@ -6,6 +6,7 @@
       android:layout_width="match_parent"
       android:layout_height="match_parent"
       android:layout_gravity="center"
+      android:background="@color/controls_scrim"
       android:layoutDirection="ltr">
   </FrameLayout>
 
@@ -131,15 +132,23 @@
 
     <include layout="@layout/exo_player_control_rewind_button" />
 
-    <ImageButton android:id="@+id/exo_play_pause"
-        style="@style/ExoStyledControls.Button.Center.PlayPause"/>
-
-    <ProgressBar android:id="@+id/loading"
-        style="?android:attr/progressBarStyle"
+    <FrameLayout
         android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:indeterminateTint="@color/brand"
-        android:visibility="gone"/>
+        android:layout_height="wrap_content">
+
+      <ImageButton android:id="@+id/exo_play_pause"
+          style="@style/ExoStyledControls.Button.Center.PlayPause"
+          android:layout_gravity="center"/>
+
+      <ProgressBar android:id="@+id/loading"
+          android:layout_width="60dp"
+          android:layout_height="60dp"
+          android:layout_gravity="center"
+          android:indeterminate="true"
+          android:indeterminateDrawable="@drawable/spinner_ring_anim"
+          android:visibility="gone"/>
+
+    </FrameLayout>
 
     <include layout="@layout/exo_player_control_ffwd_button" />
 

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -5,6 +5,9 @@
     <color name="brand">#fe6f61</color>
     <color name="shortcut_background">#F5F5F5</color>
 
+    <!-- Full-frame dim behind the controls; fades with the controller via @id/exo_controls_background. -->
+    <color name="controls_scrim">#66000000</color>
+
     <color name="ui_controls_background">#98000000</color>
     <color name="exo_bottom_bar_background" tools:keep="@color/exo_bottom_bar_background">@color/ui_controls_background</color>
     <color name="exo_black_opacity_70" tools:keep="@color/exo_black_opacity_70">@color/ui_controls_background</color>


### PR DESCRIPTION
## Summary
Restyles the center play/pause button and the buffering indicator to a cleaner, flatter look, and stabilises the controls row while loading.

## Changes
- **Flat play/pause glyph** — `exo_styled_controls_play/pause` now render a flat filled white glyph (reusing `ic_play_arrow_24dp` / `ic_pause_24dp`) instead of the filled circle + radial gradient.
- **Full-frame scrim** — a light dim (`@color/controls_scrim`) backs `exo_controls_background`, so the whole frame dims behind the controls and fades in/out with the controller. This keeps the white glyphs readable on bright scenes without a per-button background.
- **Thin loading spinner** — the buffering `ProgressBar` uses a thin, brand-coloured circular arc (`spinner_ring` + `spinner_ring_anim`, an AnimatedVectorDrawable) instead of the default platform spinner.
- **No row shift while loading** — the play button and spinner share a `FrameLayout`, and during loading the button is hidden with `INVISIBLE` (not `GONE`) so it keeps its slot and the center controls row no longer resizes/jumps.

## Compatibility
- minSdk 23: static VectorDrawable and AnimatedVectorDrawable are supported natively; no support-library flag needed.
- Android TV / D-pad focus is unchanged from the previous behaviour: the button is not focusable only while loading, and focus returns to it on ready (`focusPlay`).

## Testing
- `./gradlew assembleLatestUniversalDebug` builds green.
- Manual device verification pending: flat glyph, scrim fading with the controls, thin spinner during buffering, and stable button row.