### PR TITLE
Improve Ukrainian wording for skip offset

### DIFF
--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -46,9 +46,9 @@
     <string name="pref_skip_fetch">Шукати сегменти онлайн</string>
     <string name="pref_skip_fetch_on">Шукати сегменти заставок і титрів в онлайн-базах, якщо джерело їх не надало</string>
     <string name="pref_skip_fetch_off">Використовувати лише сегменти від застосунку</string>
-    <string name="skip_offset_title">Зсув пропуску</string>
+    <string name="skip_offset_title">Зміщення пропуску</string>
     <string name="skip_offset_reset">Скинути</string>
-    <string name="button_skip_offset">Зсув пропуску</string>
+    <string name="button_skip_offset">Зміщення пропуску</string>
     <string name="button_skip">Пропустити</string>
     <string name="notification_skipped">Сегмент пропущено</string>
     <string name="pref_show_clock">Показувати годинник</string>


### PR DESCRIPTION
## Change

The Ukrainian label for the skip-offset control read "Зсув пропуску", which sounds like an awkward calque to native speakers.

Replace it with **"Зміщення пропуску"** (the natural parallel to the Russian "Смещение пропуска") for both affected strings:

- `skip_offset_title`
- `button_skip_offset`

English and Russian strings are unchanged.