### PR TITLE
Improve Sentry reports: load watchdog, reliable scope, URL scrubbing

### DIFF
--- a/app/src/main/java/com/brouken/player/App.java
+++ b/app/src/main/java/com/brouken/player/App.java
@@ -3,7 +3,12 @@ package com.brouken.player;
 import android.app.Application;
 import android.preference.PreferenceManager;
 
+import io.sentry.SentryEvent;
 import io.sentry.android.core.SentryAndroid;
+import io.sentry.protocol.Message;
+import io.sentry.protocol.SentryException;
+
+import java.util.List;
 
 public class App extends Application {
 
@@ -18,11 +23,32 @@ public class App extends Application {
             options.setRelease(BuildConfig.APPLICATION_ID + "@" + BuildConfig.VERSION_NAME);
             options.setDist(String.valueOf(BuildConfig.VERSION_CODE));
             options.setEnvironment(BuildConfig.DEBUG ? "debug" : "release");
-            // Honor the user's consent toggle. Checked per event (and for events cached offline or
-            // from a crash and sent on the next launch), so switching it off takes effect immediately.
-            options.setBeforeSend((event, hint) ->
-                    PreferenceManager.getDefaultSharedPreferences(this)
-                            .getBoolean("crashReporting", true) ? event : null);
+            options.setBeforeSend((event, hint) -> {
+                // Honor the user's consent toggle. Checked per event (and for events cached offline or
+                // from a crash and sent on the next launch), so switching it off takes effect immediately.
+                if (!PreferenceManager.getDefaultSharedPreferences(this)
+                        .getBoolean("crashReporting", true)) {
+                    return null;
+                }
+                // Drop URL query strings that ExoPlayer bakes into error messages (e.g. "Response code:
+                // 403 for https://host/path?token=...") so tokens/session ids never leave the device.
+                stripUrlQueries(event);
+                return event;
+            });
         });
+    }
+
+    private static void stripUrlQueries(final SentryEvent event) {
+        final Message message = event.getMessage();
+        if (message != null) {
+            message.setFormatted(Utils.stripUrlQuery(message.getFormatted()));
+            message.setMessage(Utils.stripUrlQuery(message.getMessage()));
+        }
+        final List<SentryException> exceptions = event.getExceptions();
+        if (exceptions != null) {
+            for (SentryException exception : exceptions) {
+                exception.setValue(Utils.stripUrlQuery(exception.getValue()));
+            }
+        }
     }
 }

--- a/app/src/main/java/com/brouken/player/PlayerActivity.java
+++ b/app/src/main/java/com/brouken/player/PlayerActivity.java
@@ -186,6 +186,11 @@ public class PlayerActivity extends Activity {
     public BrightnessControl mBrightnessControl;
     public static boolean haveMedia;
     private boolean videoLoading;
+    // Watchdog for a silent load failure: if the player never reaches STATE_READY within this window
+    // (stuck buffering, a broken next-episode URL, etc.) the load is reported to Sentry. Such stalls
+    // often produce no PlaybackException, so onPlayerError alone would never catch them.
+    private static final long VIDEO_LOAD_TIMEOUT_MS = 30_000L;
+    private final Runnable loadTimeoutRunnable = this::reportVideoLoadTimeout;
     public static boolean controllerVisible;
     public static boolean controllerVisibleFully;
     public static Snackbar snackbar;
@@ -2968,11 +2973,38 @@ public class PlayerActivity extends Activity {
         }
     }
 
