### PR TITLE
Prefer ffmpeg audio for MKV on TV boxes

### DIFF
--- a/app/src/main/java/com/brouken/player/PlayerActivity.java
+++ b/app/src/main/java/com/brouken/player/PlayerActivity.java
@@ -38,6 +38,7 @@ import android.media.audiofx.LoudnessEnhancer;
 import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
+import android.os.Handler;
 import android.os.Parcelable;
 import android.provider.DocumentsContract;
 import android.provider.Settings;
@@ -93,8 +94,11 @@ import androidx.media3.datasource.DefaultHttpDataSource;
 import androidx.media3.exoplayer.DefaultRenderersFactory;
 import androidx.media3.exoplayer.ExoPlaybackException;
 import androidx.media3.exoplayer.ExoPlayer;
+import androidx.media3.exoplayer.Renderer;
 import androidx.media3.exoplayer.RenderersFactory;
 import androidx.media3.exoplayer.SeekParameters;
+import androidx.media3.exoplayer.audio.AudioRendererEventListener;
+import androidx.media3.exoplayer.audio.AudioSink;
 import androidx.media3.exoplayer.mediacodec.MediaCodecSelector;
 import androidx.media3.exoplayer.source.DefaultMediaSourceFactory;
 import androidx.media3.exoplayer.trackselection.DefaultTrackSelector;
@@ -3571,6 +3575,20 @@ public class PlayerActivity extends Activity {
         mPrefs.updateSubtitle(uri);
     }
 
+    // Whether the current media is a Matroska container, detected from the resolved MIME type or the
+    // URI extension. Extensionless streams that never reveal a matroska type are not matched.
+    private boolean isMatroskaMedia() {
+        if (MimeTypes.VIDEO_MATROSKA.equals(mPrefs.mediaType)) {
+            return true;
+        }
+        if (mPrefs.mediaUri == null) {
+            return false;
+        }
+        final String path = mPrefs.mediaUri.getPath();
+        // Case-insensitive ".mkv" suffix test without allocating a lower-cased copy of the path.
+        return path != null && path.regionMatches(true, path.length() - 4, ".mkv", 0, 4);
+    }
+
     public void initializePlayer() {
         boolean isNetworkUri = Utils.isSupportedNetworkUri(mPrefs.mediaUri);
         haveMedia = mPrefs.mediaUri != null;
@@ -3633,7 +3651,29 @@ public class PlayerActivity extends Activity {
         DefaultExtractorsFactory extractorsFactory = new DefaultExtractorsFactory()
                 .setTsExtractorFlags(DefaultTsPayloadReaderFactory.FLAG_ENABLE_HDMV_DTS_AUDIO_STREAMS)
                 .setTsExtractorTimestampSearchBytes(1500 * TsExtractor.TS_PACKET_SIZE);
-        @SuppressLint("WrongConstant") DefaultRenderersFactory renderersFactory = new DefaultRenderersFactory(this)
+        // On TV boxes, decode MKV audio in software (ffmpeg) instead of routing it to the platform
+        // audio decoder / HDMI passthrough. Some TV decoders and passthrough paths wedge on init for
+        // the heavy codecs common in MKV remuxes (DTS/EAC3/TrueHD) — the load then never reaches a
+        // ready state (JPP-1005). Preferring the ffmpeg audio renderer sidesteps that path entirely.
+        // Only audio is affected (video keeps the user's decoder priority), and only for MKV on a TV;
+        // phones already fall back to ffmpeg for these codecs, and non-MKV keeps passthrough intact.
+        final boolean preferFfmpegAudio = isTvBox && isMatroskaMedia();
+        DefaultRenderersFactory baseRenderersFactory = preferFfmpegAudio
+                ? new DefaultRenderersFactory(this) {
+                    @Override
+                    protected void buildAudioRenderers(Context context, int extensionRendererMode,
+                                                       MediaCodecSelector mediaCodecSelector,
+                                                       boolean enableDecoderFallback, AudioSink audioSink,
+                                                       Handler eventHandler,
+                                                       AudioRendererEventListener eventListener,
+                                                       ArrayList<Renderer> out) {
+                        super.buildAudioRenderers(context, EXTENSION_RENDERER_MODE_PREFER,
+                                mediaCodecSelector, enableDecoderFallback, audioSink, eventHandler,
+                                eventListener, out);
+                    }
+                }
+                : new DefaultRenderersFactory(this);
+        @SuppressLint("WrongConstant") DefaultRenderersFactory renderersFactory = baseRenderersFactory
                 .setExtensionRendererMode(mPrefs.decoderPriority)
                 .setMapDV7ToHevc(mPrefs.mapDV7ToHevc);
         if (forceHevcForDolbyVision) {


### PR DESCRIPTION
## Problem

On some Android TV boxes, opening an MKV (e.g. a torrent stream) hangs on a black screen and eventually surfaces **JPP-1005 (LOAD_TIMEOUT)**: playback never reaches a ready state within the load watchdog window. The same files play fine on phones and in other Media3-based players.

Root cause: the platform audio decoder / HDMI passthrough on these devices **wedges during initialization** for the heavy audio codecs common in MKV remuxes (DTS/EAC3/TrueHD). The init call blocks on the playback thread without throwing, so no `PlaybackException` is raised — the load just stalls. Phones don't hit this because they have no such platform decoder and already fall back to the ffmpeg extension for these codecs.

## Fix

For **MKV on a TV box**, build the ffmpeg audio renderer ahead of the platform one (via a `DefaultRenderersFactory.buildAudioRenderers` override using `EXTENSION_RENDERER_MODE_PREFER`), so the wedging platform audio path is never taken.

- **Audio only** — video renderers keep the user's decoder priority.
- **Scoped to MKV on TV** — detected by MIME `video/x-matroska` or a `.mkv` URL path, gated by `isTvBox`.
- Non-MKV content and phones are unchanged, so audio passthrough for other containers is untouched.

## Trade-off

MKV audio on a TV box is decoded in software (ffmpeg) rather than via the platform decoder / passthrough, so bitstream passthrough (e.g. DTS-HD/TrueHD to an AVR) is not used for MKV on TV. This matches the behavior of other Media3-based players that software-decode audio by default.

## Notes / limitations

- An extensionless stream that never reveals a Matroska MIME type is not matched.
- A Dolby Vision video decoder wedge at load time is not addressed by this audio-only routing.

## Testing

Manual (no unit tests in this project): confirmed the build compiles (`assembleLatestUniversalRelease`) and that non-MKV playback is byte-for-byte the previous code path.