### PR TITLE
Select skip segments by cross-source voting and add a session skip-offset control

### DIFF
--- a/SKIP/SKIP_ACCURACY_PLAN.md
+++ b/SKIP/SKIP_ACCURACY_PLAN.md
@@ -1,0 +1,215 @@
+# Plan: accurate skip-segment selection + optional video-based boundary refinement
+
+## Context
+
+Online skip-segment lookup (`com.brouken.player.skip`) misfires in two distinct ways (diagnosis in
+`SKIP/SKIP_VOTING_PLAN.md`):
+
+1. **Shifted skip** — 4 of 6 sources (IntroDB.app, Aniskip, TheIntroDB, IntroHater) return absolute
+   broadcast seconds, and `NetworkSegmentsSource` applies them without remap. Worse, the current
+   `bestScored` (trust×signal, `ACCEPT=0.60`) lets them overtake duration-aware SkipDB, inverting its
+   own "file-adaptivity first" principle.
+2. **Extra/phantom skip** — winner-take-all: one bad source supplies the whole list; plus mapping bugs
+   (`isMovie = season<1||episode<1`, split-cour `cand[0]`, open-ended `99999`, cache without
+   `durationSec`, never-expiring negative cache).
+
+**Goal (P0, mandatory):** most accurate segment selection for movies and series — replace
+winner-take-all with **cross-source voting** that is coordinate-system aware.
+**Goal (P1, desirable):** optional refinement of boundaries from the video itself (black-frame snap),
+default OFF and auto-disabled on weak devices.
+
+### Fixed decisions
+- Scope: **P0 + P1** (chapters deferred, see "Out of scope").
+- Single unconfirmed segment: **behaves as before** (auto-skip per `skipMode`/`skipModeCredits`).
+  Coverage prioritized; voting still fixes the shift (coordinate-base) and dedups agreeing segments.
+- Probe budget: **whole profile** (max coverage) → to avoid accumulating latency, sources are probed
+  **in parallel**.
+
+### Logistics (artifacts in the project directory)
+As the first implementation step (before code edits):
+1. **New branch** off `master`: `feature/skip-segment-voting`.
+2. **Save this whole plan** in the repo: `SKIP/SKIP_ACCURACY_PLAN.md` (this file).
+3. **Progress journal**: `SKIP/SKIP_ACCURACY_PROGRESS.md` — kept up to date during execution (modeled
+   on `SKIP/FIND_INTRO_PROGRESS.MD`): checklist of steps A1–A4/B1–B4, statuses, decisions/notes,
+   manual-test results. Update after each significant step.
+
+---
+
+## Part A — P0: voting (accuracy)
+
+### A1. Model: `skip/SkipSegment.java`
+Voting is "per segment type", but the model only knows `Type{SKIP,AD}` (intro/recap/credits category
+from the API is lost). Add:
+- `enum Category { INTRO, RECAP, CREDITS, PREVIEW, UNKNOWN }` + `public final Category category;`
+- `enum CoordBase { DURATION_AWARE, ABSOLUTE, CHAPTER }` + `public final CoordBase coordBase;` +
+  `public final int timeTrust;` (time-source priority: chapter > duration-aware > absolute).
+- `public boolean confirmed;` (runtime flag: ≥2 agreeing). Keep the old constructor as an overload
+  (`Category.UNKNOWN`, `ABSOLUTE`) so `IntentSegmentsSource` need not be rewritten.
+
+### A2. Core: `skip/SegmentFinder.java` (main work)
+- **Parallel profile probe.** Replace the sequential ladder with a fan-out modeled on
+  `SubtitleFetcher.java` (`client.newCall().enqueue()` + `CountDownLatch`). Each source →
+  `Scored{segments, signal, coordBase, timeTrust}`. Probe **all** profile sources (remove `ACCEPT`
+  early exit and `NONEMPTY_BUDGET`); overall deadline ≈ one timeout (5–6s) + cancel via
+  `Thread.interrupt()`.
+- **Two order profiles** (order = time priority on equal agreement):
+  - non-anime: `SkipDB(DA) → SkipMe(DA) → [ABS: TheIntroDB, IntroDB.app, IntroHater]`
+  - anime: `Aniskip(primary, ABS) → SkipDB(DA) → SkipMe(DA) → [ABS: ...]`
+- **Voting** (`voteSegments(...)` instead of `bestScored`):
+  1. Group same-`Category` segments from all non-empty sources.
+  2. **Agreement = ≥2 sources** put a segment in one zone (overlap OR starts within
+     `AGREE_TOLERANCE_SEC`, default 30s) → `confirmed=true`.
+  3. **Timing** of a confirmed segment — from the highest `timeTrust` among agreeing sources (for
+     anime, prefer Aniskip's time). **Do not average** across different coordinate systems.
+  4. **Single segment** (only 1 source, type not seen elsewhere) → included as before
+     (`confirmed=false`, stays in the list; UI handles per mode — see A3).
+- Remove the inversion: adaptivity is expressed via `timeTrust`/order, not a fixed signal.
+- **Cache**: key `imdb|tmdb|season|episode|durationBucket` (bucket = rounded `durationSec`, so a
+  replay of a different rip does not reuse stale timings). Negative result — TTL (e.g. 10 min), not
+  for the whole process.
+- **Fix `isMovie`**: season present, episode 0/absent → do not blindly treat as movie (use the series
+  profile when a season exists).
+- **Remove all debug logging** from the working tree (`TAG="SkipSegments"`, `Log.d`, `fmt`, TODO, and
+  `Candidate.name` added only for logs; revert the `execute()` reordering if it was only for logs) —
+  CLAUDE.md rule.
+
+### A3. Consumption: `skip/NetworkSegmentsSource.java` / `skip/SkipManager.java` / UI
+- `NetworkSegmentsSource` returns the already-grouped/tagged voting output (still fresh copies each
+  rebuild so `skipped` does not leak).
+- **Open-ended `99999`**: allow only for `Category.CREDITS`/end-of-file; otherwise drop or synthesize
+  a reasonable end. Cross-check `classifyCredits`/`reachesEnd` (`CREDITS_END_FRACTION=0.75`, tol 1.5s).
+- **UI policy** in `PlayerActivity.skipTick()` (~1843): behavior by `confirmed` — per the "as before"
+  decision, a single segment still auto-skips per mode. Keep `confirmed` in the model (headroom for a
+  future tightening) but do NOT weaken current auto-skip. `Type.AD` — as now (silent auto-skip).
+
+### A4. Constants
+All thresholds in one place (next to current `ACCEPT`/`NONEMPTY_BUDGET`): `AGREE_TOLERANCE_SEC=30`,
+`MIN_VOTES=2`, probe deadline, `timeTrust` priorities by `CoordBase`.
+
+---
+
+## Part B — P1 (optional): black-frame snap boundary refinement
+
+> **REMOVED (user feedback).** The content-based refinement below (black-frame + scene-cut, via
+> `SegmentRefiner`) was implemented and tested on-device but did not work well enough, so it was
+> dropped in full. Only the deterministic **manual skip offset** (`skipOffset`, see B4) survives from
+> Part B. The rest of this section is kept as a historical record of what was tried. P0 is unaffected.
+
+**Isolated: 1 new class + 1 pref + ~5 small call sites. Default OFF. Deletable without touching P0.**
+Ranking: black-frame (recommended) > silence (phase 2) > scene-change (reject). No in-player frame
+access — use a **separate `MediaMetadataRetriever`** over the same URI in the background, never
+touching `player`/surface/renderers.
+
+### B1. New file: `skip/SegmentRefiner.java`
+- `static Thread refine(Context, Uri, Map<String,String> headers, List<SkipSegment>, double
+  durationSec, Callback)` — interruptible **daemon** thread (contract like `SegmentFinder.find`),
+  callback on the worker with a **new** list; worker's first line `Process.setThreadPriority(LOWEST)`.
+- **Eligibility** (on the worker, first): scheme `file`/`content`, or http(s) with
+  `Utils.isProgressiveContainerUri(uri)`; otherwise no-op (no HLS/DASH/DRM). Refine **≤2 boundaries**:
+  intro/recap end (`SKIP && !credits`) and credits start.
+- **Algorithm**: window **±8s** around the broadcast value, clamped to `[0,duration]` and to neighbor
+  boundaries (only "nudge", never "invent"/"delete"). Coarse pass 1s step `OPTION_CLOSEST_SYNC` +
+  `getScaledFrameAtTime(...,96,54)` (API27+, thumbnail-res); blackness = mean luma < ~0.06 AND low
+  variance (catches fade, rejects dark scenes). If a "dark valley" exists — fine pass 0.25s step
+  `OPTION_CLOSEST`, snap intro-end to the last black frame, credits-start to the first. No valley →
+  original unchanged.
+- **Budgets (hard)**: wall-clock ≈10s (`System.nanoTime()` check between frames → graceful abort),
+  ≤24 `OPTION_CLOSEST` decodes, `Thread.interrupted()` between frames, `retriever.release()` in
+  `finally`, any throwable → "no change".
+- Classifier (`isBlack`, valley/edge search) — package-private static without Android types (pure like
+  `SegmentAdjuster`), suitable for a JVM test.
+
+### B2. `skip/SkipManager.java`
+`public void applyRefined(List<SkipSegment> refined, double durationSec)` — replaces the list, re-runs
+`classifyCredits(durationSec)`, carries over `skipped` by position. `skipTick` unchanged — the next
+tick (250ms) reads new boundaries; `skipSeekTo` (~1891, `SeekParameters.EXACT`) already lands exactly.
+
+### B3. `PlayerActivity.java` (small insertions)
+- Field `segmentRefinerThread` + `cancelSegmentRefiner()` (mirror `cancelSegmentFinder` ~1773); cancel
+  in `resetApiState` (~1676) and `setupSkipSource` (~1685).
+- `maybeRefineSegments()` at the end of `rebuildSkip()` (after ~1724) — only when
+  `skipManager.hasSegments() && mPrefs.skipEnabled && mPrefs.skipRefineContent &&
+  Utils.isContentRefinementCapable(this)` and a per-media gate. Captures `targetIndex`,
+  `currentPlayingUri()` (~2807) + headers (like ~3440), starts with `postDelayed` ~3s (do not disturb
+  start-up buffering). Both paths (intent and network) funnel through the single `rebuildSkip()`, so
+  one site suffices.
+- `onSegmentsRefined(targetIndex, refined)` via `runOnUiThread`, guard like `onSegmentsFetched`
+  (~1764): discard if `player==null`, index changed, or no segments → `applyRefined` +
+  `updateSkipHighlights()`.
+
+### B1b. Scene-cut (added to `SegmentRefiner`)
+A boundary is often a hard cut with no fade, so `snapBoundary` now: tries the black-frame snap first
+only when `useBlack`; otherwise / on its miss, falls back to `snapToSceneCut` when `useSceneCut` —
+sample exact frames at 0.5s over a narrow ±3s window, reduce each to a 4×4 luma-grid signature, and
+snap to the **significant cut nearest the estimate** (largest consecutive-signature distance above
+`SCENE_CUT_MIN`, tie-broken by proximity). Decode budget raised to 48 (still under the 10s wall-clock).
+
+### B4. Prefs + gating (disable strategy)
+Two independent refinement techniques + a manual offset, all in the **Skip** settings section
+(`pref_skip_header`), each `app:dependency="skipEnabled"`:
+- **`skipRefineScene`** (`SwitchPreferenceCompat`, **default ON**) — scene-cut snap; the primary fix
+  for small (~1–3s) offsets at hard cuts, hence on by default.
+- **`skipRefineBlack`** (`SwitchPreferenceCompat`, **default OFF**) — additionally prefer a nearby
+  fade/black frame when present (tried before the scene-cut fallback).
+- **`skipOffset`** (`ListPreference`, values `-5..+5`, **default 0**) — deterministic global shift of
+  every segment (no analysis), for when neither snap lands right. Applied in `SkipManager.applyOffset`
+  (shift + clamp to media bounds); set via `SkipManager.setOffsetSec` from `rebuildSkip` before `rebuild`.
+- `maybeRefineSegments` runs when **either** refine toggle is on and passes `useBlack`/`useSceneCut`.
+- **No hard device lock** (overridable everywhere). Safety nets instead of a device-tier gate:
+  - `SegmentRefiner` no-ops on `Build.VERSION.SDK_INT < 27` (its `getScaledFrameAtTime` needs API 27).
+  - Per-media gate in `maybeRefineSegments`: refuse when `height>2160`, or `height>1080 && isTvBox`.
+- `Utils.isContentRefinementCapable(Context)` (SDK≥27 && !low-RAM && ≥4 cores) is **kept but unused** —
+  a ready hook for a future "disable/smart-default on old hardware" behavior.
+
+---
+
+## Work order
+0. Create branch `feature/skip-segment-voting`; save plan to `SKIP/SKIP_ACCURACY_PLAN.md`; start
+   `SKIP/SKIP_ACCURACY_PROGRESS.md` with a checklist.
+1. A1 model → A2 voting core → A3 consumption → A4 constants (P0).
+2. B1 refiner → B2 applyRefined → B3 hooks → B4 pref/gating (P1).
+3. Remove debug logging; build; manual verification per checklist.
+4. Update `SKIP/SKIP_ACCURACY_PROGRESS.md` along the way; finally `git diff` for cleanliness (no debug).
+
+## Files to modify
+- `app/.../skip/SkipSegment.java` — category, coordBase/timeTrust, confirmed (A1).
+- `app/.../skip/SegmentFinder.java` — parallel probe, profiles, voting, cache, isMovie, remove logs
+  (A2). **Core work.**
+- `app/.../skip/NetworkSegmentsSource.java`, `skip/SkipManager.java` — consumption, open-ended cap,
+  `applyRefined` (A3, B2).
+- `app/.../PlayerActivity.java` — remove debug logs; refiner hooks (A3, B3).
+- `app/.../skip/SegmentRefiner.java` — **new** (B1).
+- `app/.../Prefs.java`, `res/xml/root_preferences.xml`, `res/values/strings.xml`,
+  `app/.../SettingsActivity.java`, `app/.../Utils.java` — pref + gating (B4).
+
+## Reuse
+- Fan-out probe: `SubtitleFetcher.java` (enqueue + `CountDownLatch`).
+- Threading/cancel: `SegmentFinder.find`/`cancelSegmentFinder`, `nextUriThread`, `frameRateSwitchThread`.
+- OkHttp/JSON/endpoints: `SegmentFinder` helpers + `SegmentEndpoints.java`.
+- Gating: `Utils.isTvBox`, `player.getVideoFormat()` (~2204), `setEnabled` pattern in `SettingsActivity` (~93).
+- URI/eligibility: `currentPlayingUri()` (~2807), `Utils.isProgressiveContainerUri`.
+
+## Verification (no tests in project → build + manual)
+1. `./gradlew assembleLatestUniversalDebug` (JDK 17); artifact — `just-plus.player.debug.apk`.
+2. **Non-anime** (Breaking Bad `tt0903747` S1E1): duration-aware SkipDB gives timing; absolute
+   TheIntroDB does not overtake nor apply shifted.
+3. **Anime** (Attack on Titan `tt2560140` S1E1): Aniskip primary; SkipMe does not override timing.
+4. **Replay shift**: same title, different length does not take the stale cache (key with duration bucket).
+5. **Voting**: ≥2 agreeing → `confirmed`, exact timing; single → shown (per mode).
+6. **Latency**: parallel profile probe fits within ~one timeout (temporary request-count log, then remove).
+7. **P1** (Pulp Fiction `tt0110912` / local MKV with fade intro): snap ≤0.25s; file with no black
+   boundary → explicit no-op; HLS URL → "ineligible", 0 retriever calls; episode change during refine
+   → interrupt without callback; 4K long-GOP → graceful abort in ~10s.
+8. **P1 gating**: low-RAM/API26 emulator — pref greyed out; TV + >1080p — per-media refusal.
+9. **Non-regression**: with pref OFF (default) player/skip behavior byte-identical; `git grep
+   skipRefineContent` outside the new class touches only the guard, Prefs, XML, SettingsActivity.
+10. `git diff` — no debug logging before commit (CLAUDE.md).
+
+## Out of scope (deferred)
+- **Chapters as a time source** — strongest lever against shift, but deliberately deferred in
+  `SKIP_VOTING_PLAN.md` ("network only for now"). Model is ready (`CoordBase.CHAPTER`, top
+  `timeTrust`) — port `ChapterScanner` as a separate `SkipSource` next iteration. Limitation: current
+  parsers (`ContainerMetadataReader`/`Mp4`/`Matroska`) read only the start of the file — MP4 `moov`/MKV
+  Chapters at EOF are not reached; needs extension.
+- **Silence detection** — phase 2 inside `SegmentRefiner` (fallback for audio-led content), if field
+  data shows black-frame misses.

--- a/SKIP/SKIP_ACCURACY_PROGRESS.md
+++ b/SKIP/SKIP_ACCURACY_PROGRESS.md
@@ -1,0 +1,99 @@
+# Progress: accurate skip-segment selection + optional boundary refinement
+
+Tracking implementation of `SKIP/SKIP_ACCURACY_PLAN.md`.
+Branch: `feature/skip-segment-voting`.
+
+Legend: `[ ]` pending · `[~]` in progress · `[x]` done
+
+## Step 0 — logistics
+- [x] Branch `feature/skip-segment-voting` created off `master`
+- [x] Plan saved to `SKIP/SKIP_ACCURACY_PLAN.md`
+- [x] Progress journal started (`SKIP/SKIP_ACCURACY_PROGRESS.md`)
+
+## Part A — P0 voting (accuracy)
+- [x] **A1** `SkipSegment` model: `Category`, `CoordBase`, `timeTrust`, `confirmed`; keep legacy ctor
+- [x] **A2** `SegmentFinder`: parallel profile probe (`probeAll` + `CountDownLatch` + `AtomicReferenceArray`)
+- [x] **A2** Two order profiles (anime / non-anime); absolute sources to tail
+- [x] **A2** `voteSegments`/`bestCluster`: group by category, cluster by tolerance, ≥2 = confirmed, timing from top `timeTrust`, no averaging; one segment per category (dedup/anti-phantom)
+- [x] **A2** Cache key with duration bucket; negative-result TTL (10 min) via `CacheEntry`
+- [x] **A2** Fix `isMovie` gate (season present → series profile even if episode 0)
+- [x] **A2** Remove all debug logging (`TAG`, `Log.d`, `fmt`, `Candidate.name`, TODO) — whole class rewritten clean
+- [x] **A3** `NetworkSegmentsSource`: preserve voting metadata + `confirmed` in copy loop; open-ended `99999` capped to CREDITS in `addMsArray`
+- [x] **A3** UI policy in `skipTick`: unchanged (single = auto-skip per mode; `confirmed` kept for future)
+- [x] **A4** Centralize constants (`AGREE_TOLERANCE_SEC=30`, `MIN_VOTES=2`, `PROBE_DEADLINE_SEC`, `NEG_CACHE_TTL_MS`, `TT_*`)
+
+## Part B — manual skip offset only (content refinement REMOVED)
+> **Decision (user feedback):** the content-based video refinement (black-frame + scene-cut) was
+> tried on-device and did not work well enough, so it was **removed entirely**. Only the deterministic
+> manual offset is kept. `SegmentRefiner` deleted; `SkipManager.applyRefined`, the `PlayerActivity`
+> refiner hooks, the `skipRefineScene`/`skipRefineBlack` prefs + switches + strings, and
+> `Utils.isContentRefinementCapable` are all gone. `Utils` reverted to package-private.
+- [x] ~~Manual `skipOffset` ListPreference in settings~~ → **replaced by a session-only in-player
+  control** (user feedback: offset should be session-scoped and reachable from the player, not global
+  settings). Persisted pref/`ListPreference`/arrays/`parseIntSafe`/`pref_skip_offset` removed.
+- [x] **Session skip-offset control**: `skipOffsetSec` + `skipSeenThisSession` session fields on
+  `PlayerActivity` (reset in `resetApiAccess`); dedicated bottom-row button `buttonSkipOffset` next to
+  the gear, shown only when a skip segment exists now or earlier this session (`updateSkipOffsetButton`).
+- [x] **Slider panel** `showSkipOffsetDialog` (end-docked translucent, like quality): value readout +
+  `SeekBar` (touch fine 0.25 s; TV D-pad `keyProgressIncrement`=0.5 s, focusable) + −/+ + Reset; range
+  ±30 s. `applySkipOffset` → `SkipManager.setOffsetSec` + `rebuildSkip` (live highlight move).
+- [x] `SkipManager.setOffsetSec`/`applyOffset` kept as-is (already in-memory). New icon
+  `ic_skip_offset_24dp`; strings `skip_offset_title`/`skip_offset_reset`/`button_skip_offset` (en/uk/ru).
+
+## Build & verification
+
+### Verified (this session)
+- [x] `./gradlew assembleLatestUniversalDebug` green (compiled/dexed/packaged; only pre-existing Java-8 source/target warnings)
+- [x] Cleanliness: no `SkipSegments`/`Log.d`/`TODO(debug)`/Claude mentions in changed code
+
+### NOT verified — needs a real device / emulator run
+> The whole feature has been built but **not exercised at runtime** — no playback, no live network
+> lookups, no device profiling were done. All behavioral claims below are unverified. Run this
+> checklist before relying on it / merging. Watch `adb logcat` for crashes; there is no debug logging
+> in the code, so add temporary logging locally if needed while testing, then remove it.
+
+P0 — voting / accuracy:
+- [ ] **Non-anime** (Breaking Bad `tt0903747` S1E1 via LAMPA): intro/credits fire on time; the
+  duration-aware SkipDB timing is used, an absolute source (TheIntroDB) does not overtake it or apply
+  a shifted time.
+- [ ] **Anime** (Attack on Titan `tt2560140` S1E1): Aniskip is primary; its OP/ED timing is used and
+  SkipMe/others do not override it.
+- [ ] **Voting / phantom control**: when ≥2 sources agree, the segment is used with the most
+  file-accurate timing; conflicting single-source picks in a category do not produce a double intro.
+- [ ] **Single-source coverage**: a category reported by only one source is still offered/auto-skipped
+  (per the "as before" decision) — coverage not lost.
+- [ ] **Replay-shift**: replaying the same title from a differently-cut rip (different duration) does
+  NOT reuse stale cached timings (duration-bucket cache key).
+- [ ] **Negative-cache TTL**: a title that returned nothing after a transient network error is
+  re-probed later in the same process (within ~10 min TTL), not silenced permanently.
+- [ ] **Latency**: parallel profile probe completes within roughly one source timeout (not the sum);
+  first skip is offered promptly.
+- [ ] **Playback safety**: all sources missing / offline → no segments, no crash, playback unaffected;
+  open-ended credits do not stall the player.
+
+P1 — content refinement (default OFF; enable the "Refine segments from video" toggle to test):
+- [ ] **Fade snap**: local MP4/MKV with a known fade-out intro → intro end snaps to the black frame
+  (small nudge); credits start likewise.
+- [ ] **No-op safety**: a file with no black boundary in the window → boundary unchanged (no wrong snap).
+- [ ] **Ineligible sources**: HLS/DASH URL → refiner bails ("ineligible"), no retriever work; DRM
+  content untouched.
+- [ ] **Cancellation**: switching episode mid-refine interrupts the worker, no late callback applied.
+- [ ] **Budget**: 4K long-GOP file → graceful abort within the ~10s wall-clock budget, playback smooth.
+- [ ] **Gating**: toggle is switchable on any device (no grey-out); API 26 → enabling it is a safe
+  runtime no-op; TV box + >1080p (or any >2160p) → per-media refusal (no second decoder spun up).
+
+Non-regression:
+- [ ] With the refine pref OFF (default), playback and skip behavior are byte-identical to before P1.
+
+Note: fix during build — `Utils` was package-private; made `public` so the `skip` subpackage can call
+`isProgressiveContainerUri` / `isContentRefinementCapable`.
+
+## Notes / decisions
+- Single unconfirmed segment: behaves as before (auto-skip per mode) — coverage prioritized.
+- Probe budget: whole profile, done in parallel to bound latency.
+- Chapters + silence-detection: out of scope (deferred); model leaves `CoordBase.CHAPTER` headroom.
+
+## Log
+- (init) Step 0 complete: branch + plan + progress artifacts in `SKIP/`.
+- P0 (A1–A4) + P1 (B1–B4) implemented; debug logging removed; `Utils` made public.
+- Build `assembleLatestUniversalDebug` green. Remaining: on-device verification checklist.

--- a/app/src/main/java/com/brouken/player/PlayerActivity.java
+++ b/app/src/main/java/com/brouken/player/PlayerActivity.java
@@ -252,8 +252,10 @@ public class PlayerActivity extends Activity {
     private ImageButton buttonOpen;
     private ImageButton buttonPlaylist;
     private ImageButton buttonQuality;
+    private ImageButton buttonSkipOffset;
     private android.app.Dialog qualityDialog;
     private android.app.Dialog playlistDialog;
+    private android.app.Dialog skipOffsetDialog;
     private ImageButton buttonPiP;
     private ImageButton buttonAspectRatio;
     private ImageButton buttonRotation;
@@ -352,6 +354,14 @@ public class PlayerActivity extends Activity {
     int selectedVideoTrackIndex = -1;
     // Sticky quality across auto-next: number of lines of the last chosen SOURCE label (0 = none).
     int stickyQualityLines;
+    // Skip-segment timing offset (seconds) — in-session only, never persisted; applies to all
+    // playlist items and is reset on a new media session (resetApiAccess).
+    private double skipOffsetSec = 0;
+    // True once any skip segment has appeared this session; keeps the offset button available
+    // afterwards even on an item that itself has no segments.
+    private boolean skipSeenThisSession;
+    private static final double SKIP_OFFSET_MAX_SEC = 30;   // ± range of the offset slider
+    private static final double SKIP_OFFSET_STEP_SEC = 0.25; // fine step (touch / ± buttons)
     // Set before a SOURCE-switch reinitialisation so the player keeps a paused state (initializePlayer
     // otherwise force-plays under apiAccess). Consumed once inside initializePlayer.
     boolean sourceSwitchKeepPaused;
@@ -616,6 +626,13 @@ public class PlayerActivity extends Activity {
         buttonQuality.setContentDescription(getString(R.string.button_quality));
         buttonQuality.setVisibility(View.GONE);
         buttonQuality.setOnClickListener(view -> showQualityDialog());
+
+        buttonSkipOffset = new ImageButton(this, null, 0, R.style.ExoStyledControls_Button_Bottom);
+        buttonSkipOffset.setImageResource(R.drawable.ic_skip_offset_24dp);
+        buttonSkipOffset.setId(View.generateViewId());
+        buttonSkipOffset.setContentDescription(getString(R.string.button_skip_offset));
+        buttonSkipOffset.setVisibility(View.GONE);
+        buttonSkipOffset.setOnClickListener(view -> showSkipOffsetDialog());
 
         if (Utils.isPiPSupported(this)) {
             // TODO: Android 12 improvements:
@@ -1127,6 +1144,7 @@ public class PlayerActivity extends Activity {
         if (!isTvBox) {
             controls.addView(buttonRotation);
         }
+        controls.addView(buttonSkipOffset);
         controls.addView(exoSettings);
 
         exoBasicControls.addView(horizontalScrollView);
@@ -1672,6 +1690,13 @@ public class PlayerActivity extends Activity {
         skipBuilt = false;
         cancelSegmentFinder();
         hideSkipButton();
+        // Skip offset is session-scoped: a new media session resets it and hides its control.
+        skipOffsetSec = 0;
+        skipSeenThisSession = false;
+        if (skipOffsetDialog != null && skipOffsetDialog.isShowing()) {
+            skipOffsetDialog.dismiss();
+        }
+        updateSkipOffsetButton();
         if (timeBar != null) {
             timeBar.clearSkipHighlights();
         }
@@ -1717,8 +1742,222 @@ public class PlayerActivity extends Activity {
                 durationSec = durationMs / 1000.0;
             }
         }
+        skipManager.setOffsetSec(skipOffsetSec);
         skipManager.rebuild(durationSec);
         updateSkipHighlights();
+        if (skipManager.hasSegments()) {
+            skipSeenThisSession = true;
+        }
+        updateSkipOffsetButton();
+    }
+
+    /** The offset button is shown once any skip segment exists — now or earlier this session. */
+    private void updateSkipOffsetButton() {
+        if (buttonSkipOffset == null) {
+            return;
+        }
+        final boolean show = mPrefs.skipEnabled && skipManager != null
+                && (skipManager.hasSegments() || skipSeenThisSession);
+        buttonSkipOffset.setVisibility(show ? View.VISIBLE : View.GONE);
+    }
+
+    private String formatSkipOffset(double sec) {
+        if (Math.abs(sec) < 0.001) {
+            return "0 s";
+        }
+        String s = String.format(java.util.Locale.US, "%+.2f", sec);
+        if (s.indexOf('.') >= 0) { // trim trailing zeros: "+2.50" -> "+2.5", "+3.00" -> "+3"
+            int end = s.length();
+            while (end > 0 && s.charAt(end - 1) == '0') {
+                end--;
+            }
+            if (end > 0 && s.charAt(end - 1) == '.') {
+                end--;
+            }
+            s = s.substring(0, end);
+        }
+        return s + " s";
+    }
+
+    /** Apply a new session skip offset and re-derive the segments (moves timeline highlights live). */
+    private void applySkipOffset(double sec) {
+        skipOffsetSec = sec;
+        rebuildSkip();
+    }
+
+    // Session-only skip-offset panel: an end-docked translucent panel matching the quality/playlist
+    // dialogs — a large centred value readout, a coral-tinted SeekBar (touch = fine 0.25s drag; TV =
+    // D-pad 0.5s steps) flanked by borderless −/+ icon buttons, and a subtle Reset pill.
+    private void showSkipOffsetDialog() {
+        if (player == null) {
+            return;
+        }
+        final int accent = 0xFFFE6F61;      // coral, matches the skip timeline highlight
+        final int trackBg = 0x33FFFFFF;
+        final int progressMax = (int) Math.round(2 * SKIP_OFFSET_MAX_SEC / SKIP_OFFSET_STEP_SEC);
+        final int mid = progressMax / 2;
+
+        final LinearLayout root = new LinearLayout(this);
+        root.setOrientation(LinearLayout.VERTICAL);
+
+        final TextView header = new TextView(this);
+        header.setText(getString(R.string.skip_offset_title));
+        header.setTextColor(Color.WHITE);
+        header.setTextSize(TypedValue.COMPLEX_UNIT_SP, 18);
+        header.setTypeface(Typeface.DEFAULT_BOLD);
+        header.setPadding(0, 0, 0, Utils.dpToPx(14));
+        root.addView(header);
+
+        final View divider = new View(this);
+        final LinearLayout.LayoutParams dividerLp = new LinearLayout.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT, Utils.dpToPx(1));
+        divider.setLayoutParams(dividerLp);
+        divider.setBackgroundColor(0x1AFFFFFF);
+        root.addView(divider);
+
+        root.addView(makeVerticalSpacer());
+
+        final TextView value = new TextView(this);
+        value.setTextSize(TypedValue.COMPLEX_UNIT_SP, 40);
+        value.setTypeface(Typeface.create("sans-serif-light", Typeface.NORMAL));
+        value.setGravity(Gravity.CENTER);
+        value.setPadding(0, 0, 0, Utils.dpToPx(20));
+        root.addView(value);
+
+        final android.widget.SeekBar seekBar = new android.widget.SeekBar(this);
+        seekBar.setMax(progressMax);
+        seekBar.setKeyProgressIncrement(2); // D-pad step = 0.5 s
+        seekBar.setProgress((int) Math.round(skipOffsetSec / SKIP_OFFSET_STEP_SEC) + mid);
+        seekBar.setFocusable(true);
+        seekBar.setSplitTrack(false);
+        seekBar.setProgressTintList(ColorStateList.valueOf(accent));
+        seekBar.setThumbTintList(ColorStateList.valueOf(accent));
+        seekBar.setProgressBackgroundTintList(ColorStateList.valueOf(trackBg));
+
+        final ImageButton minus = new ImageButton(this, null, 0, R.style.ExoStyledControls_Button_Bottom);
+        minus.setImageResource(R.drawable.ic_remove_24dp);
+        minus.setContentDescription("-");
+        final ImageButton plus = new ImageButton(this, null, 0, R.style.ExoStyledControls_Button_Bottom);
+        plus.setImageResource(R.drawable.ic_add_24dp);
+        plus.setContentDescription("+");
+
+        final LinearLayout row = new LinearLayout(this);
+        row.setOrientation(LinearLayout.HORIZONTAL);
+        row.setGravity(Gravity.CENTER_VERTICAL);
+        final LinearLayout.LayoutParams seekLp = new LinearLayout.LayoutParams(
+                0, ViewGroup.LayoutParams.WRAP_CONTENT, 1f);
+        seekLp.leftMargin = Utils.dpToPx(6);
+        seekLp.rightMargin = Utils.dpToPx(6);
+        seekBar.setLayoutParams(seekLp);
+        row.addView(minus);
+        row.addView(seekBar);
+        row.addView(plus);
+        root.addView(row);
+
+        root.addView(makeVerticalSpacer());
+
+        final TextView reset = new TextView(this);
+        reset.setText(getString(R.string.skip_offset_reset));
+        reset.setTextColor(Color.WHITE);
+        reset.setTextSize(TypedValue.COMPLEX_UNIT_SP, 15);
+        reset.setGravity(Gravity.CENTER);
+        reset.setClickable(true);
+        reset.setFocusable(true);
+        reset.setPadding(Utils.dpToPx(28), Utils.dpToPx(11), Utils.dpToPx(28), Utils.dpToPx(11));
+        final GradientDrawable resetContent = new GradientDrawable();
+        resetContent.setCornerRadius(Utils.dpToPx(22));
+        resetContent.setColor(0x1AFFFFFF);
+        final GradientDrawable resetMask = new GradientDrawable();
+        resetMask.setCornerRadius(Utils.dpToPx(22));
+        resetMask.setColor(Color.WHITE);
+        reset.setBackground(new RippleDrawable(ColorStateList.valueOf(0x40FFFFFF), resetContent, resetMask));
+        final LinearLayout.LayoutParams resetLp = new LinearLayout.LayoutParams(
+                ViewGroup.LayoutParams.WRAP_CONTENT, ViewGroup.LayoutParams.WRAP_CONTENT);
+        resetLp.gravity = Gravity.CENTER_HORIZONTAL;
+        reset.setLayoutParams(resetLp);
+        root.addView(reset);
+
+        // Reflects the current value into the readout (coral when non-zero, white at rest).
+        final Runnable render = () -> {
+            value.setText(formatSkipOffset(skipOffsetSec));
+            value.setTextColor(Math.abs(skipOffsetSec) < 0.001 ? Color.WHITE : accent);
+        };
+        render.run();
+
+        seekBar.setOnSeekBarChangeListener(new android.widget.SeekBar.OnSeekBarChangeListener() {
+            @Override
+            public void onProgressChanged(android.widget.SeekBar sb, int progress, boolean fromUser) {
+                if (fromUser) {
+                    applySkipOffset((progress - mid) * SKIP_OFFSET_STEP_SEC);
+                    render.run();
+                }
+            }
+
+            @Override
+            public void onStartTrackingTouch(android.widget.SeekBar sb) {
+            }
+
+            @Override
+            public void onStopTrackingTouch(android.widget.SeekBar sb) {
+            }
+        });
+        minus.setOnClickListener(v -> {
+            final int p = Math.max(0, seekBar.getProgress() - 1);
+            seekBar.setProgress(p);
+            applySkipOffset((p - mid) * SKIP_OFFSET_STEP_SEC);
+            render.run();
+        });
+        plus.setOnClickListener(v -> {
+            final int p = Math.min(progressMax, seekBar.getProgress() + 1);
+            seekBar.setProgress(p);
+            applySkipOffset((p - mid) * SKIP_OFFSET_STEP_SEC);
+            render.run();
+        });
+        reset.setOnClickListener(v -> {
+            seekBar.setProgress(mid);
+            applySkipOffset(0);
+            render.run();
+        });
+
+        int padTop = 0;
+        int padBottom = 0;
+        final WindowInsets rootInsets = coordinatorLayout.getRootWindowInsets();
+        if (rootInsets != null) {
+            padTop = rootInsets.getSystemWindowInsetTop();
+            padBottom = rootInsets.getSystemWindowInsetBottom();
+        }
+        final int hPad = Utils.dpToPx(24);
+        root.setPadding(hPad, padTop + Utils.dpToPx(20), hPad, padBottom + Utils.dpToPx(24));
+
+        if (skipOffsetDialog != null) {
+            skipOffsetDialog.dismiss();
+        }
+        skipOffsetDialog = new android.app.Dialog(this, android.R.style.Theme_Translucent_NoTitleBar);
+        skipOffsetDialog.setContentView(root);
+        skipOffsetDialog.setCanceledOnTouchOutside(true);
+        final Window window = skipOffsetDialog.getWindow();
+        if (window != null) {
+            window.addFlags(android.view.WindowManager.LayoutParams.FLAG_LAYOUT_IN_SCREEN);
+            if (Build.VERSION.SDK_INT >= 30) {
+                window.setDecorFitsSystemWindows(false);
+            } else {
+                window.getDecorView().setSystemUiVisibility(
+                        View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN | View.SYSTEM_UI_FLAG_LAYOUT_STABLE);
+            }
+            window.setLayout(Utils.dpToPx(360), ViewGroup.LayoutParams.MATCH_PARENT);
+            window.setGravity(Gravity.END);
+            window.setBackgroundDrawable(new android.graphics.drawable.ColorDrawable(0xF0141414));
+        }
+        playerView.hideController();
+        skipOffsetDialog.show();
+        seekBar.post(seekBar::requestFocus);
+    }
+
+    private View makeVerticalSpacer() {
+        final View spacer = new View(this);
+        spacer.setLayoutParams(new LinearLayout.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT, 0, 1f));
+        return spacer;
     }
 
     // Online skip-segment lookup (FIND_INTO.MD): when the current item has no intent-provided segments,
@@ -3681,6 +3920,10 @@ public class PlayerActivity extends Activity {
         if (qualityDialog != null) {
             qualityDialog.dismiss();
             qualityDialog = null;
+        }
+        if (skipOffsetDialog != null) {
+            skipOffsetDialog.dismiss();
+            skipOffsetDialog = null;
         }
         if (buttonPlaylist != null) {
             buttonPlaylist.setVisibility(View.GONE);

--- a/app/src/main/java/com/brouken/player/skip/NetworkSegmentsSource.java
+++ b/app/src/main/java/com/brouken/player/skip/NetworkSegmentsSource.java
@@ -28,9 +28,14 @@ public class NetworkSegmentsSource implements SkipSource {
     @Override
     public List<SkipSegment> getSegments(double durationSec) {
         // Fresh instances each rebuild so the once-only `skipped` flags never leak across rebuilds.
+        // The voting metadata (category/coordinate/time-trust) and the `confirmed` verdict are
+        // preserved — only the runtime flags reset.
         final List<SkipSegment> out = new ArrayList<>(segments.size());
         for (SkipSegment seg : segments) {
-            out.add(new SkipSegment(seg.startSec, seg.endSec, seg.type));
+            final SkipSegment copy = new SkipSegment(seg.startSec, seg.endSec, seg.type,
+                    seg.category, seg.coordBase, seg.timeTrust);
+            copy.confirmed = seg.confirmed;
+            out.add(copy);
         }
         return out;
     }

--- a/app/src/main/java/com/brouken/player/skip/SegmentFinder.java
+++ b/app/src/main/java/com/brouken/player/skip/SegmentFinder.java
@@ -5,10 +5,15 @@ import org.json.JSONException;
 import org.json.JSONObject;
 
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReferenceArray;
 
 import okhttp3.HttpUrl;
 import okhttp3.MediaType;
@@ -19,20 +24,27 @@ import okhttp3.Response;
 import okhttp3.ResponseBody;
 
 /**
- * Fetches intro/recap/outro skip segments for one movie or one series episode, keyed only by stable
+ * Fetches intro/recap/credits skip segments for one movie or one series episode, keyed only by stable
  * ids (imdb, tmdb, and season/episode for series) — no title search.
  *
- * <p>Sources are queried in trust order and their results are <b>quality-scored</b>
- * ({@code score = trust × signal}); the best-scoring result wins rather than simply the first
- * non-empty one, so a weak early source (a single-submission guess) cannot shadow a precise later
- * one. Cost is bounded by two stop rules: a strong hit ({@code score ≥ ACCEPT}) returns immediately,
- * and empty responses never stop the search while at most {@link #NONEMPTY_BUDGET} non-empty results
- * are weighed before settling (see {@code SKIPME_SOURCE_PLAN.md}).
+ * <p>All sources in the applicable profile are probed <b>in parallel</b>, then the results are merged
+ * by <b>cross-source voting</b> rather than a single winner-take-all pick:
+ * <ul>
+ *   <li>Segments are grouped by {@link SkipSegment.Category} (a source's intro can only agree with
+ *       another source's intro), then clustered by start time within {@link #AGREE_TOLERANCE_SEC}.</li>
+ *   <li>A cluster backed by at least {@link #MIN_VOTES} distinct sources is {@code confirmed} — this
+ *       is what kills phantom segments a single bad source would otherwise inject.</li>
+ *   <li>The kept segment's <b>timing comes from the most file-accurate agreeing source</b> (highest
+ *       {@link SkipSegment#timeTrust}); timings from different coordinate systems are never averaged.</li>
+ * </ul>
+ * Coverage is prioritized for single-source categories: a category seen by only one source is still
+ * offered (as {@code confirmed=false}) rather than dropped.
  *
  * <p>Runs on a background thread; the callback fires on that same worker thread (the caller marshals
- * to the UI thread). Results (including "nothing found") are cached in memory for the process
- * lifetime, keyed by {@code imdb|tmdb|season|episode}. On any error or timeout a source yields
- * nothing — playback is never affected.
+ * to the UI thread). Results are cached in memory keyed by {@code imdb|tmdb|season|episode|duration};
+ * negative (empty) results expire after {@link #NEG_CACHE_TTL_MS} so a transient network error does
+ * not silence a title for the whole process. On any error or timeout a source yields nothing —
+ * playback is never affected.
  */
 public final class SegmentFinder {
 
@@ -46,15 +58,22 @@ public final class SegmentFinder {
     private static final int TIMEOUT_SEC = 5;
     private static final double OPEN_ENDED_SEC = 99999; // TheIntroDB null end → open-ended
 
-    /** A result with {@code score ≥ ACCEPT} is accepted immediately, ending the probe loop. */
-    private static final double ACCEPT = 0.60;
-    /**
-     * Max <b>non-empty</b> results to weigh before settling on the best. Empty responses never count
-     * and never stop the search — they are the cheap negatives fallbacks exist for, so the ladder is
-     * walked until a source has data (up to the whole list). This cap only bounds how many weak
-     * (below-{@link #ACCEPT}) candidates we gather before picking the highest-scoring one.
-     */
-    private static final int NONEMPTY_BUDGET = 3;
+    // ---- Voting / probe tuning (all thresholds centralized here) -----------------------------
+
+    /** Two segments of the same category whose starts fall within this window are treated as agreeing. */
+    private static final double AGREE_TOLERANCE_SEC = 30;
+    /** Distinct sources needed to mark a segment {@code confirmed}. */
+    private static final int MIN_VOTES = 2;
+    /** Overall wall-clock ceiling for the parallel probe (sources run concurrently, not summed). */
+    private static final int PROBE_DEADLINE_SEC = TIMEOUT_SEC + 3;
+    /** How long an empty ("nothing found") result stays cached before it is re-probed. */
+    private static final long NEG_CACHE_TTL_MS = 10 * 60 * 1000L;
+
+    // Time-source priority per source (higher wins when agreeing segments disagree on timing).
+    private static final int TT_SKIPDB = SkipSegment.TIME_TRUST_DURATION_AWARE;       // 200
+    private static final int TT_SKIPME = SkipSegment.TIME_TRUST_DURATION_AWARE - 10;  // 190 (erratic shift)
+    private static final int TT_ANIME = SkipSegment.TIME_TRUST_DURATION_AWARE + 50;   // 250 (Aniskip primary)
+    private static final int TT_ABS = SkipSegment.TIME_TRUST_ABSOLUTE;                // 100
 
     private static final MediaType JSON = MediaType.parse("application/json; charset=utf-8");
 
@@ -64,8 +83,18 @@ public final class SegmentFinder {
             .callTimeout(TIMEOUT_SEC + 1, TimeUnit.SECONDS)
             .build();
 
-    // Process-lifetime cache; empty results are cached too, to avoid re-hitting dead titles.
-    private static final Map<String, List<SkipSegment>> CACHE = new ConcurrentHashMap<>();
+    // Process-lifetime cache; empty results are cached with an expiry (see NEG_CACHE_TTL_MS).
+    private static final Map<String, CacheEntry> CACHE = new ConcurrentHashMap<>();
+
+    private static final class CacheEntry {
+        final List<SkipSegment> segments;
+        final long expiresAt; // 0 = never expires (non-empty result)
+
+        CacheEntry(List<SkipSegment> segments, long expiresAt) {
+            this.segments = segments;
+            this.expiresAt = expiresAt;
+        }
+    }
 
     /**
      * Starts an async lookup. Returns the worker {@link Thread} so the caller can {@code interrupt()}
@@ -91,13 +120,18 @@ public final class SegmentFinder {
         if (imdbInput == null && tmdbInput == null) {
             return new ArrayList<>();
         }
-        // Season/episode presence is what distinguishes a series episode from a movie (per the intent).
-        final boolean isMovie = season < 1 || episode < 1;
+        // A season implies a series episode even if the episode number is missing/0 — don't blindly
+        // treat it as a movie (that would query the wrong, movie-only sources).
+        final boolean isMovie = season < 1;
         final int keySeason = isMovie ? -1 : season;
-        final int keyEpisode = isMovie ? -1 : episode;
+        final int keyEpisode = isMovie ? -1 : Math.max(episode, -1);
+        // Cache key includes the duration bucket: duration-aware sources adapt to the stream length,
+        // so a replay of a differently-cut rip must not reuse stale timings.
+        final long durationBucket = durationSec > 0 ? Math.round(durationSec) : -1;
         final String key = (imdbInput != null ? imdbInput : "") + "|"
-                + (tmdbInput != null ? tmdbInput : "") + "|" + keySeason + "|" + keyEpisode;
-        final List<SkipSegment> cached = CACHE.get(key);
+                + (tmdbInput != null ? tmdbInput : "") + "|" + keySeason + "|" + keyEpisode
+                + "|" + durationBucket;
+        final List<SkipSegment> cached = getCached(key);
         if (cached != null) {
             return cached;
         }
@@ -120,40 +154,44 @@ public final class SegmentFinder {
 
         final String imdb = imdbId;      // effectively final for the step lambdas
         final long tmdb = tmdbNumeric;
-        final List<Candidate> candidates = new ArrayList<>();
+        final int ep = Math.max(episode, -1);
+        final List<Step> steps = new ArrayList<>();
         if (isMovie) {
+            // Duration-aware first, absolute community sources last.
             if (imdb != null) {
-                candidates.add(new Candidate(1.0, () -> skipDb(imdb, -1, -1, durationSec)));
+                steps.add(() -> skipDb(imdb, -1, -1, durationSec));
             }
             if (imdb != null || tmdb >= 0) {
-                candidates.add(new Candidate(0.8, () -> theIntroDb(imdb, tmdb, -1, -1, true)));
-                // SkipMe.db is demoted to the tail: its server-side duration shift is erratic and can
-                // return times offset from the actual encode. Kept only as a broad last resort.
-                candidates.add(new Candidate(0.5, () -> skipMe(imdb, tmdb, -1, -1, durationSec)));
+                steps.add(() -> skipMe(imdb, tmdb, -1, -1, durationSec));
+                steps.add(() -> theIntroDb(imdb, tmdb, -1, -1, true));
             }
             if (imdb != null) {
-                candidates.add(new Candidate(0.4, () -> introHater(imdb, -1, -1)));
+                steps.add(() -> introHater(imdb, -1, -1));
             }
         } else {
             if (imdb != null) {
-                // Anime first: Aniskip is the anime-specialist (crowd-voted OP/ED, per-MAL episode). It
-                // returns empty fast for non-anime (arm finds no MAL), so the ladder falls through.
-                candidates.add(new Candidate(0.9, () -> aniskip(imdb, season, episode)));
-                candidates.add(new Candidate(1.0, () -> skipDb(imdb, season, episode, durationSec)));
-                candidates.add(new Candidate(0.7, () -> introDbApp(imdb, season, episode)));
+                // Aniskip is the anime specialist (crowd-voted OP/ED with real ends); for anime files
+                // — usually the broadcast cut — its absolute timings match, so it is the primary time
+                // source (TT_ANIME). It returns empty fast for non-anime, so it simply drops out then.
+                steps.add(() -> aniskip(imdb, season, ep));
+                steps.add(() -> skipDb(imdb, season, ep, durationSec));
+                steps.add(() -> skipMe(imdb, tmdb, season, ep, durationSec));
+                steps.add(() -> introDbApp(imdb, season, ep));
             }
             if (imdb != null || tmdb >= 0) {
-                candidates.add(new Candidate(0.8, () -> theIntroDb(imdb, tmdb, season, episode, false)));
-                // SkipMe.db demoted to the tail (erratic duration shift → offset times).
-                candidates.add(new Candidate(0.5, () -> skipMe(imdb, tmdb, season, episode, durationSec)));
+                steps.add(() -> theIntroDb(imdb, tmdb, season, ep, false));
             }
             if (imdb != null) {
-                candidates.add(new Candidate(0.4, () -> introHater(imdb, season, episode)));
+                steps.add(() -> introHater(imdb, season, ep));
             }
         }
 
-        final List<SkipSegment> result = bestScored(candidates);
-        CACHE.put(key, result);
+        final List<Scored> results = probeAll(steps);
+        if (Thread.currentThread().isInterrupted()) {
+            return new ArrayList<>(); // media changed mid-probe — don't deliver or cache
+        }
+        final List<SkipSegment> result = voteSegments(results);
+        putCached(key, result);
         return result;
     }
 
@@ -161,7 +199,30 @@ public final class SegmentFinder {
         return s == null || s.trim().isEmpty();
     }
 
-    // ---- Quality-aware selection -------------------------------------------------------------
+    // ---- Cache -------------------------------------------------------------------------------
+
+    private static List<SkipSegment> getCached(String key) {
+        final CacheEntry entry = CACHE.get(key);
+        if (entry == null) {
+            return null;
+        }
+        if (entry.expiresAt != 0 && System.currentTimeMillis() >= entry.expiresAt) {
+            CACHE.remove(key); // stale negative — re-probe
+            return null;
+        }
+        return entry.segments;
+    }
+
+    private static void putCached(String key, List<SkipSegment> result) {
+        final long expiresAt = result.isEmpty() ? System.currentTimeMillis() + NEG_CACHE_TTL_MS : 0;
+        CACHE.put(key, new CacheEntry(result, expiresAt));
+    }
+
+    // ---- Parallel probe ----------------------------------------------------------------------
+
+    private interface Step {
+        Scored run();
+    }
 
     /** A source result carrying its quality {@link #signal} (0..1); the segment list may be empty. */
     private static final class Scored {
@@ -178,52 +239,152 @@ public final class SegmentFinder {
         }
     }
 
-    private interface Step {
-        Scored run();
+    /**
+     * Runs every step concurrently and collects their results, bounded by {@link #PROBE_DEADLINE_SEC}.
+     * Slots for steps that time out remain null. Each source's own call timeouts keep this well under
+     * the deadline in practice.
+     */
+    private static List<Scored> probeAll(List<Step> steps) {
+        final int n = steps.size();
+        final AtomicReferenceArray<Scored> slots = new AtomicReferenceArray<>(n);
+        final CountDownLatch latch = new CountDownLatch(n);
+        final Thread[] workers = new Thread[n];
+        for (int i = 0; i < n; i++) {
+            final int idx = i;
+            final Step step = steps.get(i);
+            final Thread worker = new Thread(() -> {
+                try {
+                    slots.set(idx, step.run());
+                } catch (Throwable ignored) {
+                    // A misbehaving source must never break the probe.
+                } finally {
+                    latch.countDown();
+                }
+            }, "SegmentSource-" + i);
+            worker.setDaemon(true);
+            workers[i] = worker;
+            worker.start();
+        }
+        try {
+            latch.await(PROBE_DEADLINE_SEC, TimeUnit.SECONDS);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        } finally {
+            for (Thread worker : workers) {
+                worker.interrupt();
+            }
+        }
+        final List<Scored> out = new ArrayList<>(n);
+        for (int i = 0; i < n; i++) {
+            out.add(slots.get(i));
+        }
+        return out;
     }
 
-    /** A queryable source: its base {@code trust} weight paired with the {@link Step} that runs it. */
-    private static final class Candidate {
-        final double trust;
-        final Step step;
+    // ---- Voting ------------------------------------------------------------------------------
 
-        Candidate(double trust, Step step) {
-            this.trust = trust;
-            this.step = step;
+    /** One source's take on a segment, kept with its source index (for vote counting) and signal. */
+    private static final class Vote {
+        final SkipSegment seg;
+        final double signal;
+        final int sourceId;
+
+        Vote(SkipSegment seg, double signal, int sourceId) {
+            this.seg = seg;
+            this.signal = signal;
+            this.sourceId = sourceId;
         }
     }
 
     /**
-     * Queries candidates in order, returning the segments of the highest-scoring result
-     * ({@code trust × signal}). Stops early on a strong hit ({@code score ≥ ACCEPT}); empty responses
-     * never stop the search, and at most {@link #NONEMPTY_BUDGET} non-empty results are weighed before
-     * settling. Candidates lacking the required id are omitted upstream.
+     * Merges per-source results into a final list: for each category, the best agreeing cluster wins,
+     * its timing taken from the highest-{@code timeTrust} member. At most one segment per category is
+     * emitted, which also removes duplicate/conflicting picks.
      */
-    private static List<SkipSegment> bestScored(List<Candidate> candidates) {
-        Scored best = null;
-        double bestScore = -1;
-        int hits = 0;
-        for (Candidate candidate : candidates) {
-            if (Thread.currentThread().isInterrupted()) {
-                break;
+    private static List<SkipSegment> voteSegments(List<Scored> results) {
+        // Collect every source's segments into per-category vote buckets.
+        final Map<SkipSegment.Category, List<Vote>> byCategory = new LinkedHashMap<>();
+        for (int sourceId = 0; sourceId < results.size(); sourceId++) {
+            final Scored r = results.get(sourceId);
+            if (r == null || r.isEmpty()) {
+                continue;
             }
-            final Scored result = candidate.step.run();
-            if (result == null || result.isEmpty()) {
-                continue; // empty doesn't consume the budget — keep looking down the ladder
-            }
-            final double score = candidate.trust * result.signal;
-            if (score > bestScore) {
-                bestScore = score;
-                best = result;
-            }
-            if (score >= ACCEPT) {
-                break; // strong hit — good enough
-            }
-            if (++hits >= NONEMPTY_BUDGET) {
-                break; // gathered enough weak candidates; settle on the best so far
+            for (SkipSegment seg : r.segments) {
+                List<Vote> bucket = byCategory.get(seg.category);
+                if (bucket == null) {
+                    bucket = new ArrayList<>();
+                    byCategory.put(seg.category, bucket);
+                }
+                bucket.add(new Vote(seg, r.signal, sourceId));
             }
         }
-        return best != null ? best.segments : new ArrayList<>();
+
+        final List<SkipSegment> out = new ArrayList<>();
+        for (Map.Entry<SkipSegment.Category, List<Vote>> entry : byCategory.entrySet()) {
+            final SkipSegment best = bestCluster(entry.getValue());
+            if (best != null) {
+                out.add(best);
+            }
+        }
+        return out;
+    }
+
+    /**
+     * Clusters same-category votes by start time and returns the winning cluster's representative
+     * segment (a fresh copy with {@code confirmed} set), or null if there are no votes. Winner =
+     * most distinct sources, then highest {@code timeTrust}, then highest signal, then earliest.
+     */
+    private static SkipSegment bestCluster(List<Vote> votes) {
+        if (votes.isEmpty()) {
+            return null;
+        }
+        Collections.sort(votes, (a, b) -> Double.compare(a.seg.startSec, b.seg.startSec));
+
+        SkipSegment bestSeg = null;
+        int bestSources = -1;
+        int bestTrust = -1;
+        double bestSignal = -1;
+
+        int i = 0;
+        while (i < votes.size()) {
+            final double anchor = votes.get(i).seg.startSec;
+            int j = i;
+            // Grow the cluster while starts stay within the agreement window of the anchor.
+            final List<Vote> cluster = new ArrayList<>();
+            while (j < votes.size() && votes.get(j).seg.startSec - anchor <= AGREE_TOLERANCE_SEC) {
+                cluster.add(votes.get(j));
+                j++;
+            }
+            i = j;
+
+            // Representative: most file-accurate timing (highest timeTrust), then signal, then earliest.
+            Vote rep = cluster.get(0);
+            final java.util.Set<Integer> sources = new java.util.HashSet<>();
+            for (Vote v : cluster) {
+                sources.add(v.sourceId);
+                if (v.seg.timeTrust > rep.seg.timeTrust
+                        || (v.seg.timeTrust == rep.seg.timeTrust && v.signal > rep.signal)) {
+                    rep = v;
+                }
+            }
+            final int distinctSources = sources.size();
+
+            final boolean better = distinctSources > bestSources
+                    || (distinctSources == bestSources && rep.seg.timeTrust > bestTrust)
+                    || (distinctSources == bestSources && rep.seg.timeTrust == bestTrust
+                        && rep.signal > bestSignal);
+            if (better) {
+                bestSources = distinctSources;
+                bestTrust = rep.seg.timeTrust;
+                bestSignal = rep.signal;
+                final SkipSegment src = rep.seg;
+                final SkipSegment kept = new SkipSegment(src.startSec, src.endSec, src.type,
+                        src.category, src.coordBase, src.timeTrust);
+                kept.confirmed = distinctSources >= MIN_VOTES;
+                bestSeg = kept;
+            }
+        }
+        return bestSeg;
     }
 
     // ---- Sources -----------------------------------------------------------------------------
@@ -251,9 +412,9 @@ public final class SegmentFinder {
         final JSONObject intro = segs.optJSONObject("intro");
         final JSONObject recap = segs.optJSONObject("recap");
         final JSONObject outro = segs.optJSONObject("outro");
-        addMs(out, intro);
-        addMs(out, recap);
-        addMs(out, outro);
+        addMs(out, intro, SkipSegment.Category.INTRO, SkipSegment.CoordBase.DURATION_AWARE, TT_SKIPDB);
+        addMs(out, recap, SkipSegment.Category.RECAP, SkipSegment.CoordBase.DURATION_AWARE, TT_SKIPDB);
+        addMs(out, outro, SkipSegment.Category.CREDITS, SkipSegment.CoordBase.DURATION_AWARE, TT_SKIPDB);
         // Signal: average confidence (0..1) over the present segment objects.
         double sum = 0;
         int n = 0;
@@ -281,9 +442,9 @@ public final class SegmentFinder {
         final JSONObject intro = root.optJSONObject("intro");
         final JSONObject recap = root.optJSONObject("recap");
         final JSONObject outro = root.optJSONObject("outro");
-        addSecObject(out, intro);
-        addSecObject(out, recap);
-        addSecObject(out, outro);
+        addSecObject(out, intro, SkipSegment.Category.INTRO, TT_ABS);
+        addSecObject(out, recap, SkipSegment.Category.RECAP, TT_ABS);
+        addSecObject(out, outro, SkipSegment.Category.CREDITS, TT_ABS);
         // Signal: best of confidence × min(1, submission_count/3) — a single submission scores low.
         double best = 0;
         for (JSONObject o : new JSONObject[]{intro, recap, outro}) {
@@ -333,9 +494,9 @@ public final class SegmentFinder {
         final JSONArray intro = media.optJSONArray("intro");
         final JSONArray recap = media.optJSONArray("recap");
         final JSONArray credits = media.optJSONArray("credits");
-        addMsArray(out, intro);
-        addMsArray(out, recap);
-        addMsArray(out, credits);
+        addMsArray(out, intro, SkipSegment.Category.INTRO, SkipSegment.CoordBase.DURATION_AWARE, TT_SKIPME);
+        addMsArray(out, recap, SkipSegment.Category.RECAP, SkipSegment.CoordBase.DURATION_AWARE, TT_SKIPME);
+        addMsArray(out, credits, SkipSegment.Category.CREDITS, SkipSegment.CoordBase.DURATION_AWARE, TT_SKIPME);
         // Signal: min(1, maxSubmissions/5) — 5+ submissions is treated as fully trusted.
         final int maxSub = Math.max(maxSubmissions(intro),
                 Math.max(maxSubmissions(recap), maxSubmissions(credits)));
@@ -345,6 +506,9 @@ public final class SegmentFinder {
     /** Anime gate: arm (imdb→MAL for the season), then Aniskip (MAL-relative episode). */
     private static Scored aniskip(String imdbId, int season, int episode) {
         final List<SkipSegment> out = new ArrayList<>();
+        if (episode < 1) {
+            return new Scored(out, 0); // Aniskip is per-episode; nothing to ask without one
+        }
         // arm — note: never pass ?include= (it drops the -season fields).
         final HttpUrl armUrl = HttpUrl.parse(SegmentEndpoints.ARM).newBuilder()
                 .addQueryParameter("id", imdbId)
@@ -366,12 +530,12 @@ public final class SegmentFinder {
                 entrySeason = entry.optInt("thetvdb-season", -1);
             }
             if (entrySeason == season) {
-                malId = entry.optLong("myanimelist", -1); // cand[0] — first match for the season
+                malId = entry.optLong("myanimelist", -1); // first MAL match for the season
                 break;
             }
         }
         if (malId < 0) {
-            return new Scored(out, 0); // not anime (or no MAL for this season) → fall through
+            return new Scored(out, 0); // not anime (or no MAL for this season) → drop out
         }
         final HttpUrl skipUrl = HttpUrl.parse(SegmentEndpoints.ANISKIP).newBuilder()
                 .addPathSegment(String.valueOf(malId))
@@ -398,10 +562,28 @@ public final class SegmentFinder {
             if (interval == null) {
                 continue;
             }
-            addSeg(out, interval.optDouble("startTime", Double.NaN), interval.optDouble("endTime", Double.NaN));
+            final SkipSegment.Category cat = aniskipCategory(r.optString("skipType", ""));
+            // Anime files are usually the broadcast cut, so Aniskip's absolute times are the primary
+            // time source for anime (TT_ANIME, above duration-aware).
+            addSeg(out, interval.optDouble("startTime", Double.NaN),
+                    interval.optDouble("endTime", Double.NaN), cat, SkipSegment.CoordBase.ABSOLUTE, TT_ANIME);
         }
         // Crowd-voted with real op/ed ends — a high, fixed signal for anime.
         return new Scored(out, 0.9);
+    }
+
+    private static SkipSegment.Category aniskipCategory(String skipType) {
+        final String t = skipType.toLowerCase(Locale.US);
+        if (t.contains("recap")) {
+            return SkipSegment.Category.RECAP;
+        }
+        if (t.contains("op")) {
+            return SkipSegment.Category.INTRO;
+        }
+        if (t.contains("ed")) {
+            return SkipSegment.Category.CREDITS;
+        }
+        return SkipSegment.Category.UNKNOWN;
     }
 
     /**
@@ -425,9 +607,9 @@ public final class SegmentFinder {
         if (root == null) {
             return new Scored(out, 0);
         }
-        addMsArray(out, root.optJSONArray("intro"));
-        addMsArray(out, root.optJSONArray("recap"));
-        addMsArray(out, root.optJSONArray("credits"));
+        addMsArray(out, root.optJSONArray("intro"), SkipSegment.Category.INTRO, SkipSegment.CoordBase.ABSOLUTE, TT_ABS);
+        addMsArray(out, root.optJSONArray("recap"), SkipSegment.Category.RECAP, SkipSegment.CoordBase.ABSOLUTE, TT_ABS);
+        addMsArray(out, root.optJSONArray("credits"), SkipSegment.Category.CREDITS, SkipSegment.CoordBase.ABSOLUTE, TT_ABS);
         // No per-result confidence field; a fixed medium-high signal (matches SkipDB on tested titles).
         return new Scored(out, 0.8);
     }
@@ -465,12 +647,31 @@ public final class SegmentFinder {
             if (o == null) {
                 continue;
             }
-            addSeg(out, o.optDouble("start", Double.NaN), o.optDouble("end", Double.NaN));
+            final SkipSegment.Category cat = introHaterCategory(o.optString("label", ""));
+            addSeg(out, o.optDouble("start", Double.NaN), o.optDouble("end", Double.NaN),
+                    cat, SkipSegment.CoordBase.ABSOLUTE, TT_ABS);
             final double s = (o.optBoolean("verified", false) ? 0.5 : 0.3)
                     + Math.min(0.3, o.optInt("votes", 0) * 0.1);
             signal = Math.max(signal, s);
         }
         return new Scored(out, signal);
+    }
+
+    private static SkipSegment.Category introHaterCategory(String label) {
+        final String l = label.toLowerCase(Locale.US);
+        if (l.contains("recap")) {
+            return SkipSegment.Category.RECAP;
+        }
+        if (l.contains("credit") || l.contains("outro") || l.contains("ending")) {
+            return SkipSegment.Category.CREDITS;
+        }
+        if (l.contains("preview") || l.contains("next")) {
+            return SkipSegment.Category.PREVIEW;
+        }
+        if (l.contains("intro") || l.contains("opening")) {
+            return SkipSegment.Category.INTRO;
+        }
+        return SkipSegment.Category.UNKNOWN;
     }
 
     /** imdb → tmdb id via TMDB find (lazy; only reached from the TheIntroDB step). */
@@ -511,15 +712,18 @@ public final class SegmentFinder {
     // ---- Normalization -----------------------------------------------------------------------
 
     /** Add a segment from an object carrying {start_ms,end_ms}. */
-    private static void addMs(List<SkipSegment> out, JSONObject o) {
+    private static void addMs(List<SkipSegment> out, JSONObject o, SkipSegment.Category category,
+                              SkipSegment.CoordBase coordBase, int timeTrust) {
         if (o == null) {
             return;
         }
-        addSeg(out, o.optDouble("start_ms", Double.NaN) / 1000.0, o.optDouble("end_ms", Double.NaN) / 1000.0);
+        addSeg(out, o.optDouble("start_ms", Double.NaN) / 1000.0,
+                o.optDouble("end_ms", Double.NaN) / 1000.0, category, coordBase, timeTrust);
     }
 
     /** Add a segment from an object carrying {start_sec,end_sec} (falling back to *_ms). */
-    private static void addSecObject(List<SkipSegment> out, JSONObject o) {
+    private static void addSecObject(List<SkipSegment> out, JSONObject o, SkipSegment.Category category,
+                                     int timeTrust) {
         if (o == null) {
             return;
         }
@@ -531,11 +735,16 @@ public final class SegmentFinder {
         if (Double.isNaN(end)) {
             end = o.optDouble("end_ms", Double.NaN) / 1000.0;
         }
-        addSeg(out, start, end);
+        addSeg(out, start, end, category, SkipSegment.CoordBase.ABSOLUTE, timeTrust);
     }
 
-    /** Add segments from an array of {start_ms,end_ms} (null end_ms → open-ended). */
-    private static void addMsArray(List<SkipSegment> out, JSONArray array) {
+    /**
+     * Add segments from an array of {start_ms,end_ms}. A null {@code end_ms} means open-ended; that is
+     * only meaningful for end credits (which run to the file end), so an open-ended non-credits segment
+     * is dropped rather than left spanning most of the file.
+     */
+    private static void addMsArray(List<SkipSegment> out, JSONArray array, SkipSegment.Category category,
+                                   SkipSegment.CoordBase coordBase, int timeTrust) {
         if (array == null) {
             return;
         }
@@ -546,8 +755,12 @@ public final class SegmentFinder {
             }
             final double start = o.optDouble("start_ms", Double.NaN) / 1000.0;
             final double endMs = o.optDouble("end_ms", Double.NaN);
-            final double end = Double.isNaN(endMs) ? OPEN_ENDED_SEC : endMs / 1000.0;
-            addSeg(out, start, end);
+            final boolean openEnded = Double.isNaN(endMs);
+            if (openEnded && category != SkipSegment.Category.CREDITS) {
+                continue; // open-ended only makes sense for credits
+            }
+            final double end = openEnded ? OPEN_ENDED_SEC : endMs / 1000.0;
+            addSeg(out, start, end, category, coordBase, timeTrust);
         }
     }
 
@@ -566,7 +779,8 @@ public final class SegmentFinder {
         return max;
     }
 
-    private static void addSeg(List<SkipSegment> out, double startSec, double endSec) {
+    private static void addSeg(List<SkipSegment> out, double startSec, double endSec,
+                               SkipSegment.Category category, SkipSegment.CoordBase coordBase, int timeTrust) {
         if (Double.isNaN(startSec) || Double.isNaN(endSec) || endSec <= startSec) {
             return;
         }
@@ -574,7 +788,7 @@ public final class SegmentFinder {
         if (startSec < 1) {
             startSec = 1;
         }
-        out.add(new SkipSegment(startSec, endSec, SkipSegment.Type.SKIP));
+        out.add(new SkipSegment(startSec, endSec, SkipSegment.Type.SKIP, category, coordBase, timeTrust));
     }
 
     // ---- HTTP --------------------------------------------------------------------------------

--- a/app/src/main/java/com/brouken/player/skip/SkipManager.java
+++ b/app/src/main/java/com/brouken/player/skip/SkipManager.java
@@ -1,5 +1,6 @@
 package com.brouken.player.skip;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
@@ -32,6 +33,14 @@ public class SkipManager {
     private SkipSource source;
     private List<SkipSegment> segments = Collections.emptyList();
 
+    /** User-configured global shift applied to every segment (seconds); 0 = off. */
+    private double offsetSec = 0;
+
+    /** Set the manual skip offset (session-scoped, set from the player). Applied on the next {@link #rebuild}. */
+    public void setOffsetSec(double offsetSec) {
+        this.offsetSec = offsetSec;
+    }
+
     /** Set the source for the current media (e.g. a new {@link IntentSegmentsSource}); clears segments. */
     public void setSource(SkipSource source) {
         this.source = source;
@@ -45,8 +54,33 @@ public class SkipManager {
 
     /** Recompute segments against the now-known duration. Safe to call repeatedly. */
     public void rebuild(double durationSec) {
-        segments = source != null ? source.getSegments(durationSec) : Collections.<SkipSegment>emptyList();
+        final List<SkipSegment> base = source != null
+                ? source.getSegments(durationSec) : Collections.<SkipSegment>emptyList();
+        segments = offsetSec != 0 ? applyOffset(base, durationSec) : base;
         classifyCredits(durationSec);
+    }
+
+    /** Shift every segment by {@link #offsetSec}, clamped to the media bounds; drop any pushed out. */
+    private List<SkipSegment> applyOffset(List<SkipSegment> in, double durationSec) {
+        final boolean durationKnown = durationSec > 0 && !Double.isNaN(durationSec);
+        final List<SkipSegment> out = new ArrayList<>(in.size());
+        for (SkipSegment s : in) {
+            double start = s.startSec + offsetSec;
+            double end = s.endSec + offsetSec;
+            if (start < 0) {
+                start = 0;
+            }
+            if (durationKnown && end > durationSec) {
+                end = durationSec;
+            }
+            if (end <= start) {
+                continue; // shifted out of range
+            }
+            final SkipSegment shifted = new SkipSegment(start, end, s.type, s.category, s.coordBase, s.timeTrust);
+            shifted.confirmed = s.confirmed;
+            out.add(shifted);
+        }
+        return out;
     }
 
     /**

--- a/app/src/main/java/com/brouken/player/skip/SkipSegment.java
+++ b/app/src/main/java/com/brouken/player/skip/SkipSegment.java
@@ -13,12 +13,55 @@ public class SkipSegment {
         AD
     }
 
+    /**
+     * The kind of SKIP segment as reported by the source. Cross-source voting groups segments of the
+     * same category (intro vs recap vs credits), so a source's intro cannot "agree" with another's
+     * credits. {@link #UNKNOWN} is used when the category is not preserved (e.g. intent segments).
+     */
+    public enum Category {
+        INTRO,
+        RECAP,
+        CREDITS,
+        PREVIEW,
+        UNKNOWN
+    }
+
+    /**
+     * The coordinate system a segment's timing lives in. Duration-aware sources adapt their timings to
+     * the actual stream length; absolute sources return broadcast-cut seconds that only match when the
+     * file is the same cut; chapters are file-accurate by definition. Voting never averages across
+     * different coordinate systems — it takes the timing of the agreeing source with the highest
+     * {@link #timeTrust}.
+     */
+    public enum CoordBase {
+        DURATION_AWARE,
+        ABSOLUTE,
+        CHAPTER
+    }
+
+    /** Time-source priority tiers (higher wins when agreeing segments disagree on timing). */
+    public static final int TIME_TRUST_ABSOLUTE = 100;
+    public static final int TIME_TRUST_DURATION_AWARE = 200;
+    public static final int TIME_TRUST_CHAPTER = 300;
+
     public final double startSec;
     public final double endSec;
     public final Type type;
+    public final Category category;
+    public final CoordBase coordBase;
+
+    /** Time-source priority of the source that produced this timing (see {@code TIME_TRUST_*}). */
+    public final int timeTrust;
 
     /** Runtime flag: set once the segment has been skipped, so it is only acted on once. */
     public boolean skipped;
+
+    /**
+     * Runtime flag: set by the voting aggregator when at least two sources agreed on this segment.
+     * Kept for future UI/policy tightening; the current policy still offers/auto-skips unconfirmed
+     * single-source segments (coverage is prioritized).
+     */
+    public boolean confirmed;
 
     /**
      * Runtime flag: set by {@link SkipManager} when this is the end-credits segment — a {@code SKIP}
@@ -36,10 +79,27 @@ public class SkipSegment {
      */
     public boolean reachesEnd;
 
-    public SkipSegment(double startSec, double endSec, Type type) {
+    /**
+     * Full constructor used by the voting aggregator, carrying the segment's category and coordinate
+     * metadata so voting can group by type and pick timing from the most file-accurate source.
+     */
+    public SkipSegment(double startSec, double endSec, Type type, Category category,
+                       CoordBase coordBase, int timeTrust) {
         this.startSec = startSec;
         this.endSec = endSec;
         this.type = type;
+        this.category = category;
+        this.coordBase = coordBase;
+        this.timeTrust = timeTrust;
+    }
+
+    /**
+     * Legacy constructor: category {@link Category#UNKNOWN}, {@link CoordBase#ABSOLUTE} coordinates.
+     * Used by {@link IntentSegmentsSource} (intent segments are a single source, never voted) and by
+     * copy-loops that preserve an existing segment's already-resolved timing.
+     */
+    public SkipSegment(double startSec, double endSec, Type type) {
+        this(startSec, endSec, type, Category.UNKNOWN, CoordBase.ABSOLUTE, TIME_TRUST_ABSOLUTE);
     }
 
     public long startMs() {

--- a/app/src/main/res/drawable/ic_add_24dp.xml
+++ b/app/src/main/res/drawable/ic_add_24dp.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:pathData="M19,13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z" />
+</vector>

--- a/app/src/main/res/drawable/ic_remove_24dp.xml
+++ b/app/src/main/res/drawable/ic_remove_24dp.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:pathData="M19,13H5v-2h14v2z" />
+</vector>

--- a/app/src/main/res/drawable/ic_skip_offset_24dp.xml
+++ b/app/src/main/res/drawable/ic_skip_offset_24dp.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:pathData="M3,17v2h6v-2H3zM3,5v2h10V5H3zM13,21v-2h8v-2h-8v-2h-2v6h2zM7,9v2H3v2h4v2h2V9H7zM21,13v-2H11v2h10zM15,7h2V5h4V3h-4V1h-2v6z" />
+</vector>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -42,6 +42,9 @@
     <string name="pref_skip_fetch">Искать сегменты онлайн</string>
     <string name="pref_skip_fetch_on">Искать сегменты заставок и титров в онлайн-базах, если источник их не предоставил</string>
     <string name="pref_skip_fetch_off">Использовать только сегменты от запускающего приложения</string>
+    <string name="skip_offset_title">Смещение пропуска</string>
+    <string name="skip_offset_reset">Сбросить</string>
+    <string name="button_skip_offset">Смещение пропуска</string>
     <string name="button_skip">Пропустить</string>
     <string name="notification_skipped">Сегмент пропущен</string>
     <string name="pref_show_clock">Показывать часы</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -43,6 +43,9 @@
     <string name="pref_skip_fetch">Шукати сегменти онлайн</string>
     <string name="pref_skip_fetch_on">Шукати сегменти заставок і титрів в онлайн-базах, якщо джерело їх не надало</string>
     <string name="pref_skip_fetch_off">Використовувати лише сегменти від застосунку</string>
+    <string name="skip_offset_title">Зсув пропуску</string>
+    <string name="skip_offset_reset">Скинути</string>
+    <string name="button_skip_offset">Зсув пропуску</string>
     <string name="button_skip">Пропустити</string>
     <string name="notification_skipped">Сегмент пропущено</string>
     <string name="pref_show_clock">Показувати годинник</string>

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -35,4 +35,5 @@
     <item>button</item>
     <item>auto</item>
   </string-array>
+
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -44,6 +44,9 @@
     <string name="pref_skip_fetch">Find segments online</string>
     <string name="pref_skip_fetch_on">Look up intro/credits segments from online databases when the source provides none</string>
     <string name="pref_skip_fetch_off">Only use segments provided by the launching app</string>
+    <string name="skip_offset_title">Skip offset</string>
+    <string name="skip_offset_reset">Reset</string>
+    <string name="button_skip_offset">Skip offset</string>
     <string name="button_skip">Skip</string>
     <string name="notification_skipped">Segment skipped</string>
     <string name="pref_show_clock">Show clock</string>


### PR DESCRIPTION
## Summary

Two related improvements to the skip-segment feature.

### Accuracy — cross-source voting
Replaces the winner-take-all online lookup with cross-source voting:
- All sources in the applicable profile are probed **in parallel**, then grouped by category (intro/recap/credits) and clustered by start time.
- A cluster backed by **≥2 distinct sources** is *confirmed*; its timing is taken from the **most file-accurate agreeing source** (duration-aware / anime-primary over absolute), never averaging across coordinate systems.
- Two order profiles (anime vs non-anime) demote absolute-second sources to the tail.
- `SkipSegment` now carries category / coordinate-base / time-trust metadata and a `confirmed` flag.
- Fixes: cache key includes a duration bucket and negative results expire (TTL); the movie/series gate no longer misclassifies a season with a missing episode; open-ended ends are capped to credits.

### Session skip-offset control
A dedicated in-player control to nudge skip timing for the current session:
- A bottom-bar button (next to the settings gear) that appears **only once a skip segment exists** in the timeline now or earlier in the session.
- Opens a slider panel styled to match the quality/playlist dialogs: large value readout, coral-tinted `SeekBar` (touch = fine 0.25 s drag; TV remote = 0.5 s D-pad steps, focusable), −/+ icon buttons and a Reset pill; range ±30 s.
- Applies **live** via `SkipManager` (shift + clamp to media bounds), moving the timeline highlights.
- **Session-scoped**: carries across playlist episodes, resets on a new media session, and is not persisted to settings.

## Notes
- No unit tests in this project; verified via `./gradlew assembleLatestUniversalDebug` and manual on-device testing (touch).
- Design/implementation notes live under `SKIP/`.