### PR TITLE
Default end-credits skip to the Skip button

### DIFF
--- a/app/src/main/java/com/brouken/player/Prefs.java
+++ b/app/src/main/java/com/brouken/player/Prefs.java
@@ -97,7 +97,7 @@ class Prefs {
     public boolean subtitleStyleBold = false;
     public boolean skipEnabled = true;
     public String skipMode = SKIP_MODE_BUTTON;
-    public String skipModeCredits = SKIP_MODE_AUTO;
+    public String skipModeCredits = SKIP_MODE_BUTTON;
     public boolean skipFetchOnline = true;
     public boolean showClock = false;
     public boolean crashReporting = true;

--- a/app/src/main/res/xml/root_preferences.xml
+++ b/app/src/main/res/xml/root_preferences.xml
@@ -79,7 +79,7 @@
             app:useSimpleSummaryProvider="true" />
 
         <ListPreference
-            app:defaultValue="auto"
+            app:defaultValue="button"
             app:dependency="skipEnabled"
             app:entries="@array/skip_mode_entries"
             app:entryValues="@array/skip_mode_values"


### PR DESCRIPTION
Previously end credits were auto-skipped by default (`skipModeCredits = auto`), unlike intro/recap segments which show a Skip button.

This changes the default so end credits are offered via the Skip button, consistent with the intro/recap behaviour:

- `Prefs.java` — `skipModeCredits` default `auto` → `button`
- `root_preferences.xml` — credits mode `defaultValue` `auto` → `button`

Players who prefer automatic skipping can still switch it back in Settings (End credits → Skip automatically). No playback logic changes — `PlayerActivity` already honours `skipModeCredits`.