### PR TITLE
Recover from Dolby Vision stall by decoding base layer as HEVC

### DIFF
--- a/app/src/main/java/com/brouken/player/PlayerActivity.java
+++ b/app/src/main/java/com/brouken/player/PlayerActivity.java
@@ -95,6 +95,7 @@ import androidx.media3.exoplayer.ExoPlaybackException;
 import androidx.media3.exoplayer.ExoPlayer;
 import androidx.media3.exoplayer.RenderersFactory;
 import androidx.media3.exoplayer.SeekParameters;
+import androidx.media3.exoplayer.mediacodec.MediaCodecSelector;
 import androidx.media3.exoplayer.source.DefaultMediaSourceFactory;
 import androidx.media3.exoplayer.trackselection.DefaultTrackSelector;
 import androidx.media3.extractor.DefaultExtractorsFactory;
@@ -200,10 +201,18 @@ public class PlayerActivity extends Activity {
     public static boolean haveMedia;
     private boolean videoLoading;
     // Watchdog for a silent load failure: if the player never reaches STATE_READY within this window
-    // (stuck buffering, a broken next-episode URL, etc.) the load is reported to Sentry. Such stalls
-    // often produce no PlaybackException, so onPlayerError alone would never catch them.
+    // (stuck buffering, a broken next-episode URL, etc.) a friendly LOAD_TIMEOUT message is shown.
+    // Such stalls often produce no PlaybackException, so onPlayerError alone would never catch them.
     private static final long VIDEO_LOAD_TIMEOUT_MS = 30_000L;
     private final Runnable loadTimeoutRunnable = this::reportVideoLoadTimeout;
+    // One-shot recovery for a mid-playback stall (Media3 StuckPlayerDetector → ERROR_CODE_TIMEOUT),
+    // typically the device's Dolby Vision decoder wedging on a stream: re-decode the DV track as plain
+    // HEVC (HDR10). forceHevcForDolbyVision drives the codec selector at the next player build;
+    // pendingStuckRecovery marks that rebuild so the reset in initializePlayer keeps the flag;
+    // stuckRecoveryAttemptedUri guards against retrying the same URI in a loop.
+    private boolean forceHevcForDolbyVision;
+    private boolean pendingStuckRecovery;
+    private String stuckRecoveryAttemptedUri;
     public static boolean controllerVisible;
     public static boolean controllerVisibleFully;
     public static Snackbar snackbar;
@@ -3286,6 +3295,16 @@ public class PlayerActivity extends Activity {
         boolean isNetworkUri = Utils.isSupportedNetworkUri(mPrefs.mediaUri);
         haveMedia = mPrefs.mediaUri != null;
 
+        // Unless this is the stuck-playback recovery rebuild (which must keep forceHevcForDolbyVision),
+        // clear the one-shot Dolby Vision recovery state so a normal open plays DV through its regular
+        // path and a future stall on any item can recover again.
+        if (pendingStuckRecovery) {
+            pendingStuckRecovery = false;
+        } else {
+            forceHevcForDolbyVision = false;
+            stuckRecoveryAttemptedUri = null;
+        }
+
         // Fresh media — drop any container track names so the tap re-parses for this item.
         containerTracks.clear();
         resolvedTrackNames.clear();
@@ -3334,9 +3353,17 @@ public class PlayerActivity extends Activity {
         DefaultExtractorsFactory extractorsFactory = new DefaultExtractorsFactory()
                 .setTsExtractorFlags(DefaultTsPayloadReaderFactory.FLAG_ENABLE_HDMV_DTS_AUDIO_STREAMS)
                 .setTsExtractorTimestampSearchBytes(1500 * TsExtractor.TS_PACKET_SIZE);
-        @SuppressLint("WrongConstant") RenderersFactory renderersFactory = new DefaultRenderersFactory(this)
+        @SuppressLint("WrongConstant") DefaultRenderersFactory renderersFactory = new DefaultRenderersFactory(this)
                 .setExtensionRendererMode(mPrefs.decoderPriority)
                 .setMapDV7ToHevc(mPrefs.mapDV7ToHevc);
+        if (forceHevcForDolbyVision) {
+            // Stuck-playback recovery: route a Dolby Vision track to the plain HEVC decoder (its
+            // base layer is HEVC), bypassing a device DV decoder that wedged. Picture stays HDR10.
+            renderersFactory.setMediaCodecSelector((mimeType, requiresSecureDecoder, requiresTunnelingDecoder) ->
+                    MediaCodecSelector.DEFAULT.getDecoderInfos(
+                            MimeTypes.VIDEO_DOLBY_VISION.equals(mimeType) ? MimeTypes.VIDEO_H265 : mimeType,
+                            requiresSecureDecoder, requiresTunnelingDecoder));
+        }
 
         ExoPlayer.Builder playerBuilder = new ExoPlayer.Builder(this, renderersFactory)
                 .setTrackSelector(trackSelector);
@@ -3878,6 +3905,30 @@ public class PlayerActivity extends Activity {
                     && recoverFromContainerError()) {
                 return;
             }
+            // A mid-playback stall: Media3's StuckPlayerDetector reports "no progress" as a
+            // TYPE_UNEXPECTED error with ERROR_CODE_TIMEOUT. Not an app bug — the device decoder wedged
+            // (commonly a Dolby Vision stream its DV decoder can't handle). Try a one-shot recovery that
+            // re-decodes DV as plain HEVC; if not applicable / already tried, show a friendly message.
+            if (error.errorCode == PlaybackException.ERROR_CODE_TIMEOUT) {
+                if (recoverFromStuckPlayback()) {
+                    return;
+                }
+                showSnack(getString(R.string.error_playback_stalled)
+                        + " (" + PlayerErrorCode.STUCK_TIMEOUT + ")", error.getLocalizedMessage());
+                // Report as device/firmware telemetry (tagged), not an app bug.
+                io.sentry.Sentry.captureException(error, scope -> {
+                    scope.setTag("player.error_code", error.getErrorCodeName());
+                    scope.setTag("player.stall_class", "device_decoder");
+                    final MediaItem item = player != null ? player.getCurrentMediaItem() : null;
+                    final Uri uri = item != null && item.localConfiguration != null
+                            ? item.localConfiguration.uri : mPrefs.mediaUri;
+                    if (Utils.isSupportedNetworkUri(uri)) {
+                        scope.setExtra("media_uri", Utils.uriToReportString(uri));
+                    }
+                });
+                releasePlayer(false);
+                return;
+            }
             // Enrich via the per-capture ScopeCallback overload (not withScope) so the tag/extra land
             // on exactly this event.
             io.sentry.Sentry.captureException(error, scope -> {
@@ -3952,6 +4003,41 @@ public class PlayerActivity extends Activity {
         player.setMediaItems(items, index, position);
         player.prepare();
         player.play();
+        return true;
+    }
+
+    // One-shot recovery from a mid-playback stall (ERROR_CODE_TIMEOUT) on a Dolby Vision track: rebuild
+    // the player forcing the DV track through the plain HEVC decoder (bypassing a device DV decoder that
+    // wedged). The renderers factory / codec selector can only be set at construction, so a full rebuild
+    // is required; position is preserved via savePlayer() and restorePlayState resumes playback. Guarded
+    // per URI so a stream that stalls again after the switch fails once instead of looping. Returns true
+    // when a recovery rebuild was scheduled.
+    private boolean recoverFromStuckPlayback() {
+        if (player == null) {
+            return false;
+        }
+        final MediaItem item = player.getCurrentMediaItem();
+        if (item == null || item.localConfiguration == null) {
+            return false;
+        }
+        final Format videoFormat = player.getVideoFormat();
+        if (videoFormat == null || !MimeTypes.VIDEO_DOLBY_VISION.equals(videoFormat.sampleMimeType)) {
+            return false;
+        }
+        final String uri = item.localConfiguration.uri.toString();
+        if (uri.equals(stuckRecoveryAttemptedUri)) {
+            return false;
+        }
+        stuckRecoveryAttemptedUri = uri;
+        forceHevcForDolbyVision = true;
+        pendingStuckRecovery = true;
+        restorePlayState = true;
+        // Rebuild on the next loop, after this onPlayerError callback returns, so the player is not
+        // released while its own listener is executing.
+        playerView.post(() -> {
+            releasePlayer();
+            initializePlayer();
+        });
         return true;
     }
 

--- a/app/src/main/java/com/brouken/player/PlayerErrorCode.java
+++ b/app/src/main/java/com/brouken/player/PlayerErrorCode.java
@@ -21,7 +21,11 @@ enum PlayerErrorCode {
     /** ExoPlayer {@code TYPE_UNEXPECTED}: an internal player error. */
     UNEXPECTED_ERROR("JPP-1004"),
     /** Playback never reached a ready state within the load watchdog window. */
-    LOAD_TIMEOUT("JPP-1005");
+    LOAD_TIMEOUT("JPP-1005"),
+    /** Media3 {@code StuckPlayerDetector} reported no playback progress ({@code ERROR_CODE_TIMEOUT}) —
+     *  a mid-playback stall (typically the device decoder wedging on a stream), distinct from the
+     *  pre-ready {@link #LOAD_TIMEOUT}. */
+    STUCK_TIMEOUT("JPP-1006");
 
     final String code;
 

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -4,6 +4,7 @@
     <string name="error_stream_not_ready">Не удалось получить ссылку на видео. Попробуйте перезапустить воспроизведение.</string>
     <string name="error_playback_general">Не удалось воспроизвести это видео.</string>
     <string name="error_playback_timeout">Воспроизведение слишком долго не начинается. Попробуйте ещё раз.</string>
+    <string name="error_playback_stalled">Воспроизведение остановилось — это устройство, возможно, не может декодировать этот файл.</string>
     <string name="error_details">Подробности</string>
     <string name="open_subtitles">Загрузить субтитры</string>
     <string name="onboarding_open_description">Нажмите, чтобы открыть видеофайл. Нажмите и удерживайте для загрузки внешних субтитров.</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -13,6 +13,7 @@
     <string name="error_stream_not_ready">Не вдалося отримати посилання на відео. Спробуйте перезапустити відтворення.</string>
     <string name="error_playback_general">Не вдалося відтворити це відео.</string>
     <string name="error_playback_timeout">Відтворення надто довго не починається. Спробуйте ще раз.</string>
+    <string name="error_playback_stalled">Відтворення зупинилося — цей пристрій, можливо, не може декодувати цей файл.</string>
     <string name="request_scope">Щоб автоматично завантажити субтитри, або увімкнути перехід до наступного файлу в теці, надайте %s доступ до головної теки з вашими відеофайлами (наприклад \"Відео\").</string>
     <string name="delete_query">Видалити файл\?</string>
     <string name="delete_confirmation">Видалити</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -14,6 +14,7 @@
     <string name="error_stream_not_ready">Couldn\'t get the video link. Please try restarting playback.</string>
     <string name="error_playback_general">Couldn\'t play this video.</string>
     <string name="error_playback_timeout">Playback took too long to start. Please try again.</string>
+    <string name="error_playback_stalled">Playback stalled — this device may not be able to decode this file.</string>
     <string name="request_scope">To automatically load external subtitles or enable skipping to next file in a directory, grant %s access to the topmost folder containing your videos (e.g. Movies).</string>
     <string name="delete_query">Delete this file\?</string>
     <string name="delete_confirmation">Delete</string>


### PR DESCRIPTION
## Problem

Sentry `JUST-PLUS-PLAYER-8`: a user on a low-end Realtek Google TV box saw error **JPP-1004** ("Couldn't play this video") on a 4K Dolby Vision HDR remux, even though the video started playing and then froze.

Root cause (confirmed by probing the stream): the file is **Dolby Vision Profile 8.1** (HEVC Main10, HDR10-compatible base layer). The device's hardware Dolby Vision decoder wedges mid-stream; Media3's `StuckPlayerDetector` then reports "no progress" as an `ExoPlaybackException` of type `TYPE_UNEXPECTED` with `ERROR_CODE_TIMEOUT`. The app mapped that generically to `JPP-1004`, reported it to Sentry as an app bug, and left the user stuck. The existing `mapDV7ToHevc` setting does not help — it only covers Profile 7.

## Change

- Detect `ERROR_CODE_TIMEOUT` in `onPlayerError` before the generic Sentry capture.
- **One-shot recovery**: rebuild the player with a custom `MediaCodecSelector` that routes a `video/dolby-vision` track to the plain HEVC decoder (its base layer is HEVC, so the picture stays HDR10), resuming from the stalled position. Guarded per URI so a stream that stalls again fails once instead of looping.
- If recovery is not applicable or was already tried, show a dedicated message with a new code **`JPP-1006` (`STUCK_TIMEOUT`)** and report the event as device/firmware telemetry (tagged `player.stall_class=device_decoder`) rather than an app bug.
- Add `error_playback_stalled` string (en + uk/ru) and fix a stale watchdog comment.

## Scope notes

No user-facing setting is added (recovery is automatic). Buffer/load-control tuning, changing the stuck-detector timeout, and rebuilding the ffmpeg extension were considered and deliberately left out — none address this incident.

## Testing

`./gradlew assembleLatestUniversalDebug` builds clean. Real-world confirmation should be done on the Realtek TV box that reproduces the decoder wedge (a phone with a different decoder plays the file normally).

Fixes JUST-PLUS-PLAYER-8