### PR TITLE
Handle Lampac resolver "not ready" responses gracefully

### DIFF
--- a/app/src/main/java/com/brouken/player/PlayerActivity.java
+++ b/app/src/main/java/com/brouken/player/PlayerActivity.java
@@ -3315,6 +3315,9 @@ public class PlayerActivity extends Activity {
             if (error instanceof ExoPlaybackException) {
                 final ExoPlaybackException exoPlaybackException = (ExoPlaybackException) error;
                 if (exoPlaybackException.type == ExoPlaybackException.TYPE_SOURCE) {
+                    // A source error is fatal — surface it (message + code) before releasing, since
+                    // after teardown the deferred controller-visible path can no longer fire.
+                    showError(exoPlaybackException);
                     releasePlayer(false);
                     return;
                 }
@@ -3323,6 +3326,11 @@ public class PlayerActivity extends Activity {
                 } else {
                     errorToShow = exoPlaybackException;
                 }
+            } else {
+                // Any other playback error — surface a general message + code instead of failing
+                // silently (it was already reported to Sentry above).
+                showSnack(getString(R.string.error_playback_general)
+                        + " (" + PlayerErrorCode.GENERAL_ERROR + ")", error.getLocalizedMessage());
             }
         }
     }
@@ -3676,7 +3684,6 @@ public class PlayerActivity extends Activity {
     }
 
     void showError(ExoPlaybackException error) {
-        final String errorGeneral = error.getLocalizedMessage();
         String errorDetailed;
         final PlayerErrorCode code;
 
@@ -3695,12 +3702,13 @@ public class PlayerActivity extends Activity {
                 break;
             case ExoPlaybackException.TYPE_REMOTE:
             default:
-                errorDetailed = errorGeneral;
+                errorDetailed = error.getLocalizedMessage();
                 code = PlayerErrorCode.UNEXPECTED_ERROR;
                 break;
         }
 
-        showSnack(errorGeneral + " (" + code + ")", errorDetailed);
+        // Friendly primary message + stable code; the raw player message stays available behind "Details".
+        showSnack(getString(R.string.error_playback_general) + " (" + code + ")", errorDetailed);
     }
 
     void showSnack(final String textPrimary, final String textSecondary) {

--- a/app/src/main/java/com/brouken/player/PlayerActivity.java
+++ b/app/src/main/java/com/brouken/player/PlayerActivity.java
@@ -174,7 +174,18 @@ public class PlayerActivity extends Activity {
                 resolvedMediaTypes.put(originalUri.toString(), mimeType);
             }
         }
+
+        @Override
+        public void onResolverNotReady(Uri originalUri) {
+            if (originalUri != null) {
+                resolverNotReadyUri = originalUri.toString();
+            }
+        }
     };
+
+    // Set (on a load thread) to the URI whose response was a Lampac resolver handshake instead of
+    // media; read in onPlayerError to show a friendly message rather than retrying/reporting.
+    private volatile String resolverNotReadyUri;
 
     public CustomPlayerView playerView;
     public static ExoPlayer player;
