### PR TITLE
Pass SENTRY_DSN to the release build

### DIFF
--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -26,6 +26,7 @@ jobs:
       - run: echo "${{ secrets.KEYSTORE_BASE64 }}" | base64 --decode > ${GITHUB_WORKSPACE}/keystore.jks
 
       - run: ./gradlew assembleLatestUniversalRelease
+          -PSENTRY_DSN=${{ secrets.SENTRY_DSN }}
           -Pandroid.injected.signing.store.file=${GITHUB_WORKSPACE}/keystore.jks
           -Pandroid.injected.signing.store.password=${{ secrets.KEYSTORE_PASSWORD }}
           -Pandroid.injected.signing.key.alias=key


### PR DESCRIPTION
## Problem

The release workflow (`android-build.yml`) built the APK with `./gradlew assembleLatestUniversalRelease` without ever supplying `SENTRY_DSN`. Since `local.properties` is not present in CI, `sentryDsn` resolved to an empty string, so `BuildConfig.SENTRY_DSN` was empty and `App.onCreate` returned early — **Sentry was never initialized in shipped/OTA builds**. This is why no events (crashes or player load errors such as JPP-1002) ever reached Sentry from released versions.

## Fix

Inject the DSN into the release build from a repository secret. The DSN is a public client key that already ships inside every APK, so storing it as a secret is only to avoid hardcoding it in the workflow.

## Follow-up

- Add a repository secret `SENTRY_DSN` (Settings → Secrets and variables → Actions) with the project DSN value.
- A new tag/release is required after merge; the already-built 0.0.7 cannot be fixed retroactively.