### PR TITLE
Add SkipMe.db and IntroHater skip-segment sources with quality-aware …

### DIFF
--- a/app/src/main/java/com/brouken/player/skip/SegmentEndpoints.java
+++ b/app/src/main/java/com/brouken/player/skip/SegmentEndpoints.java
@@ -11,6 +11,19 @@ final class SegmentEndpoints {
 
     /** TV + movies, imdb-keyed, duration-aware. Primary source. */
     static final String SKIPDB = "https://api.skipdb.tv/api/segments";
+    /**
+     * TV + movies, crowd-sourced, duration-aware. Multi-id: accepts imdb / tmdb / tvdb / anilist in
+     * one POST, so it also works when only a tmdb id is known. {@code POST /v1/movies} with a
+     * single-item JSON array; 404 → nothing found. Gated on a recognized client User-Agent
+     * ({@link #SKIPME_UA}) — a plain request is rejected with {@code "Client not supported"}.
+     */
+    static final String SKIPME = "https://db.skipme.workers.dev/v1/movies";
+    /** Client User-Agent SkipMe.db accepts (the published client string; any other UA gets a 403). */
+    static final String SKIPME_UA = "SkipMe.db/0.0";
+    /** Community DB, imdb-keyed ({@code imdb[:season:episode]}), coordinates in seconds. */
+    static final String INTROHATER = "https://introhater.com/api/v1/segments/";
+    /** Baked-in public read key (permission read:segments); a request without it gets a 401. */
+    static final String INTROHATER_KEY = "introhater_mpv_client";
     /** TV only, imdb-keyed. */
     static final String INTRODB = "https://api.introdb.app/segments";
     /** imdb → MAL mapping per season (never pass ?include=). */

--- a/app/src/main/java/com/brouken/player/skip/SegmentFinder.java
+++ b/app/src/main/java/com/brouken/player/skip/SegmentFinder.java
@@ -1,6 +1,7 @@
 package com.brouken.player.skip;
 
 import org.json.JSONArray;
+import org.json.JSONException;
 import org.json.JSONObject;
 
 import java.util.ArrayList;
@@ -10,20 +11,28 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 
 import okhttp3.HttpUrl;
+import okhttp3.MediaType;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
+import okhttp3.RequestBody;
 import okhttp3.Response;
 import okhttp3.ResponseBody;
 
 /**
  * Fetches intro/recap/outro skip segments for one movie or one series episode, keyed only by stable
- * ids (imdb, and season/episode for series) — no title search. Implements the ordered fallback
- * ladder from {@code FIND_INTO.MD}: the first source that returns a non-empty result wins.
+ * ids (imdb, tmdb, and season/episode for series) — no title search.
+ *
+ * <p>Sources are queried in trust order and their results are <b>quality-scored</b>
+ * ({@code score = trust × signal}); the best-scoring result wins rather than simply the first
+ * non-empty one, so a weak early source (a single-submission guess) cannot shadow a precise later
+ * one. Cost is bounded by two stop rules: a strong hit ({@code score ≥ ACCEPT}) returns immediately,
+ * and empty responses never stop the search while at most {@link #NONEMPTY_BUDGET} non-empty results
+ * are weighed before settling (see {@code SKIPME_SOURCE_PLAN.md}).
  *
  * <p>Runs on a background thread; the callback fires on that same worker thread (the caller marshals
  * to the UI thread). Results (including "nothing found") are cached in memory for the process
- * lifetime, keyed by {@code imdb|season|episode}. On any error or timeout a source yields nothing —
- * playback is never affected.
+ * lifetime, keyed by {@code imdb|tmdb|season|episode}. On any error or timeout a source yields
+ * nothing — playback is never affected.
  */
 public final class SegmentFinder {
 
@@ -36,6 +45,18 @@ public final class SegmentFinder {
 
     private static final int TIMEOUT_SEC = 5;
     private static final double OPEN_ENDED_SEC = 99999; // TheIntroDB null end → open-ended
+
+    /** A result with {@code score ≥ ACCEPT} is accepted immediately, ending the probe loop. */
+    private static final double ACCEPT = 0.60;
+    /**
+     * Max <b>non-empty</b> results to weigh before settling on the best. Empty responses never count
+     * and never stop the search — they are the cheap negatives fallbacks exist for, so the ladder is
+     * walked until a source has data (up to the whole list). This cap only bounds how many weak
+     * (below-{@link #ACCEPT}) candidates we gather before picking the highest-scoring one.
+     */
+    private static final int NONEMPTY_BUDGET = 3;
+
+    private static final MediaType JSON = MediaType.parse("application/json; charset=utf-8");
 
     private static final OkHttpClient CLIENT = new OkHttpClient.Builder()
             .connectTimeout(TIMEOUT_SEC, TimeUnit.SECONDS)
@@ -90,8 +111,8 @@ public final class SegmentFinder {
             }
         }
         // No imdb id but we have a tmdb id → reverse-resolve imdb (TMDB external_ids) so the broad
-        // imdb-keyed sources (SkipDB, IntroDB.app, Aniskip) can still be used. If that fails we fall
-        // back to TheIntroDB, which is queried by tmdb id directly.
+        // imdb-keyed sources (SkipDB, IntroDB.app, Aniskip, IntroHater) can still be used. If that
+        // fails we fall back to the multi-id / tmdb-keyed sources (SkipMe.db, TheIntroDB).
         String imdbId = imdbInput;
         if (imdbId == null && tmdbNumeric >= 0) {
             imdbId = tmdbExternalImdb(tmdbNumeric, isMovie);
@@ -99,21 +120,39 @@ public final class SegmentFinder {
 
         final String imdb = imdbId;      // effectively final for the step lambdas
         final long tmdb = tmdbNumeric;
-        List<SkipSegment> result;
+        final List<Candidate> candidates = new ArrayList<>();
         if (isMovie) {
-            result = firstNonEmpty(
-                    () -> imdb != null ? skipDb(imdb, -1, -1, durationSec) : null,
-                    () -> theIntroDb(imdb, tmdb, -1, -1, true));
+            if (imdb != null) {
+                candidates.add(new Candidate(1.0, () -> skipDb(imdb, -1, -1, durationSec)));
+            }
+            if (imdb != null || tmdb >= 0) {
+                candidates.add(new Candidate(0.8, () -> theIntroDb(imdb, tmdb, -1, -1, true)));
+                // SkipMe.db is demoted to the tail: its server-side duration shift is erratic and can
+                // return times offset from the actual encode. Kept only as a broad last resort.
+                candidates.add(new Candidate(0.5, () -> skipMe(imdb, tmdb, -1, -1, durationSec)));
+            }
+            if (imdb != null) {
+                candidates.add(new Candidate(0.4, () -> introHater(imdb, -1, -1)));
+            }
         } else {
-            result = firstNonEmpty(
-                    () -> imdb != null ? skipDb(imdb, season, episode, durationSec) : null,
-                    () -> imdb != null ? introDbApp(imdb, season, episode) : null,
-                    () -> imdb != null ? aniskip(imdb, season, episode) : null,
-                    () -> theIntroDb(imdb, tmdb, season, episode, false));
+            if (imdb != null) {
+                // Anime first: Aniskip is the anime-specialist (crowd-voted OP/ED, per-MAL episode). It
+                // returns empty fast for non-anime (arm finds no MAL), so the ladder falls through.
+                candidates.add(new Candidate(0.9, () -> aniskip(imdb, season, episode)));
+                candidates.add(new Candidate(1.0, () -> skipDb(imdb, season, episode, durationSec)));
+                candidates.add(new Candidate(0.7, () -> introDbApp(imdb, season, episode)));
+            }
+            if (imdb != null || tmdb >= 0) {
+                candidates.add(new Candidate(0.8, () -> theIntroDb(imdb, tmdb, season, episode, false)));
+                // SkipMe.db demoted to the tail (erratic duration shift → offset times).
+                candidates.add(new Candidate(0.5, () -> skipMe(imdb, tmdb, season, episode, durationSec)));
+            }
+            if (imdb != null) {
+                candidates.add(new Candidate(0.4, () -> introHater(imdb, season, episode)));
+            }
         }
-        if (result == null) {
-            result = new ArrayList<>();
-        }
+
+        final List<SkipSegment> result = bestScored(candidates);
         CACHE.put(key, result);
         return result;
     }
@@ -122,28 +161,75 @@ public final class SegmentFinder {
         return s == null || s.trim().isEmpty();
     }
 
-    private interface Step {
-        List<SkipSegment> run();
+    // ---- Quality-aware selection -------------------------------------------------------------
+
+    /** A source result carrying its quality {@link #signal} (0..1); the segment list may be empty. */
+    private static final class Scored {
+        final List<SkipSegment> segments;
+        final double signal;
+
+        Scored(List<SkipSegment> segments, double signal) {
+            this.segments = segments;
+            this.signal = signal;
+        }
+
+        boolean isEmpty() {
+            return segments == null || segments.isEmpty();
+        }
     }
 
-    @SafeVarargs
-    private static List<SkipSegment> firstNonEmpty(Step... steps) {
-        for (Step step : steps) {
+    private interface Step {
+        Scored run();
+    }
+
+    /** A queryable source: its base {@code trust} weight paired with the {@link Step} that runs it. */
+    private static final class Candidate {
+        final double trust;
+        final Step step;
+
+        Candidate(double trust, Step step) {
+            this.trust = trust;
+            this.step = step;
+        }
+    }
+
+    /**
+     * Queries candidates in order, returning the segments of the highest-scoring result
+     * ({@code trust × signal}). Stops early on a strong hit ({@code score ≥ ACCEPT}); empty responses
+     * never stop the search, and at most {@link #NONEMPTY_BUDGET} non-empty results are weighed before
+     * settling. Candidates lacking the required id are omitted upstream.
+     */
+    private static List<SkipSegment> bestScored(List<Candidate> candidates) {
+        Scored best = null;
+        double bestScore = -1;
+        int hits = 0;
+        for (Candidate candidate : candidates) {
             if (Thread.currentThread().isInterrupted()) {
-                return new ArrayList<>();
+                break;
             }
-            final List<SkipSegment> segments = step.run();
-            if (segments != null && !segments.isEmpty()) {
-                return segments;
+            final Scored result = candidate.step.run();
+            if (result == null || result.isEmpty()) {
+                continue; // empty doesn't consume the budget — keep looking down the ladder
+            }
+            final double score = candidate.trust * result.signal;
+            if (score > bestScore) {
+                bestScore = score;
+                best = result;
+            }
+            if (score >= ACCEPT) {
+                break; // strong hit — good enough
+            }
+            if (++hits >= NONEMPTY_BUDGET) {
+                break; // gathered enough weak candidates; settle on the best so far
             }
         }
-        return new ArrayList<>();
+        return best != null ? best.segments : new ArrayList<>();
     }
 
     // ---- Sources -----------------------------------------------------------------------------
 
-    /** SkipDB: {segments:{intro,recap,outro,preview}}, each null or {start_ms,end_ms}. */
-    private static List<SkipSegment> skipDb(String imdbId, int season, int episode, double durationSec) {
+    /** SkipDB: {segments:{intro,recap,outro,preview}}, each null or {start_ms,end_ms,confidence}. */
+    private static Scored skipDb(String imdbId, int season, int episode, double durationSec) {
         final HttpUrl.Builder url = HttpUrl.parse(SegmentEndpoints.SKIPDB).newBuilder()
                 .addQueryParameter("imdb_id", imdbId);
         if (season >= 1 && episode >= 1) {
@@ -153,41 +239,111 @@ public final class SegmentFinder {
         if (durationSec > 0) {
             url.addQueryParameter("duration", String.valueOf((long) durationSec));
         }
-        final JSONObject root = getJson(url.build());
         final List<SkipSegment> out = new ArrayList<>();
+        final JSONObject root = getJson(url.build());
         if (root == null) {
-            return out;
+            return new Scored(out, 0);
         }
         final JSONObject segs = root.optJSONObject("segments");
         if (segs == null) {
-            return out;
+            return new Scored(out, 0);
         }
-        addMs(out, segs.optJSONObject("intro"));
-        addMs(out, segs.optJSONObject("recap"));
-        addMs(out, segs.optJSONObject("outro"));
-        return out;
+        final JSONObject intro = segs.optJSONObject("intro");
+        final JSONObject recap = segs.optJSONObject("recap");
+        final JSONObject outro = segs.optJSONObject("outro");
+        addMs(out, intro);
+        addMs(out, recap);
+        addMs(out, outro);
+        // Signal: average confidence (0..1) over the present segment objects.
+        double sum = 0;
+        int n = 0;
+        for (JSONObject o : new JSONObject[]{intro, recap, outro}) {
+            if (o != null) {
+                sum += o.optDouble("confidence", 0.5);
+                n++;
+            }
+        }
+        return new Scored(out, n > 0 ? sum / n : 0.5);
     }
 
-    /** IntroDB.app: {intro,recap,outro}, each null or {start_sec,end_sec,start_ms,end_ms}. */
-    private static List<SkipSegment> introDbApp(String imdbId, int season, int episode) {
+    /** IntroDB.app: {intro,recap,outro}, each null or {start_sec,end_sec,confidence,submission_count}. */
+    private static Scored introDbApp(String imdbId, int season, int episode) {
         final HttpUrl url = HttpUrl.parse(SegmentEndpoints.INTRODB).newBuilder()
                 .addQueryParameter("imdb_id", imdbId)
                 .addQueryParameter("season", String.valueOf(season))
                 .addQueryParameter("episode", String.valueOf(episode))
                 .build();
-        final JSONObject root = getJson(url);
         final List<SkipSegment> out = new ArrayList<>();
+        final JSONObject root = getJson(url);
         if (root == null) {
-            return out;
+            return new Scored(out, 0);
         }
-        addSecObject(out, root.optJSONObject("intro"));
-        addSecObject(out, root.optJSONObject("recap"));
-        addSecObject(out, root.optJSONObject("outro"));
-        return out;
+        final JSONObject intro = root.optJSONObject("intro");
+        final JSONObject recap = root.optJSONObject("recap");
+        final JSONObject outro = root.optJSONObject("outro");
+        addSecObject(out, intro);
+        addSecObject(out, recap);
+        addSecObject(out, outro);
+        // Signal: best of confidence × min(1, submission_count/3) — a single submission scores low.
+        double best = 0;
+        for (JSONObject o : new JSONObject[]{intro, recap, outro}) {
+            if (o != null) {
+                final double confidence = o.optDouble("confidence", 0.5);
+                final double subs = o.optDouble("submission_count", 1);
+                best = Math.max(best, confidence * Math.min(1.0, subs / 3.0));
+            }
+        }
+        return new Scored(out, best);
+    }
+
+    /**
+     * SkipMe.db: crowd-sourced, multi-id (imdb/tmdb/tvdb/anilist), duration-aware. {@code POST
+     * /v1/movies} with a single-item JSON array; response element carries {intro,recap,credits,
+     * preview} arrays of {start_ms,end_ms(nullable),submissions}.
+     */
+    private static Scored skipMe(String imdbId, long tmdbId, int season, int episode, double durationSec) {
+        final List<SkipSegment> out = new ArrayList<>();
+        final JSONObject req = new JSONObject();
+        try {
+            if (imdbId != null) {
+                req.put("imdb_id", imdbId);
+            }
+            if (tmdbId >= 0) {
+                req.put("tmdb_id", tmdbId);
+            }
+            if (season >= 1 && episode >= 1) {
+                req.put("season", season);
+                req.put("episode", episode);
+            }
+            if (durationSec > 0) {
+                req.put("duration_ms", (long) (durationSec * 1000));
+            }
+        } catch (JSONException e) {
+            return new Scored(out, 0);
+        }
+        final JSONArray response = postJsonArray(SegmentEndpoints.SKIPME, new JSONArray().put(req),
+                SegmentEndpoints.SKIPME_UA);
+        if (response == null) {
+            return new Scored(out, 0);
+        }
+        final JSONObject media = response.optJSONObject(0);
+        if (media == null) {
+            return new Scored(out, 0);
+        }
+        final JSONArray intro = media.optJSONArray("intro");
+        final JSONArray recap = media.optJSONArray("recap");
+        final JSONArray credits = media.optJSONArray("credits");
+        addMsArray(out, intro);
+        addMsArray(out, recap);
+        addMsArray(out, credits);
+        // Signal: min(1, maxSubmissions/5) — 5+ submissions is treated as fully trusted.
+        final int maxSub = Math.max(maxSubmissions(intro),
+                Math.max(maxSubmissions(recap), maxSubmissions(credits)));
+        return new Scored(out, Math.min(1.0, maxSub / 5.0));
     }
 
     /** Anime gate: arm (imdb→MAL for the season), then Aniskip (MAL-relative episode). */
-    private static List<SkipSegment> aniskip(String imdbId, int season, int episode) {
+    private static Scored aniskip(String imdbId, int season, int episode) {
         final List<SkipSegment> out = new ArrayList<>();
         // arm — note: never pass ?include= (it drops the -season fields).
         final HttpUrl armUrl = HttpUrl.parse(SegmentEndpoints.ARM).newBuilder()
@@ -195,7 +351,7 @@ public final class SegmentFinder {
                 .build();
         final JSONArray entries = getJsonArray(armUrl);
         if (entries == null) {
-            return out;
+            return new Scored(out, 0);
         }
         long malId = -1;
         for (int i = 0; i < entries.length(); i++) {
@@ -215,7 +371,7 @@ public final class SegmentFinder {
             }
         }
         if (malId < 0) {
-            return out; // not anime (or no MAL for this season) → fall through
+            return new Scored(out, 0); // not anime (or no MAL for this season) → fall through
         }
         final HttpUrl skipUrl = HttpUrl.parse(SegmentEndpoints.ANISKIP).newBuilder()
                 .addPathSegment(String.valueOf(malId))
@@ -227,11 +383,11 @@ public final class SegmentFinder {
                 .build();
         final JSONObject root = getJson(skipUrl);
         if (root == null) {
-            return out;
+            return new Scored(out, 0);
         }
         final JSONArray results = root.optJSONArray("results");
         if (results == null) {
-            return out;
+            return new Scored(out, 0);
         }
         for (int i = 0; i < results.length(); i++) {
             final JSONObject r = results.optJSONObject(i);
@@ -244,19 +400,20 @@ public final class SegmentFinder {
             }
             addSeg(out, interval.optDouble("startTime", Double.NaN), interval.optDouble("endTime", Double.NaN));
         }
-        return out;
+        // Crowd-voted with real op/ed ends — a high, fixed signal for anime.
+        return new Scored(out, 0.9);
     }
 
     /**
      * TheIntroDB (tmdb-keyed): fetch intro/recap/credits arrays. Uses {@code knownTmdbId} when the
      * caller already has it (from the intent); otherwise resolves it lazily via TMDB find from the imdb id.
      */
-    private static List<SkipSegment> theIntroDb(String imdbId, long knownTmdbId, int season, int episode,
-                                                boolean isMovie) {
+    private static Scored theIntroDb(String imdbId, long knownTmdbId, int season, int episode,
+                                     boolean isMovie) {
         final long tmdbId = knownTmdbId >= 0 ? knownTmdbId : tmdbFind(imdbId, isMovie);
         final List<SkipSegment> out = new ArrayList<>();
         if (tmdbId < 0) {
-            return out;
+            return new Scored(out, 0);
         }
         final HttpUrl.Builder url = HttpUrl.parse(SegmentEndpoints.THEINTRODB).newBuilder()
                 .addQueryParameter("tmdb_id", String.valueOf(tmdbId));
@@ -266,12 +423,54 @@ public final class SegmentFinder {
         }
         final JSONObject root = getJson(url.build());
         if (root == null) {
-            return out;
+            return new Scored(out, 0);
         }
         addMsArray(out, root.optJSONArray("intro"));
         addMsArray(out, root.optJSONArray("recap"));
         addMsArray(out, root.optJSONArray("credits"));
-        return out;
+        // No per-result confidence field; a fixed medium-high signal (matches SkipDB on tested titles).
+        return new Scored(out, 0.8);
+    }
+
+    /**
+     * IntroHater community DB (imdb-keyed): {@code GET /segments/{imdb[:season:episode]}} with the
+     * public {@code x-api-key}. Returns an array of {start,end,label,votes,verified} in seconds.
+     */
+    private static Scored introHater(String imdbId, int season, int episode) {
+        final boolean isEpisode = season >= 1 && episode >= 1;
+        final String videoId = isEpisode ? imdbId + ":" + season + ":" + episode : imdbId;
+        final List<SkipSegment> out = new ArrayList<>();
+        final HttpUrl url = HttpUrl.parse(SegmentEndpoints.INTROHATER + videoId);
+        if (url == null) {
+            return new Scored(out, 0);
+        }
+        final Request request = new Request.Builder()
+                .url(url)
+                .header("Accept", "application/json")
+                .header("x-api-key", SegmentEndpoints.INTROHATER_KEY)
+                .build();
+        final String body = execute(request);
+        if (body == null) {
+            return new Scored(out, 0);
+        }
+        final JSONArray array;
+        try {
+            array = new JSONArray(body);
+        } catch (Exception e) {
+            return new Scored(out, 0);
+        }
+        double signal = 0;
+        for (int i = 0; i < array.length(); i++) {
+            final JSONObject o = array.optJSONObject(i);
+            if (o == null) {
+                continue;
+            }
+            addSeg(out, o.optDouble("start", Double.NaN), o.optDouble("end", Double.NaN));
+            final double s = (o.optBoolean("verified", false) ? 0.5 : 0.3)
+                    + Math.min(0.3, o.optInt("votes", 0) * 0.1);
+            signal = Math.max(signal, s);
+        }
+        return new Scored(out, signal);
     }
 
     /** imdb → tmdb id via TMDB find (lazy; only reached from the TheIntroDB step). */
@@ -352,6 +551,21 @@ public final class SegmentFinder {
         }
     }
 
+    /** Max {@code submissions} across an array of timestamp objects (0 when absent). */
+    private static int maxSubmissions(JSONArray array) {
+        if (array == null) {
+            return 0;
+        }
+        int max = 0;
+        for (int i = 0; i < array.length(); i++) {
+            final JSONObject o = array.optJSONObject(i);
+            if (o != null) {
+                max = Math.max(max, o.optInt("submissions", 1));
+            }
+        }
+        return max;
+    }
+
     private static void addSeg(List<SkipSegment> out, double startSec, double endSec) {
         if (Double.isNaN(startSec) || Double.isNaN(endSec) || endSec <= startSec) {
             return;
@@ -393,10 +607,37 @@ public final class SegmentFinder {
         if (url == null) {
             return null;
         }
-        final Request request = new Request.Builder()
+        return execute(new Request.Builder()
                 .url(url)
                 .header("Accept", "application/json")
+                .build());
+    }
+
+    /** POST a JSON array body, sending {@code userAgent} (some APIs gate on it), and parse the array reply. */
+    private static JSONArray postJsonArray(String url, JSONArray body, String userAgent) {
+        final HttpUrl httpUrl = HttpUrl.parse(url);
+        if (httpUrl == null) {
+            return null;
+        }
+        final Request request = new Request.Builder()
+                .url(httpUrl)
+                .header("Accept", "application/json")
+                .header("User-Agent", userAgent)
+                .post(RequestBody.create(body.toString(), JSON))
                 .build();
+        final String reply = execute(request);
+        if (reply == null) {
+            return null;
+        }
+        try {
+            return new JSONArray(reply);
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    /** Executes a prepared request, returning the body string or null on any non-2xx / failure. */
+    private static String execute(Request request) {
         try (Response response = CLIENT.newCall(request).execute()) {
             if (!response.isSuccessful()) {
                 return null;


### PR DESCRIPTION
…selection

Extend the online skip-segment lookup with two more fallback providers:

- SkipMe.db (POST /v1/movies): crowd-sourced, multi-id (imdb/tmdb/tvdb/anilist).
- IntroHater community DB (GET /segments/{imdb[:season:episode]}): imdb-keyed.

Replace the first-non-empty ladder with quality-aware selection: each source result is scored as trust x signal (signal from confidence / submission counts), and the best-scoring result wins. A strong hit (score >= ACCEPT) is accepted immediately; empty responses never stop the search, and a small budget bounds how many weak non-empty candidates are weighed.

Order sources by reliability: the anime-specialist Aniskip is tried first for series (it returns empty fast for non-anime), and SkipMe.db is demoted to the tail because its server-side duration shift can return times offset from the actual encode.

Query order:
- Movie:  SkipDB, TheIntroDB, SkipMe.db, IntroHater
- Series: Aniskip, SkipDB, IntroDB.app, TheIntroDB, SkipMe.db, IntroHater