+    private void cancelLoadWatchdog() {
+        if (playerView != null) {
+            playerView.removeCallbacks(loadTimeoutRunnable);
+        }
+    }
+
+    private void reportVideoLoadTimeout() {
+        if (player == null) {
+            return;
+        }
+        final MediaItem item = player.getCurrentMediaItem();
+        final Uri uri = item != null && item.localConfiguration != null
+                ? item.localConfiguration.uri : mPrefs.mediaUri;
+        final long position = player.getCurrentPosition();
+        // Per-capture ScopeCallback overload so the level/tags/extra apply to exactly this message.
+        io.sentry.Sentry.captureMessage("Video load timeout", scope -> {
+            scope.setLevel(io.sentry.SentryLevel.WARNING);
+            scope.setTag("player.load_timeout_ms", String.valueOf(VIDEO_LOAD_TIMEOUT_MS));
+            scope.setTag("player.playlist", String.valueOf(player.getMediaItemCount() > 1));
+            scope.setExtra("player.position_ms", String.valueOf(position));
+            if (Utils.isSupportedNetworkUri(uri)) {
+                scope.setExtra("media_uri", Utils.uriToReportString(uri));
+            }
+        });
+    }
+
     public void releasePlayer() {
         releasePlayer(true);
     }
 
     public void releasePlayer(boolean save) {
+        cancelLoadWatchdog();
         if (save) {
             savePlayer();
         }
@@ -3128,6 +3160,7 @@ public class PlayerActivity extends Activity {
 
             if (state == Player.STATE_READY) {
                 frameRendered = true;
+                cancelLoadWatchdog();
 
                 // Ready — hide the spinner and re-enable the episode arrows. Done unconditionally (not only on
                 // the initial open) so episode switches, which don't set videoLoading, are also cleared.
@@ -3230,7 +3263,11 @@ public class PlayerActivity extends Activity {
                 // Buffering (e.g. switching episodes) — show the spinner in place of play and disable the arrows.
                 updateLoading(true);
                 setEpisodeNavLoading(true);
+                // (Re)arm the watchdog: if this buffering never resolves to STATE_READY, it is a stuck load.
+                playerView.removeCallbacks(loadTimeoutRunnable);
+                playerView.postDelayed(loadTimeoutRunnable, VIDEO_LOAD_TIMEOUT_MS);
             } else if (state == Player.STATE_ENDED) {
+                cancelLoadWatchdog();
                 playbackFinished = true;
                 if (apiAccess) {
                     finish();
@@ -3241,6 +3278,7 @@ public class PlayerActivity extends Activity {
         @Override
         public void onPlayerError(PlaybackException error) {
             updateLoading(false);
+            cancelLoadWatchdog();
             // An extensionless streaming URL (e.g. a resolver that returns HLS) gets guessed as a
             // progressive source and then fails to parse. Re-prepare it as the manifest type the
             // real response revealed before treating the source error as fatal.
@@ -3248,9 +3286,16 @@ public class PlayerActivity extends Activity {
                     && recoverFromContainerError()) {
                 return;
             }
-            io.sentry.Sentry.withScope(scope -> {
+            // Enrich via the per-capture ScopeCallback overload (not withScope) so the tag/extra land
+            // on exactly this event.
+            io.sentry.Sentry.captureException(error, scope -> {
                 scope.setTag("player.error_code", error.getErrorCodeName());
-                io.sentry.Sentry.captureException(error);
+                final MediaItem item = player != null ? player.getCurrentMediaItem() : null;
+                final Uri uri = item != null && item.localConfiguration != null
+                        ? item.localConfiguration.uri : mPrefs.mediaUri;
+                if (Utils.isSupportedNetworkUri(uri)) {
+                    scope.setExtra("media_uri", Utils.uriToReportString(uri));
+                }
             });
             if (error instanceof ExoPlaybackException) {
                 final ExoPlaybackException exoPlaybackException = (ExoPlaybackException) error;

--- a/app/src/main/java/com/brouken/player/Utils.java
+++ b/app/src/main/java/com/brouken/player/Utils.java
@@ -556,6 +556,38 @@ class Utils {
         return scheme.startsWith("http") || scheme.equals("rtsp");
     }
 
+    // Matches the query/fragment of an http(s)/rtsp URL inside free text so it can be dropped.
+    private static final java.util.regex.Pattern URL_QUERY =
+            java.util.regex.Pattern.compile("((?:https?|rtsps?)://[^\\s?#]+)[?#][^\\s,)}\\]\"']*");
+
+    // Removes the query string (and fragment) from any http(s)/rtsp URL found in the text, since query
+    // strings are where tokens/session ids live. Keeps scheme, host, port and path; leaves the rest intact.
+    public static String stripUrlQuery(final String text) {
+        if (text == null)
+            return null;
+        return URL_QUERY.matcher(text).replaceAll("$1");
+    }
+
+    // Privacy-safe rendering of a media URI for crash/error reports: keeps scheme, host, port and path
+    // (the route) only. Query string, userinfo and fragment are dropped, since query values carry
+    // tokens/session ids; request headers are never attached anywhere.
+    public static String uriToReportString(final Uri uri) {
+        if (uri == null)
+            return null;
+        final String host = uri.getHost();
+        if (host == null)
+            return uri.getScheme();
+        final StringBuilder sb = new StringBuilder();
+        if (uri.getScheme() != null)
+            sb.append(uri.getScheme()).append("://");
+        sb.append(host);
+        if (uri.getPort() != -1)
+            sb.append(':').append(uri.getPort());
+        if (uri.getEncodedPath() != null)
+            sb.append(uri.getEncodedPath());
+        return sb.toString();
+    }
+
     public static boolean isTvBox(Context context) {
         final PackageManager pm = context.getPackageManager();
 


### PR DESCRIPTION
## Summary

Follow-up to #4 (the initial Sentry integration). #4 was merged while it still contained only the first commit, so `master` shipped the base integration without the fixes and features developed afterwards. This PR brings the remaining work onto `master`.

## What it adds

- **Reliable report enrichment** — attach tags and the media URL via the per-capture `captureException(error, ScopeCallback)` / `captureMessage(msg, ScopeCallback)` overloads instead of `Sentry.withScope`. `withScope` did not apply its scope to the captured event, so playback-error reports arrived without `player.error_code` or a URL.
- **Silent load-failure watchdog** — reports a `Video load timeout` (warning) when the player does not reach `STATE_READY` within 30s of buffering: a stuck stream, a broken next-episode URL, an empty/malformed playlist. These stalls usually produce no `PlaybackException`, so `onPlayerError` alone never caught them.
- **URL scrubbing** — report the failing media URL as `scheme://host:port/path` only (query string, userinfo, fragment dropped), and strip query strings from URLs baked into ExoPlayer exception messages. Streaming links carry tokens/session ids in the query, so this keeps reports free of secrets and of keywords like `token` that would otherwise trip Sentry's server-side scrubber (it was replacing the URL with `[Filtered]`).

## Changes

- `App.java` — enrichment via ScopeCallback; `beforeSend` scrubber strips URL query strings
- `PlayerActivity.java` — load-timeout watchdog; playback-error report carries a sanitized `media_uri`
- `Utils.java` — `uriToReportString` (route only) and `stripUrlQuery` helpers

## Testing

Verified on an emulator with a live DSN: a failing tokenized URL is reported with `player.error_code` and `media_uri` = `http://host:port/path` (no query), with no token leaked in any field (confirmed in the sent event); crashes and the consent toggle behave as before. `assembleLatestUniversalDebug` builds clean.