### PR TITLE
Recover extensionless HLS playlist items on container-parse error

### DIFF
--- a/app/src/main/java/com/brouken/player/PlayerActivity.java
+++ b/app/src/main/java/com/brouken/player/PlayerActivity.java
@@ -152,6 +152,10 @@ public class PlayerActivity extends Activity {
     // Format.id -> name map that the track list and header read from once tracks are known.
     private final java.util.List<TrackMetadata> containerTracks = new java.util.ArrayList<>();
     private final java.util.Map<String, String> resolvedTrackNames = new java.util.HashMap<>();
+    // Streaming manifest type (HLS/DASH/SS) discovered from the real HTTP response of a media item
+    // whose request URL had no telling extension. Keyed by the requested URI (== MediaItem URI).
+    // Written from a load thread, read on the player thread — hence concurrent.
+    private final java.util.Map<String, String> resolvedMediaTypes = new java.util.concurrent.ConcurrentHashMap<>();
     private final TrackNameParsingDataSource.Listener trackNameListener = new TrackNameParsingDataSource.Listener() {
         @Override
         public void onMetadataParsed(java.util.List<TrackMetadata> tracks) {
@@ -162,6 +166,13 @@ public class PlayerActivity extends Activity {
         @Override
         public boolean isMetadataParsed() {
             return !containerTracks.isEmpty();
+        }
+
+        @Override
+        public void onMediaTypeResolved(Uri originalUri, String mimeType) {
+            if (originalUri != null && mimeType != null) {
+                resolvedMediaTypes.put(originalUri.toString(), mimeType);
+            }
         }
     };
 
@@ -1555,6 +1566,7 @@ public class PlayerActivity extends Activity {
         apiMediaItems.clear();
         apiPlaylistSegments.clear();
         apiPlaylistStartIndex = 0;
+        resolvedMediaTypes.clear();
         apiSeason = -1;
         apiEpisode = -1;
         apiImdbId = null;
@@ -3229,6 +3241,13 @@ public class PlayerActivity extends Activity {
         @Override
         public void onPlayerError(PlaybackException error) {
             updateLoading(false);
+            // An extensionless streaming URL (e.g. a resolver that returns HLS) gets guessed as a
+            // progressive source and then fails to parse. Re-prepare it as the manifest type the
+            // real response revealed before treating the source error as fatal.
+            if (error.errorCode == PlaybackException.ERROR_CODE_PARSING_CONTAINER_UNSUPPORTED
+                    && recoverFromContainerError()) {
+                return;
+            }
             if (error instanceof ExoPlaybackException) {
                 final ExoPlaybackException exoPlaybackException = (ExoPlaybackException) error;
                 if (exoPlaybackException.type == ExoPlaybackException.TYPE_SOURCE) {
@@ -3242,6 +3261,49 @@ public class PlayerActivity extends Activity {
                 }
             }
         }
+    }
+
+    // Re-prepare the current network item as the streaming manifest type discovered from its HTTP
+    // response (or HLS as the common fallback), so an extensionless resolver URL that actually
+    // serves HLS/DASH plays instead of dying on a progressive-parse error. Rebuilding the whole
+    // timeline forces DefaultMediaSourceFactory to re-instantiate the source with the new type
+    // (buildUpon()/replace won't, since the URI is unchanged). Guarded so a genuinely unsupported
+    // stream fails once rather than looping.
+    private boolean recoverFromContainerError() {
+        if (player == null) {
+            return false;
+        }
+        final int index = player.getCurrentMediaItemIndex();
+        final int count = player.getMediaItemCount();
+        if (index < 0 || index >= count) {
+            return false;
+        }
+        final MediaItem currentItem = player.getMediaItemAt(index);
+        if (currentItem.localConfiguration == null) {
+            return false;
+        }
+        final Uri uri = currentItem.localConfiguration.uri;
+        if (!Utils.isSupportedNetworkUri(uri)) {
+            return false;
+        }
+        String targetMime = resolvedMediaTypes.get(uri.toString());
+        if (targetMime == null) {
+            targetMime = MimeTypes.APPLICATION_M3U8;
+        }
+        if (targetMime.equals(currentItem.localConfiguration.mimeType)) {
+            return false;
+        }
+
+        final long position = player.getCurrentPosition();
+        final List<MediaItem> items = new ArrayList<>(count);
+        for (int i = 0; i < count; i++) {
+            final MediaItem item = player.getMediaItemAt(i);
+            items.add(i == index ? item.buildUpon().setMimeType(targetMime).build() : item);
+        }
+        player.setMediaItems(items, index, position);
+        player.prepare();
+        player.play();
+        return true;
     }
 
     private void enableRotation() {

--- a/app/src/main/java/com/brouken/player/TrackNameParsingDataSource.java
+++ b/app/src/main/java/com/brouken/player/TrackNameParsingDataSource.java
@@ -2,6 +2,7 @@ package com.brouken.player;
 
 import android.net.Uri;
 
+import androidx.media3.common.MimeTypes;
 import androidx.media3.datasource.DataSink;
 import androidx.media3.datasource.DataSource;
 import androidx.media3.datasource.DataSpec;
@@ -12,6 +13,7 @@ import java.io.IOException;
 import java.io.PipedInputStream;
 import java.io.PipedOutputStream;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 /**
@@ -31,6 +33,13 @@ final class TrackNameParsingDataSource implements DataSource {
     interface Listener {
         void onMetadataParsed(List<TrackMetadata> tracks);
         boolean isMetadataParsed();
+
+        /**
+         * Called (on a load thread) when the real HTTP response for a media item reveals a streaming
+         * manifest type — HLS/DASH/SmoothStreaming — that the extensionless request URL did not
+         * advertise. {@code originalUri} is the URI the player asked for (matches the MediaItem URI).
+         */
+        void onMediaTypeResolved(Uri originalUri, String mimeType);
     }
 
     // 64 KB in-RAM pipe — a standard IO chunk; keeps memory bounded and provides backpressure.
@@ -53,12 +62,90 @@ final class TrackNameParsingDataSource implements DataSource {
 
     @Override
     public long open(DataSpec dataSpec) throws IOException {
+        final long length;
         if (dataSpec.position == 0 && !listener.isMetadataParsed()) {
             teeDataSource = new TeeDataSource(upstream, pipeSink);
-            return teeDataSource.open(dataSpec);
+            length = teeDataSource.open(dataSpec);
+        } else {
+            teeDataSource = null;
+            length = upstream.open(dataSpec);
         }
-        teeDataSource = null;
-        return upstream.open(dataSpec);
+        // Once the connection is open the response headers and the final (post-redirect) URL are
+        // known: if they reveal a streaming manifest that the request URL didn't advertise (e.g. an
+        // extensionless resolver that returns HLS), report it so the player can re-prepare as HLS.
+        if (dataSpec.position == 0 && dataSpec.uri != null) {
+            reportResolvedMediaType(dataSpec.uri);
+        }
+        return length;
+    }
+
+    private void reportResolvedMediaType(Uri originalUri) {
+        try {
+            final String mimeType = resolveStreamingMimeType(upstream.getResponseHeaders(), upstream.getUri());
+            if (mimeType != null) {
+                listener.onMediaTypeResolved(originalUri, mimeType);
+            }
+        } catch (Exception ignored) {
+            // Never let media-type sniffing disturb the read path.
+        }
+    }
+
+    /**
+     * Maps an HTTP response to an ExoPlayer streaming-manifest MIME type, preferring the
+     * {@code Content-Type} header and falling back to the extension of the final redirected URL.
+     * Returns {@code null} for progressive/unknown content (the caller then keeps the default guess).
+     */
+    static String resolveStreamingMimeType(Map<String, List<String>> responseHeaders, Uri finalUri) {
+        if (responseHeaders != null) {
+            for (Map.Entry<String, List<String>> entry : responseHeaders.entrySet()) {
+                if (entry.getKey() == null || !"Content-Type".equalsIgnoreCase(entry.getKey())) {
+                    continue;
+                }
+                final List<String> values = entry.getValue();
+                if (values != null && !values.isEmpty() && values.get(0) != null) {
+                    String contentType = values.get(0);
+                    final int semicolon = contentType.indexOf(';');
+                    if (semicolon >= 0) {
+                        contentType = contentType.substring(0, semicolon);
+                    }
+                    final String mime = mimeFromContentType(contentType.trim().toLowerCase(Locale.US));
+                    if (mime != null) {
+                        return mime;
+                    }
+                }
+                break;
+            }
+        }
+        if (finalUri != null) {
+            final String path = finalUri.getPath();
+            if (path != null) {
+                final int dot = path.lastIndexOf('.');
+                if (dot >= 0 && dot < path.length() - 1) {
+                    switch (path.substring(dot + 1).toLowerCase(Locale.US)) {
+                        case "m3u8": return MimeTypes.APPLICATION_M3U8;
+                        case "mpd": return MimeTypes.APPLICATION_MPD;
+                        case "ism": case "isml": return MimeTypes.APPLICATION_SS;
+                    }
+                }
+            }
+        }
+        return null;
+    }
+
+    private static String mimeFromContentType(String contentType) {
+        switch (contentType) {
+            case "application/x-mpegurl":
+            case "application/vnd.apple.mpegurl":
+            case "audio/x-mpegurl":
+            case "audio/mpegurl":
+                return MimeTypes.APPLICATION_M3U8;
+            case "application/dash+xml":
+                return MimeTypes.APPLICATION_MPD;
+            case "application/vnd.ms-sstr+xml":
+                return MimeTypes.APPLICATION_SS;
+            default:
+                return null;
+        }
     }
 
     @Override


### PR DESCRIPTION
## Problem

When launched with an API playlist (`video_list` extra), the player played the first
episode but the second failed to load. The playlist itself was fine — the next/prev
arrows and playlist dialog appeared and the player did switch to episode 2 — it just
never loaded.

The cause: some playlist items are extensionless resolver URLs (e.g.
`http://.../lite/lme_uaflix?...&play=true`) that actually serve HLS (or redirect to an
`.m3u8`). Items were built with only `setUri(...)` and no MIME hint, so
`DefaultMediaSourceFactory` inferred a **progressive** source from the extensionless URL
and failed to parse the HLS response. `onPlayerError` treated any `TYPE_SOURCE` error as
fatal and released the whole player — no recovery.

## Fix

- **`TrackNameParsingDataSource`** (already wraps the network `DataSource`): after `open()`,
  detect the real streaming-manifest type from the HTTP response — `Content-Type`
  (`application/vnd.apple.mpegurl` etc.), falling back to the extension of the final
  post-redirect URL — and report it via a new `onMediaTypeResolved` listener callback.
- **`PlayerActivity`**: cache those resolved types per URI, and in `onPlayerError`, on
  `ERROR_CODE_PARSING_CONTAINER_UNSUPPORTED`, re-prepare the current item with the resolved
  type (HLS by default) by rebuilding the timeline, instead of tearing the player down. A
  guard prevents looping when the item already carries the target type.

No new dependencies and no pre-flight probe — `DefaultHttpDataSource` already follows
cross-protocol redirects and exposes the final URI and response headers.

## Testing

No automated tests exist in this project. Verified by building the debug APK and launching
with the reported intent: episode 1 plays, and advancing to episode 2 (extensionless
resolver URL) now loads and plays. Plain local files and single direct `http(s)` streams
are unaffected.