@@ -2983,20 +2994,11 @@ public class PlayerActivity extends Activity {
         if (player == null) {
             return;
         }
-        final MediaItem item = player.getCurrentMediaItem();
-        final Uri uri = item != null && item.localConfiguration != null
-                ? item.localConfiguration.uri : mPrefs.mediaUri;
-        final long position = player.getCurrentPosition();
-        // Per-capture ScopeCallback overload so the level/tags/extra apply to exactly this message.
-        io.sentry.Sentry.captureMessage("Video load timeout", scope -> {
-            scope.setLevel(io.sentry.SentryLevel.WARNING);
-            scope.setTag("player.load_timeout_ms", String.valueOf(VIDEO_LOAD_TIMEOUT_MS));
-            scope.setTag("player.playlist", String.valueOf(player.getMediaItemCount() > 1));
-            scope.setExtra("player.position_ms", String.valueOf(position));
-            if (Utils.isSupportedNetworkUri(uri)) {
-                scope.setExtra("media_uri", Utils.uriToReportString(uri));
-            }
-        });
+        // A silent stall (buffering never reached READY). Not sent to Sentry — it is usually an
+        // upstream/network condition, not an app bug — just surface a friendly message with its code.
+        updateLoading(false);
+        showSnack(getString(R.string.error_playback_timeout)
+                + " (" + PlayerErrorCode.LOAD_TIMEOUT + ")", null);
     }
 
     public void releasePlayer() {
@@ -3161,6 +3163,8 @@ public class PlayerActivity extends Activity {
             if (state == Player.STATE_READY) {
                 frameRendered = true;
                 cancelLoadWatchdog();
+                // Loaded successfully — clear any pending resolver-handshake flag from a prior attempt.
+                resolverNotReadyUri = null;
 
                 // Ready — hide the spinner and re-enable the episode arrows. Done unconditionally (not only on
                 // the initial open) so episode switches, which don't set videoLoading, are also cleared.
@@ -3279,6 +3283,17 @@ public class PlayerActivity extends Activity {
         public void onPlayerError(PlaybackException error) {
             updateLoading(false);
             cancelLoadWatchdog();
+            // The Lampac stream resolver returned its handshake ({"rch":…}) instead of media: it
+            // resolves the real stream by running client-side code over a WebSocket, which this player
+            // does not implement, so the link can never be obtained here. Show a friendly message and
+            // stop — this is an unsupported upstream flow, not an app bug, so it is not reported to Sentry.
+            if (isResolverNotReadyForCurrentItem()) {
+                resolverNotReadyUri = null;
+                showSnack(getString(R.string.error_stream_not_ready)
+                        + " (" + PlayerErrorCode.RESOLVER_NOT_READY + ")", null);
+                releasePlayer(false);
+                return;
+            }
             // An extensionless streaming URL (e.g. a resolver that returns HLS) gets guessed as a
             // progressive source and then fails to parse. Re-prepare it as the manifest type the
             // real response revealed before treating the source error as fatal.
@@ -3353,6 +3368,16 @@ public class PlayerActivity extends Activity {
         player.prepare();
         player.play();
         return true;
+    }
+
+    // True when the just-failed load was a Lampac resolver handshake for the item that is playing now.
+    private boolean isResolverNotReadyForCurrentItem() {
+        if (resolverNotReadyUri == null || player == null) {
+            return false;
+        }
+        final MediaItem item = player.getCurrentMediaItem();
+        return item != null && item.localConfiguration != null
+                && resolverNotReadyUri.equals(item.localConfiguration.uri.toString());
     }
 
     private void enableRotation() {
@@ -3653,24 +3678,29 @@ public class PlayerActivity extends Activity {
     void showError(ExoPlaybackException error) {
         final String errorGeneral = error.getLocalizedMessage();
         String errorDetailed;
+        final PlayerErrorCode code;
 
         switch (error.type) {
             case ExoPlaybackException.TYPE_SOURCE:
                 errorDetailed = error.getSourceException().getLocalizedMessage();
+                code = PlayerErrorCode.SOURCE_ERROR;
                 break;
             case ExoPlaybackException.TYPE_RENDERER:
                 errorDetailed = error.getRendererException().getLocalizedMessage();
+                code = PlayerErrorCode.RENDERER_ERROR;
                 break;
             case ExoPlaybackException.TYPE_UNEXPECTED:
                 errorDetailed = error.getUnexpectedException().getLocalizedMessage();
+                code = PlayerErrorCode.UNEXPECTED_ERROR;
                 break;
             case ExoPlaybackException.TYPE_REMOTE:
             default:
                 errorDetailed = errorGeneral;
+                code = PlayerErrorCode.UNEXPECTED_ERROR;
                 break;
         }
 
-        showSnack(errorGeneral, errorDetailed);
+        showSnack(errorGeneral + " (" + code + ")", errorDetailed);
     }
 
     void showSnack(final String textPrimary, final String textSecondary) {

--- a/app/src/main/java/com/brouken/player/PlayerErrorCode.java
+++ b/app/src/main/java/com/brouken/player/PlayerErrorCode.java
@@ -8,6 +8,8 @@ package com.brouken.player;
  * add new ones for new cases, never renumber or reuse an existing one.
  */
 enum PlayerErrorCode {
+    /** General fallback: a playback error that matched no more specific category below. */
+    GENERAL_ERROR("JPP-1000"),
     /** Lampac stream resolver returned its {@code {"rch":…}} WebSocket handshake instead of media —
      *  the real stream URL is resolved by client-side code over that socket, which this player does
      *  not implement, so the link can never be obtained here. */

--- a/app/src/main/java/com/brouken/player/PlayerErrorCode.java
+++ b/app/src/main/java/com/brouken/player/PlayerErrorCode.java
@@ -1,0 +1,34 @@
+package com.brouken.player;
+
+/**
+ * Central catalog ("map") of app-level playback error codes surfaced to the user.
+ *
+ * <p>Each constant maps a distinct failure the app recognises to a short alphanumeric code. When a
+ * message shows a code, this list tells exactly which case it was. Codes are stable identifiers:
+ * add new ones for new cases, never renumber or reuse an existing one.
+ */
+enum PlayerErrorCode {
+    /** Lampac stream resolver returned its {@code {"rch":…}} WebSocket handshake instead of media —
+     *  the real stream URL is resolved by client-side code over that socket, which this player does
+     *  not implement, so the link can never be obtained here. */
+    RESOLVER_NOT_READY("JPP-1001"),
+    /** ExoPlayer {@code TYPE_SOURCE}: the media could not be read or parsed. */
+    SOURCE_ERROR("JPP-1002"),
+    /** ExoPlayer {@code TYPE_RENDERER}: a decoder/renderer failed. */
+    RENDERER_ERROR("JPP-1003"),
+    /** ExoPlayer {@code TYPE_UNEXPECTED}: an internal player error. */
+    UNEXPECTED_ERROR("JPP-1004"),
+    /** Playback never reached a ready state within the load watchdog window. */
+    LOAD_TIMEOUT("JPP-1005");
+
+    final String code;
+
+    PlayerErrorCode(String code) {
+        this.code = code;
+    }
+
+    @Override
+    public String toString() {
+        return code;
+    }
+}

--- a/app/src/main/java/com/brouken/player/TrackNameParsingDataSource.java
+++ b/app/src/main/java/com/brouken/player/TrackNameParsingDataSource.java
@@ -3,6 +3,7 @@ package com.brouken.player;
 import android.net.Uri;
 
 import androidx.media3.common.MimeTypes;
+import androidx.media3.common.ParserException;
 import androidx.media3.datasource.DataSink;
 import androidx.media3.datasource.DataSource;
 import androidx.media3.datasource.DataSpec;
@@ -40,6 +41,16 @@ final class TrackNameParsingDataSource implements DataSource {
          * advertise. {@code originalUri} is the URI the player asked for (matches the MediaItem URI).
          */
         void onMediaTypeResolved(Uri originalUri, String mimeType);
+
+        /**
+         * Called (on a load thread) when a media request came back as a Lampac stream-resolver control
+         * response ({@code Content-Type: application/json}, e.g. the {@code {"rch":…}} handshake)
+         * instead of real media. Lampac resolves the real stream URL by running client-side code over
+         * its WebSocket; this player does not speak that protocol, so the resolver stays not-ready and
+         * answers with the control JSON. Reported from the response headers (see {@link #open}) so the
+         * load can fail immediately instead of blocking on the long-polled body.
+         */
+        void onResolverNotReady(Uri originalUri);
     }
 
     // 64 KB in-RAM pipe — a standard IO chunk; keeps memory bounded and provides backpressure.
@@ -75,8 +86,46 @@ final class TrackNameParsingDataSource implements DataSource {
         // extensionless resolver that returns HLS), report it so the player can re-prepare as HLS.
         if (dataSpec.position == 0 && dataSpec.uri != null) {
             reportResolvedMediaType(dataSpec.uri);
+            // A media request answered with a JSON body is a stream-resolver control response (the
+            // Lampac "not ready" handshake), never playable media. The resolver sends these headers
+            // immediately but then long-polls the body until a read timeout — so fail now, from the
+            // headers, instead of blocking ~8s on a body we already know is not media.
+            if (isJsonResponse(upstream.getResponseHeaders())) {
+                try {
+                    listener.onResolverNotReady(dataSpec.uri);
+                } catch (Exception ignored) {
+                    // Never let detection disturb the load path.
+                }
+                closeQuietly();
+                throw ParserException.createForMalformedManifest(
+                        "Stream resolver returned a non-media JSON response", /* cause= */ null);
+            }
         }
         return length;
+    }
+
+    /** Whether the response {@code Content-Type} is JSON (a resolver control response, not media). */
+    private static boolean isJsonResponse(Map<String, List<String>> responseHeaders) {
+        if (responseHeaders == null) {
+            return false;
+        }
+        for (Map.Entry<String, List<String>> entry : responseHeaders.entrySet()) {
+            if (entry.getKey() == null || !"Content-Type".equalsIgnoreCase(entry.getKey())) {
+                continue;
+            }
+            final List<String> values = entry.getValue();
+            return values != null && !values.isEmpty() && values.get(0) != null
+                    && values.get(0).toLowerCase(Locale.US).contains("json");
+        }
+        return false;
+    }
+
+    private void closeQuietly() {
+        try {
+            close();
+        } catch (IOException ignored) {
+            // Best-effort close before rethrowing the detected not-ready error.
+        }
     }
 
     private void reportResolvedMediaType(Uri originalUri) {

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -2,6 +2,7 @@
 <resources>
     <string name="error_files_missing">Приложение \"Файлы\" отключено или отсутствует</string>
     <string name="error_stream_not_ready">Не удалось получить ссылку на видео. Попробуйте перезапустить воспроизведение.</string>
+    <string name="error_playback_general">Не удалось воспроизвести это видео.</string>
     <string name="error_playback_timeout">Воспроизведение слишком долго не начинается. Попробуйте ещё раз.</string>
     <string name="error_details">Подробности</string>
     <string name="open_subtitles">Загрузить субтитры</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="error_files_missing">Приложение \"Файлы\" отключено или отсутствует</string>
+    <string name="error_stream_not_ready">Не удалось получить ссылку на видео. Попробуйте перезапустить воспроизведение.</string>
+    <string name="error_playback_timeout">Воспроизведение слишком долго не начинается. Попробуйте ещё раз.</string>
     <string name="error_details">Подробности</string>
     <string name="open_subtitles">Загрузить субтитры</string>
     <string name="onboarding_open_description">Нажмите, чтобы открыть видеофайл. Нажмите и удерживайте для загрузки внешних субтитров.</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -10,6 +10,8 @@
     <string name="open_subtitles">Завантажити субтитри</string>
     <string name="error_details">Детально</string>
     <string name="error_files_missing">Додаток \"Файли\" вимкнено або відсутній</string>
+    <string name="error_stream_not_ready">Не вдалося отримати посилання на відео. Спробуйте перезапустити відтворення.</string>
+    <string name="error_playback_timeout">Відтворення надто довго не починається. Спробуйте ще раз.</string>
     <string name="request_scope">Щоб автоматично завантажити субтитри, або увімкнути перехід до наступного файлу в теці, надайте %s доступ до головної теки з вашими відеофайлами (наприклад \"Відео\").</string>
     <string name="delete_query">Видалити файл\?</string>
     <string name="delete_confirmation">Видалити</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -11,6 +11,7 @@
     <string name="error_details">Детально</string>
     <string name="error_files_missing">Додаток \"Файли\" вимкнено або відсутній</string>
     <string name="error_stream_not_ready">Не вдалося отримати посилання на відео. Спробуйте перезапустити відтворення.</string>
+    <string name="error_playback_general">Не вдалося відтворити це відео.</string>
     <string name="error_playback_timeout">Відтворення надто довго не починається. Спробуйте ще раз.</string>
     <string name="request_scope">Щоб автоматично завантажити субтитри, або увімкнути перехід до наступного файлу в теці, надайте %s доступ до головної теки з вашими відеофайлами (наприклад \"Відео\").</string>
     <string name="delete_query">Видалити файл\?</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -11,6 +11,8 @@
     <string name="open_subtitles">Load subtitles</string>
     <string name="error_details">Details</string>
     <string name="error_files_missing">Files app is disabled or missing</string>
+    <string name="error_stream_not_ready">Couldn\'t get the video link. Please try restarting playback.</string>
+    <string name="error_playback_timeout">Playback took too long to start. Please try again.</string>
     <string name="request_scope">To automatically load external subtitles or enable skipping to next file in a directory, grant %s access to the topmost folder containing your videos (e.g. Movies).</string>
     <string name="delete_query">Delete this file\?</string>
     <string name="delete_confirmation">Delete</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -12,6 +12,7 @@
     <string name="error_details">Details</string>
     <string name="error_files_missing">Files app is disabled or missing</string>
     <string name="error_stream_not_ready">Couldn\'t get the video link. Please try restarting playback.</string>
+    <string name="error_playback_general">Couldn\'t play this video.</string>
     <string name="error_playback_timeout">Playback took too long to start. Please try again.</string>
     <string name="request_scope">To automatically load external subtitles or enable skipping to next file in a directory, grant %s access to the topmost folder containing your videos (e.g. Movies).</string>
     <string name="delete_query">Delete this file\?</string>


### PR DESCRIPTION
## Problem

Switching episodes on a Lampac-backed playlist intermittently crashed playback with `ExoPlaybackException: Source error` (`ERROR_CODE_PARSING_MANIFEST_MALFORMED`, `Input does not start with the #EXTM3U header`), reported to Sentry.

Root cause: the `rc.bwa.ad` "serial" URLs are not static playlists but a stateful resolver. Until the stream is prepared, a GET returns a JSON control message (`{"rch":true,"nws":"wss://..."}`) instead of the HLS playlist. The resolver finishes preparing by running client-side code over a WebSocket, which the player does not implement, so the link can never be obtained here. Switching to an episode before its stream is ready hits this response and the manifest parse fails. On a cold request the resolver also long-polls the body until an ~8s socket read timeout, adding a delay before the error surfaces.

## Change

- Detect the resolver control response from the response `Content-Type: application/json` in `TrackNameParsingDataSource` as soon as the headers arrive, and fail fast — avoiding the ~8s wait on the long-polled body.
- Show a friendly, localized message (en/uk/ru) with an error code and skip Sentry for this case, since it is an unsupported upstream flow rather than an app bug.
- Stop reporting load timeouts to Sentry; show a message instead.
- Add `PlayerErrorCode`, a small catalog of user-facing player error codes (`JPP-1001`…`JPP-1005`).

## Sentry routing

- `JPP-1001` (resolver not ready) and `JPP-1005` (load timeout): user message only, no Sentry.
- `JPP-1002/1003/1004` (source/renderer/unexpected): reported to Sentry as before.

## Testing

Reproduced on a physical device (OnePlus 11, Android 16) with the captured launch intent: before the change, fast episode switching failed with a black screen / delay; after it, the resolver-not-ready case shows the message immediately and no longer reaches Sentry, while normal episodes play.