### PR TITLE
Fix video-quality sorting crash on API 23

### DIFF
--- a/app/src/main/java/com/brouken/player/PlayerActivity.java
+++ b/app/src/main/java/com/brouken/player/PlayerActivity.java
@@ -1996,7 +1996,7 @@ public class PlayerActivity extends Activity {
         for (int i = 0; i < count; i++) {
             order.add(i);
         }
-        order.sort((a, b) -> Integer.compare(qualityNumber(levels[b]), qualityNumber(levels[a])));
+        Collections.sort(order, (a, b) -> Integer.compare(qualityNumber(levels[b]), qualityNumber(levels[a])));
         for (int i : order) {
             final String label = levels[i];
             final String url = urls[i];
@@ -2767,7 +2767,7 @@ public class PlayerActivity extends Activity {
             choices.add(VideoQualityChoice.auto());
             choices.add(VideoQualityChoice.maximum());
             ArrayList<Integer> longSides = new ArrayList<>(renditions.keySet());
-            longSides.sort(Collections.reverseOrder());
+            Collections.sort(longSides, Collections.reverseOrder());
             for (Integer longSide : longSides) choices.add(renditions.get(longSide));
         }
 


### PR DESCRIPTION
## Problem

The quality-switching feature (#7) used `List.sort(...)` in two places
(`readQualityMap` and `buildQualityChoices`). `List.sort` is a default
method added in **API 24**, but the app targets **minSdk 23**, so on
API 23 devices it throws `NoSuchMethodError` at runtime. Android lint
also flags it as a `NewApi` error, which broke the `build` CI on master.

## Fix

Use `Collections.sort(list, comparator)` (available since API 1) instead.
No behaviour change.