### PR TITLE
Treat null segment start as file beginning

### DIFF
--- a/app/src/main/java/com/brouken/player/skip/SegmentFinder.java
+++ b/app/src/main/java/com/brouken/player/skip/SegmentFinder.java
@@ -781,6 +781,13 @@ public final class SegmentFinder {
 
     private static void addSeg(List<SkipSegment> out, double startSec, double endSec,
                                SkipSegment.Category category, SkipSegment.CoordBase coordBase, int timeTrust) {
+        // A missing start (start_ms: null) means "from the beginning of the file" — common for intro/recap.
+        // Symmetric with the open-ended-end handling; excluded for credits, where a file-start segment
+        // would span nearly the whole file.
+        if (Double.isNaN(startSec) && !Double.isNaN(endSec)
+                && category != SkipSegment.Category.CREDITS) {
+            startSec = 0;
+        }
         if (Double.isNaN(startSec) || Double.isNaN(endSec) || endSec <= startSec) {
             return;
         }


### PR DESCRIPTION
## Problem

A skip segment with a missing start (`start_ms: null`) but a valid end was silently dropped. A `NaN` start failed the guard in `SegmentFinder.addSeg`, so intro/recap segments that some sources express as "starts at the beginning of the file" were lost.

Concrete report: for `tmdb_id=206343` s3e26 (`imdb_id=tt31530980`), TheIntroDB returns an intro with `end_ms: 126000` (2:06) and `start_ms: null` — the skip button never appeared.

## Fix

Normalize a missing start to the file beginning in the shared `addSeg` helper. This is symmetric with the existing open-ended-end handling and covers all sources that funnel through `addSeg` (TheIntroDB, SkipMe, SkipDB, IntroDB.app). Credits are excluded, so a null-start credits segment cannot span nearly the whole file.

## Notes

- No regression for valid starts: the new branch only fires on a `NaN` start, which was dropped before anyway.
- Verified with a debug build (`assembleLatestUniversalDebug`).
