### PR TITLE
Separate skip rules for end credits vs intros

### DIFF
--- a/app/src/main/java/com/brouken/player/PlayerActivity.java
+++ b/app/src/main/java/com/brouken/player/PlayerActivity.java
@@ -821,10 +821,10 @@ public class PlayerActivity extends Activity {
                 ViewGroup.LayoutParams.WRAP_CONTENT, ViewGroup.LayoutParams.WRAP_CONTENT));
         buttonSkip.setOnClickListener(v -> {
             if (pendingSkip != null && player != null) {
-                pendingSkip.skipped = true;
-                final long endMs = pendingSkip.endMs();
+                final SkipSegment segment = pendingSkip;
+                segment.skipped = true;
                 hideSkipButton();
-                skipSeekTo(endMs);
+                skipSeekTo(segment);
             }
         });
 
@@ -1805,13 +1805,20 @@ public class PlayerActivity extends Activity {
             hideSkipButton();
             return;
         }
-        // Ad segments are always skipped silently; skip segments follow the button/auto preference.
-        final boolean auto = segment.type == SkipSegment.Type.AD
-                || Prefs.SKIP_MODE_AUTO.equals(mPrefs.skipMode);
+        // Ad segments are always skipped silently. Skip segments follow a per-position preference:
+        // end credits use skipModeCredits, everything else (intro/recap) uses skipMode.
+        final boolean auto;
+        if (segment.type == SkipSegment.Type.AD) {
+            auto = true;
+        } else if (segment.credits) {
+            auto = Prefs.SKIP_MODE_AUTO.equals(mPrefs.skipModeCredits);
+        } else {
+            auto = Prefs.SKIP_MODE_AUTO.equals(mPrefs.skipMode);
+        }
         if (auto) {
             segment.skipped = true;
             hideSkipButton();
-            skipSeekTo(segment.endMs());
+            skipSeekTo(segment);
             showSkipNotification();
         } else {
             updateSkipButtonProgress(segment);
@@ -1833,12 +1840,21 @@ public class PlayerActivity extends Activity {
         skipButtonProgress.setLevel((int) Math.round(fraction * 10000));
     }
 
-    private void skipSeekTo(long positionMs) {
+    private void skipSeekTo(SkipSegment segment) {
         if (player == null)
             return;
+        // A segment reaching the file end maps its end to the duration, so skipping it lands on the
+        // very last frame. seekTo(duration) parks there — playback stalls, paused, without advancing —
+        // so it must move to the next episode like a natural end-of-media instead. Credits that stop
+        // short of the end (a post-credits scene/teaser follows) and the last item, with no next
+        // episode, fall through to an exact seek so that trailing content still plays.
+        if (segment.reachesEnd && player.hasNextMediaItem()) {
+            player.seekToNextMediaItem();
+            return;
+        }
         // Exact seek so playback resumes precisely at the segment end, not at an earlier keyframe.
         player.setSeekParameters(SeekParameters.EXACT);
-        player.seekTo(positionMs);
+        player.seekTo(segment.endMs());
     }
 
     private void showSkipButton(SkipSegment segment) {

--- a/app/src/main/java/com/brouken/player/Prefs.java
+++ b/app/src/main/java/com/brouken/player/Prefs.java
@@ -49,6 +49,7 @@ class Prefs {
     private static final String PREF_KEY_SUBTITLE_STYLE_BOLD = "subtitleStyleBold";
     private static final String PREF_KEY_SKIP_ENABLED = "skipEnabled";
     private static final String PREF_KEY_SKIP_MODE = "skipMode";
+    private static final String PREF_KEY_SKIP_MODE_CREDITS = "skipModeCredits";
     private static final String PREF_KEY_SKIP_FETCH = "skipFetchOnline";
     private static final String PREF_KEY_SHOW_CLOCK = "showClock";
     private static final String PREF_KEY_CRASH_REPORTING = "crashReporting";
@@ -94,6 +95,7 @@ class Prefs {
     public boolean subtitleStyleBold = false;
     public boolean skipEnabled = true;
     public String skipMode = SKIP_MODE_BUTTON;
+    public String skipModeCredits = SKIP_MODE_AUTO;
     public boolean skipFetchOnline = true;
     public boolean showClock = false;
     public boolean crashReporting = true;
@@ -153,6 +155,7 @@ class Prefs {
         subtitleStyleBold = mSharedPreferences.getBoolean(PREF_KEY_SUBTITLE_STYLE_BOLD, subtitleStyleBold);
         skipEnabled = mSharedPreferences.getBoolean(PREF_KEY_SKIP_ENABLED, skipEnabled);
         skipMode = mSharedPreferences.getString(PREF_KEY_SKIP_MODE, skipMode);
+        skipModeCredits = mSharedPreferences.getString(PREF_KEY_SKIP_MODE_CREDITS, skipModeCredits);
         skipFetchOnline = mSharedPreferences.getBoolean(PREF_KEY_SKIP_FETCH, skipFetchOnline);
         showClock = mSharedPreferences.getBoolean(PREF_KEY_SHOW_CLOCK, showClock);
         crashReporting = mSharedPreferences.getBoolean(PREF_KEY_CRASH_REPORTING, crashReporting);

--- a/app/src/main/java/com/brouken/player/skip/SkipManager.java
+++ b/app/src/main/java/com/brouken/player/skip/SkipManager.java
@@ -13,6 +13,22 @@ import java.util.List;
  */
 public class SkipManager {
 
+    /**
+     * A SKIP segment whose end lands past this fraction of the file is treated as the end credits.
+     * Keyed on the end (not the start) so it survives an intro that is shifted deep into the episode
+     * after a long cold open: such an intro still ends far from the finish because the bulk of the
+     * episode follows it, whereas credits end in the closing stretch even when a post-credits scene
+     * or teaser follows.
+     */
+    private static final double CREDITS_END_FRACTION = 0.75;
+
+    /**
+     * A segment ending within this many seconds of the file end counts as reaching the end. The tail
+     * segment is remapped to exactly the duration, but online sources return absolute times that may
+     * stop a touch earlier, so a small tolerance keeps them classified.
+     */
+    private static final double CREDITS_END_TOLERANCE_SEC = 1.5;
+
     private SkipSource source;
     private List<SkipSegment> segments = Collections.emptyList();
 
@@ -30,6 +46,24 @@ public class SkipManager {
     /** Recompute segments against the now-known duration. Safe to call repeatedly. */
     public void rebuild(double durationSec) {
         segments = source != null ? source.getSegments(durationSec) : Collections.<SkipSegment>emptyList();
+        classifyCredits(durationSec);
+    }
+
+    /**
+     * Classify each segment's end-of-file relationship. {@code credits} marks a SKIP segment in the
+     * closing stretch (drives the credits skip-mode); {@code reachesEnd} marks a segment ending at
+     * the file end (drives advancing to the next episode). Guarded on a known positive duration —
+     * otherwise a fraction/tolerance test against a non-positive duration would flag everything.
+     */
+    private void classifyCredits(double durationSec) {
+        final boolean durationKnown = durationSec > 0 && !Double.isNaN(durationSec);
+        for (SkipSegment seg : segments) {
+            seg.credits = durationKnown
+                    && seg.type == SkipSegment.Type.SKIP
+                    && seg.endSec >= durationSec * CREDITS_END_FRACTION;
+            seg.reachesEnd = durationKnown
+                    && seg.endSec >= durationSec - CREDITS_END_TOLERANCE_SEC;
+        }
     }
 
     public boolean hasSegments() {

--- a/app/src/main/java/com/brouken/player/skip/SkipSegment.java
+++ b/app/src/main/java/com/brouken/player/skip/SkipSegment.java
@@ -20,6 +20,22 @@ public class SkipSegment {
     /** Runtime flag: set once the segment has been skipped, so it is only acted on once. */
     public boolean skipped;
 
+    /**
+     * Runtime flag: set by {@link SkipManager} when this is the end-credits segment — a {@code SKIP}
+     * segment ending in the closing stretch of the file (it need not run all the way to the end; a
+     * post-credits scene or next-episode teaser may follow). Keyed on the end so an intro shifted to
+     * mid-episode is not mistaken for credits. Credits follow their own skip-mode preference
+     * ({@code skipModeCredits}).
+     */
+    public boolean credits;
+
+    /**
+     * Runtime flag: set by {@link SkipManager} when the segment ends at (or within tolerance of) the
+     * file end. Only then does skipping it advance the playlist to the next episode; otherwise the
+     * skip seeks to the segment end so any content after the credits still plays.
+     */
+    public boolean reachesEnd;
+
     public SkipSegment(double startSec, double endSec, Type type) {
         this.startSec = startSec;
         this.endSec = endSec;

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -34,9 +34,10 @@
     <string name="pref_skip_enabled">Включено</string>
     <string name="pref_skip_enabled_on">Пропускать заставки и рекламные сегменты от запускающего приложения</string>
     <string name="pref_skip_enabled_off">Воспроизводить как есть</string>
-    <string name="pref_skip_mode">Режим пропуска</string>
+    <string name="pref_skip_mode">Заставка</string>
     <string name="pref_skip_mode_button">Показывать кнопку «Пропустить»</string>
     <string name="pref_skip_mode_auto">Пропускать автоматически</string>
+    <string name="pref_skip_mode_credits">Финальные титры</string>
     <string name="pref_skip_fetch">Искать сегменты онлайн</string>
     <string name="pref_skip_fetch_on">Искать сегменты заставок и титров в онлайн-базах, если источник их не предоставил</string>
     <string name="pref_skip_fetch_off">Использовать только сегменты от запускающего приложения</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -35,9 +35,10 @@
     <string name="pref_skip_enabled">Увімкнено</string>
     <string name="pref_skip_enabled_on">Пропускати заставки та рекламні сегменти від застосунку</string>
     <string name="pref_skip_enabled_off">Відтворювати контент як є</string>
-    <string name="pref_skip_mode">Режим пропуску</string>
+    <string name="pref_skip_mode">Заставка</string>
     <string name="pref_skip_mode_button">Показувати кнопку «Пропустити»</string>
     <string name="pref_skip_mode_auto">Пропускати автоматично</string>
+    <string name="pref_skip_mode_credits">Кінцеві титри</string>
     <string name="pref_skip_fetch">Шукати сегменти онлайн</string>
     <string name="pref_skip_fetch_on">Шукати сегменти заставок і титрів в онлайн-базах, якщо джерело їх не надало</string>
     <string name="pref_skip_fetch_off">Використовувати лише сегменти від застосунку</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -36,9 +36,10 @@
     <string name="pref_skip_enabled">Enabled</string>
     <string name="pref_skip_enabled_on">Skip intros and ad segments provided by the launching app</string>
     <string name="pref_skip_enabled_off">Play content as is</string>
-    <string name="pref_skip_mode">Skip mode</string>
+    <string name="pref_skip_mode">Intro</string>
     <string name="pref_skip_mode_button">Show Skip button</string>
     <string name="pref_skip_mode_auto">Skip automatically</string>
+    <string name="pref_skip_mode_credits">End credits</string>
     <string name="pref_skip_fetch">Find segments online</string>
     <string name="pref_skip_fetch_on">Look up intro/credits segments from online databases when the source provides none</string>
     <string name="pref_skip_fetch_off">Only use segments provided by the launching app</string>

--- a/app/src/main/res/xml/root_preferences.xml
+++ b/app/src/main/res/xml/root_preferences.xml
@@ -71,6 +71,15 @@
             app:title="@string/pref_skip_mode"
             app:useSimpleSummaryProvider="true" />
 
+        <ListPreference
+            app:defaultValue="auto"
+            app:dependency="skipEnabled"
+            app:entries="@array/skip_mode_entries"
+            app:entryValues="@array/skip_mode_values"
+            app:key="skipModeCredits"
+            app:title="@string/pref_skip_mode_credits"
+            app:useSimpleSummaryProvider="true" />
+
         <SwitchPreferenceCompat
             app:key="skipFetchOnline"
             app:defaultValue="true"


### PR DESCRIPTION
## Summary

Splits `skip` segments by position so **end credits** and **intros/recaps** can follow independent skip rules, and fixes a stall when skipping a segment that runs to the end of the file.

Previously a single `skipMode` (button / auto) applied to every `skip` segment, and skipping an outro that reached the file end left the player wedged on the last frame — paused, not advancing to the next episode.

## Changes

- **Advance the playlist on an end-of-file skip.** `seekTo(duration)` is a within-item seek that never crosses into the next item, so it parked on the last frame. When a skipped segment reaches the file end and a next item exists, advance via `seekToNextMediaItem()` instead — mirroring a natural end-of-media. The last item still reaches `STATE_ENDED`.
- **Position classification** (`SkipManager`): a `SKIP` segment ending past 75% of the file is marked `credits`; any segment ending at the file end (within 1.5 s) is marked `reachesEnd`. Keyed on the segment **end** so an intro shifted deep into the episode (after a long cold open) is not mistaken for credits. `reachesEnd` implies `credits`, keeping the flags consistent.
- **Separate preference**: new "End credits" skip mode (`skipModeCredits`, default **auto**) beside the existing "Skip mode" (`skipMode`, default **button**, now covering intros/recaps). Existing users keep their `skipMode` value.
- Credits that stop short of the end (a post-credits scene or teaser follows) seek to the segment end so trailing content still plays; only a segment reaching the end advances to the next episode.
- Strings added for en, plus manual uk/ru.

## Behaviour matrix

| Segment | Mode preference | On skip |
|---|---|---|
| Intro / recap | `skipMode` (default button) | seek to segment end |
| End credits, more content after | `skipModeCredits` (default auto) | seek to segment end (scene plays) |
| End credits, reaching file end | `skipModeCredits` (default auto) | next episode (or `STATE_ENDED` on last item) |
| Ad | always auto | seek to segment end |

## Testing

- `./gradlew assembleLatestUniversalDebug` — builds clean; installed and smoke-tested on device.
- Manual scenarios: intro (button) · outro auto-advance · intro shifted to mid-episode (stays intro) · credits/scene/credits · last episode end.
