### PR TITLE
Add setting to control system refresh-rate matching

### DIFF
--- a/app/src/main/java/com/brouken/player/PlayerActivity.java
+++ b/app/src/main/java/com/brouken/player/PlayerActivity.java
@@ -3698,6 +3698,12 @@ public class PlayerActivity extends Activity {
 
         player = playerBuilder.build();
 
+        if (!mPrefs.allowSystemFrameRate) {
+            // Stop ExoPlayer from voting Surface.setFrameRate() on start/pause/seek. On many TV
+            // panels a refresh-rate switch (even a "seamless" one) re-syncs the panel and flickers.
+            player.setVideoChangeFrameRateStrategy(C.VIDEO_CHANGE_FRAME_RATE_STRATEGY_OFF);
+        }
+
         AudioAttributes audioAttributes = new AudioAttributes.Builder()
                 .setUsage(C.USAGE_MEDIA)
                 .setContentType(C.AUDIO_CONTENT_TYPE_MOVIE)

--- a/app/src/main/java/com/brouken/player/Prefs.java
+++ b/app/src/main/java/com/brouken/player/Prefs.java
@@ -39,6 +39,7 @@ class Prefs {
     private static final String PREF_KEY_TUNNELING = "tunneling";
     private static final String PREF_KEY_SKIP_SILENCE = "skipSilence";
     private static final String PREF_KEY_FRAMERATE_MATCHING = "frameRateMatching";
+    private static final String PREF_KEY_ALLOW_SYSTEM_FRAMERATE = "allowSystemFrameRate";
     private static final String PREF_KEY_REPEAT_TOGGLE = "repeatToggle";
     private static final String PREF_KEY_SPEED = "speed";
     private static final String PREF_KEY_FILE_ACCESS = "fileAccess";
@@ -86,6 +87,7 @@ class Prefs {
     public boolean tunneling = false;
     public boolean skipSilence = false;
     public boolean frameRateMatching = false;
+    public boolean allowSystemFrameRate = true;
     public boolean repeatToggle = false;
     public String fileAccess = "auto";
     public int decoderPriority = DefaultRenderersFactory.EXTENSION_RENDERER_MODE_ON;
@@ -146,6 +148,7 @@ class Prefs {
         tunneling = mSharedPreferences.getBoolean(PREF_KEY_TUNNELING, tunneling);
         skipSilence = mSharedPreferences.getBoolean(PREF_KEY_SKIP_SILENCE, skipSilence);
         frameRateMatching = mSharedPreferences.getBoolean(PREF_KEY_FRAMERATE_MATCHING, frameRateMatching);
+        allowSystemFrameRate = mSharedPreferences.getBoolean(PREF_KEY_ALLOW_SYSTEM_FRAMERATE, !Utils.isTvBox(mContext));
         repeatToggle = mSharedPreferences.getBoolean(PREF_KEY_REPEAT_TOGGLE, repeatToggle);
         fileAccess = mSharedPreferences.getString(PREF_KEY_FILE_ACCESS, fileAccess);
         decoderPriority = Integer.parseInt(mSharedPreferences.getString(PREF_KEY_DECODER_PRIORITY, String.valueOf(decoderPriority)));

--- a/app/src/main/java/com/brouken/player/SettingsActivity.java
+++ b/app/src/main/java/com/brouken/player/SettingsActivity.java
@@ -18,6 +18,7 @@ import androidx.preference.ListPreference;
 import androidx.preference.Preference;
 import androidx.preference.PreferenceCategory;
 import androidx.preference.PreferenceFragmentCompat;
+import androidx.preference.SwitchPreferenceCompat;
 import androidx.recyclerview.widget.RecyclerView;
 
 import com.brouken.player.update.Updater;
@@ -88,6 +89,12 @@ public class SettingsActivity extends AppCompatActivity {
     public static class SettingsFragment extends PreferenceFragmentCompat {
         @Override
         public void onCreatePreferences(Bundle savedInstanceState, String rootKey) {
+            // Inflation materializes switch defaults, so record whether the key was already
+            // persisted before that happens.
+            boolean hadAllowSystemFrameRateKey =
+                    androidx.preference.PreferenceManager.getDefaultSharedPreferences(getContext())
+                            .contains("allowSystemFrameRate");
+
             setPreferencesFromResource(R.xml.root_preferences, rootKey);
 
             Preference preferenceAutoPiP = findPreference("autoPiP");
@@ -97,6 +104,15 @@ public class SettingsActivity extends AppCompatActivity {
             Preference preferenceFrameRateMatching = findPreference("frameRateMatching");
             if (preferenceFrameRateMatching != null) {
                 preferenceFrameRateMatching.setEnabled(Build.VERSION.SDK_INT >= 23);
+            }
+            SwitchPreferenceCompat preferenceAllowSystemFrameRate = findPreference("allowSystemFrameRate");
+            if (preferenceAllowSystemFrameRate != null) {
+                // Surface.setFrameRate() only exists on API 30+; below that this toggle is a no-op.
+                preferenceAllowSystemFrameRate.setEnabled(Build.VERSION.SDK_INT >= 30);
+                if (!hadAllowSystemFrameRateKey) {
+                    // Device-specific default: off on TV (avoids the Hz-switch flicker), on elsewhere.
+                    preferenceAllowSystemFrameRate.setChecked(!Utils.isTvBox(getContext()));
+                }
             }
             ListPreference listPreferenceFileAccess = findPreference("fileAccess");
             if (listPreferenceFileAccess != null) {

--- a/app/src/main/java/com/brouken/player/Utils.java
+++ b/app/src/main/java/com/brouken/player/Utils.java
@@ -41,7 +41,6 @@ import android.view.WindowInsetsController;
 import android.view.WindowManager;
 import android.widget.FrameLayout;
 import android.widget.ImageButton;
-import android.widget.Toast;
 
 import androidx.annotation.RequiresApi;
 import androidx.documentfile.provider.DocumentFile;
@@ -642,9 +641,6 @@ class Utils {
         activity.runOnUiThread(() -> {
             boolean switchingModes = false;
 
-            if (BuildConfig.DEBUG)
-                Toast.makeText(activity, "Video frameRate: " + frameRate, Toast.LENGTH_LONG).show();
-
             if (frameRate > 0) {
                 Display display = activity.getWindow().getDecorView().getDisplay();
                 if (display == null) {
@@ -676,10 +672,8 @@ class Utils {
 
                     if (modesResolutionCount > 1) {
                         Display.Mode modeBest = null;
-                        String modes = "Available refreshRates:";
 
                         for (Display.Mode mode : modesHigh) {
-                            modes += " " + mode.getRefreshRate();
                             if (normRate(mode.getRefreshRate()) % normRate(frameRate) <= 0.0001f) {
                                 if (modeBest == null || normRate(mode.getRefreshRate()) > normRate(modeBest.getRefreshRate())) {
                                     modeBest = mode;
@@ -698,10 +692,6 @@ class Utils {
                             layoutParams.preferredDisplayModeId = modeBest.getModeId();
                             window.setAttributes(layoutParams);
                         }
-                        if (BuildConfig.DEBUG)
-                            Toast.makeText(activity, modes + "\n" +
-                                    "Video frameRate: " + frameRate + "\n" +
-                                    "Current display refreshRate: " + modeBest.getRefreshRate(), Toast.LENGTH_LONG).show();
                     }
                 }
             }

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -27,6 +27,9 @@
     <string name="pref_framerate_matching_off">Не изменять частоту обновления экрана</string>
     <string name="pref_framerate_matching_on">Переключать частоту обновления экрана в соответствии с частотой кадров видеосигнала</string>
     <string name="pref_framerate_matching">Автоматическое согласование частоты кадров</string>
+    <string name="pref_allow_system_framerate">Разрешить системе подстраивать частоту обновления</string>
+    <string name="pref_allow_system_framerate_on">Плеер может менять частоту обновления экрана под видео (на некоторых телевизорах возможно мигание)</string>
+    <string name="pref_allow_system_framerate_off">Не менять частоту обновления экрана во время воспроизведения</string>
     <string name="pref_general_header">Общие</string>
     <string name="pref_title">Настройки</string>
     <string name="pref_repeat_toggle">Переключение повтора</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -22,6 +22,9 @@
     <string name="pref_framerate_matching">Автоматичне узгодження частоти кадрів</string>
     <string name="pref_framerate_matching_on">Переключати частоту оновлення екрану відповідно до частоти кадрів відеосигналу</string>
     <string name="pref_framerate_matching_off">Не змінювати частоту оновлення екрану</string>
+    <string name="pref_allow_system_framerate">Дозволити системі підлаштовувати частоту оновлення</string>
+    <string name="pref_allow_system_framerate_on">Плеєр може змінювати частоту оновлення екрана під частоту відео (на деяких телевізорах можливе мигання)</string>
+    <string name="pref_allow_system_framerate_off">Не змінювати частоту оновлення екрана під час відтворення</string>
     <string name="pref_tunneling">Тунельне відтворення</string>
     <string name="pref_tunneling_summary">Тунелювання забезпечує кращу підтримку вмісту 4K/HDR, але може працювати не на всіх пристроях</string>
     <string name="pref_auto_pip">Автоматичний режим PiP</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -23,6 +23,9 @@
     <string name="pref_framerate_matching">Auto frame rate matching</string>
     <string name="pref_framerate_matching_on">Switch display refresh rate to match video frame rate</string>
     <string name="pref_framerate_matching_off">Do not change display refresh rate</string>
+    <string name="pref_allow_system_framerate">Allow system to adjust refresh rate</string>
+    <string name="pref_allow_system_framerate_on">The player may switch the display refresh rate to match the video (can cause flicker on some TVs)</string>
+    <string name="pref_allow_system_framerate_off">Keep the display refresh rate unchanged during playback</string>
     <string name="pref_tunneling">Tunneled playback</string>
     <string name="pref_tunneling_summary">Tunneling provides better support for 4K/HDR content, but may not work on all devices</string>
     <string name="pref_auto_pip">Auto picture-in-picture</string>

--- a/app/src/main/res/xml/root_preferences.xml
+++ b/app/src/main/res/xml/root_preferences.xml
@@ -25,6 +25,13 @@
             app:title="@string/pref_framerate_matching" />
 
         <SwitchPreferenceCompat
+            app:key="allowSystemFrameRate"
+            app:defaultValue="true"
+            app:summaryOn="@string/pref_allow_system_framerate_on"
+            app:summaryOff="@string/pref_allow_system_framerate_off"
+            app:title="@string/pref_allow_system_framerate" />
+
+        <SwitchPreferenceCompat
             app:key="autoPiP"
             app:defaultValue="false"
             app:summaryOn="@string/pref_auto_pip_on"


### PR DESCRIPTION
## Problem

On Android TV, users report the display refresh rate (Hz) switching during **pause** and **seeking**, with a visible flicker at the top of the video. Phones and tablets are unaffected.

**Root cause:** ExoPlayer's `VideoFrameReleaseHelper` calls `Surface.setFrameRate()` on Android 11+ — it sets the surface frame rate on play/resume and clears it (to 0) on every pause and rebuffer/seek (renderers are stopped whenever the player leaves `STATE_READY`). The default strategy is `VIDEO_CHANGE_FRAME_RATE_STRATEGY_ONLY_IF_SEAMLESS`. On many TV panels/HDMI boxes even a "seamless" switch re-syncs the panel, producing the flicker. Phones/tablets have a single refresh mode or genuinely seamless switching, so nothing is visible there.

## Change

Add an **"Allow system to adjust refresh rate"** toggle (`allowSystemFrameRate`) backed by `ExoPlayer.setVideoChangeFrameRateStrategy`:

- When **off**, the player sets `VIDEO_CHANGE_FRAME_RATE_STRATEGY_OFF`, so ExoPlayer no longer votes `Surface.setFrameRate()` on start/pause/seek.
- Default is **off on Android TV** (where the flicker occurs) and **on everywhere else**; the user can override it per device.
- Below API 30 the toggle is disabled, since `Surface.setFrameRate()` does not apply there.

The existing opt-in `frameRateMatching` feature (app-driven one-shot display-mode switch via `preferredDisplayModeId`) is independent and unchanged.

Also removes leftover debug toasts from `Utils.handleFrameRate`.

## Testing

Compiles (`assembleLatestUniversalDebug`). Verified on a phone that the toggle appears with the correct default (on) and playback is unchanged.

**Still to verify on the affected TV:** with the toggle at its default (off), pause/resume and seek should no longer switch Hz or flicker; toggling it on should bring the flicker back.