### PR TITLE
Remove stale onboarding_open translations

### DIFF
--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -23,8 +23,6 @@
     <string name="error_files_missing">تطبيق Files غير فعّال أو غير موجود</string>
     <string name="error_details">التفاصيل</string>
     <string name="open_subtitles">تحميل الترجمات</string>
-    <string name="onboarding_open_description">انقر لفتح ملف فيديو. اضغط ضغطة مطوّلة لتحميل الترجمات الخارجية.</string>
-    <string name="onboarding_open_title">اختر مقطع فيديو لتشغيله</string>
     <string name="shortcut_videos">الفيديوهات</string>
     <string name="pref_repeat_toggle">تكرار</string>
     <string name="pref_decoder_priority">أولوية التشفير</string>

--- a/app/src/main/res/values-az/strings.xml
+++ b/app/src/main/res/values-az/strings.xml
@@ -4,7 +4,6 @@
     <string name="video_resize_crop">Qırp</string>
     <string name="video_orientation_sensor">Avtomatik fırlanmaq</string>
     <string name="video_orientation_system">Cihaz istiqamətləndirməsi</string>
-    <string name="onboarding_open_title">Oynatmaq üçün video seç</string>
     <string name="open_subtitles">Altyazıları yüklə</string>
     <string name="error_details">Təfərrüatlar</string>
     <string name="error_files_missing">Fayllar tətbiqi deaktivdir və ya yoxdur</string>
@@ -24,7 +23,6 @@
     <string name="pref_skip_silence_off">Məzmunu olduğu kimi oynat</string>
     <string name="video_resize_fit">Uyğunlaşdır</string>
     <string name="video_orientation_video">Video istiqamətləndirmə</string>
-    <string name="onboarding_open_description">Video faylı açmaq üçün toxun.Xarici altyazıları yükləmək üçün uzun bas.</string>
     <string name="request_scope">Xarici altyazıları avtomatik yükləmək və ya kataloqda növbəti fayla keçidi aktivləşdirmək üçün videolarınızı ehtiva edən ən üst qovluğa (məsələn, Filmlər) %s giriş icazəsi verin.</string>
     <string name="pref_tunneling_summary">Tunelləmə 4K/HDR məzmunu üçün daha yaxşı dəstək verir, lakin bütün cihazlarda işləməyə bilər</string>
 </resources>

--- a/app/src/main/res/values-bn/strings.xml
+++ b/app/src/main/res/values-bn/strings.xml
@@ -5,6 +5,5 @@
     <string name="video_orientation_video">ভিডিও অরিয়েন্টেশন</string>
     <string name="video_orientation_sensor">অটো-রোটেট</string>
     <string name="video_orientation_system">ডিভাইস অরিয়েন্টেশন</string>
-    <string name="onboarding_open_title">চালানোর জন্য একটি ভিডিও বাছুন</string>
     <string name="delete_confirmation">মুছুন</string>
 </resources>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -5,8 +5,6 @@
     <string name="video_orientation_video">Orientace videa</string>
     <string name="video_orientation_sensor">Automatické otáčení</string>
     <string name="video_orientation_system">Orientace zařízení</string>
-    <string name="onboarding_open_title">Vyberte video k přehrání</string>
-    <string name="onboarding_open_description">Klepněte pro otevření souboru s videem. Dlouze podržte pro načtení externích titulků.</string>
     <string name="open_subtitles">Načíst titulky</string>
     <string name="error_details">Podrobnosti</string>
     <string name="error_files_missing">Aplikace Soubory je deaktivována nebo chybí</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -3,8 +3,6 @@
     <string name="error_files_missing">Dateien-Anwendung ist deaktiviert oder fehlt</string>
     <string name="error_details">Einzelheiten</string>
     <string name="open_subtitles">Untertitel laden</string>
-    <string name="onboarding_open_description">Tippen Sie hier, um eine Videodatei zu öffnen. Langes Tippen, um externe Untertitel zu laden.</string>
-    <string name="onboarding_open_title">Wählen Sie ein Video zum Abspielen</string>
     <string name="video_orientation_sensor">Automatisch drehen</string>
     <string name="video_orientation_video">Video-Orientierung</string>
     <string name="video_resize_crop">Zuschneiden</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -3,8 +3,6 @@
     <string name="error_files_missing">Η εφαρμογή Αρχεία είναι απενεργοποιημένη ή λείπει</string>
     <string name="error_details">Λεπτομέρειες</string>
     <string name="open_subtitles">Φόρτωση υποτίτλων</string>
-    <string name="onboarding_open_description">Πατήστε για να ανοίξετε ένα αρχείο βίντεο. Πατήστε παρατεταμένα για να φορτώσετε εξωτερικούς υπότιτλους.</string>
-    <string name="onboarding_open_title">Επιλογή βίντεο για αναπαραγωγή</string>
     <string name="video_orientation_sensor">Αυτόματη περιστροφή</string>
     <string name="video_orientation_video">Προσανατολισμός βίντεο</string>
     <string name="video_resize_crop">Περικοπή</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -4,8 +4,6 @@
     <string name="video_resize_crop">Recortar</string>
     <string name="video_orientation_video">Orientación del vídeo</string>
     <string name="video_orientation_sensor">Rotación automática</string>
-    <string name="onboarding_open_title">Escoge un vídeo para reproducir</string>
-    <string name="onboarding_open_description">Toca para abrir un archivo de vídeo. Mantén presionado para cargar subtítulos externos.</string>
     <string name="open_subtitles">Cargar subtítulos</string>
     <string name="error_details">Detalles</string>
     <string name="error_files_missing">La aplicación de archivos está desactivada o no existe</string>

--- a/app/src/main/res/values-et/strings.xml
+++ b/app/src/main/res/values-et/strings.xml
@@ -5,8 +5,6 @@
     <string name="error_details">Üksikasjad</string>
     <string name="video_orientation_video">Video paigutus</string>
     <string name="video_orientation_sensor">Pööra automaatselt</string>
-    <string name="onboarding_open_title">Vali esitatav video</string>
-    <string name="onboarding_open_description">Videofaili avamiseks klõpsi. Väliste subtiitrite lisamiseks puuduta pikalt.</string>
     <string name="error_files_missing">Failide rakendus on väljalülitatud või puudu</string>
     <string name="shortcut_videos">Videod</string>
     <string name="button_open">Ava</string>

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -3,5 +3,4 @@
     <string name="video_resize_fit">اندازه مناسب</string>
     <string name="video_resize_crop">کراپ</string>
     <string name="video_orientation_sensor">چرخش خودکار</string>
-    <string name="onboarding_open_title">یه ویدیو برای پخش انتخاب کن داداچ</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -3,8 +3,6 @@
     <string name="error_files_missing">L’application Fichiers est désactivée ou manquante</string>
     <string name="error_details">Détails</string>
     <string name="open_subtitles">Charger les sous-titres</string>
-    <string name="onboarding_open_description">Appuyez pour ouvrir un fichier vidéo. Appui long pour charger les sous-titres externes.</string>
-    <string name="onboarding_open_title">Choisissez une vidéo à lire</string>
     <string name="video_orientation_sensor">Rotation automatique</string>
     <string name="video_orientation_video">Orientation vidéo</string>
     <string name="video_resize_crop">Rogner</string>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -3,10 +3,8 @@
     <string name="video_resize_crop">क्रॉप करें</string>
     <string name="video_orientation_sensor">ऑटो-रोटेट</string>
     <string name="video_orientation_system">डिवाइस ओरिएंटेशन</string>
-    <string name="onboarding_open_title">चलाने के लिए कोई वीडियो चुनें</string>
     <string name="video_resize_fit">फिट</string>
     <string name="video_orientation_video">वीडियो ओरिएंटेशन</string>
-    <string name="onboarding_open_description">वीडियो फ़ाइल खोलने के लिए टैप करें। बाहरी उपशीर्षक लोड करने के लिए लंबा टैप करें।</string>
     <string name="open_subtitles">सबटाइटल लोड करें</string>
     <string name="error_details">विवरण</string>
     <string name="error_files_missing">Files ऐप डिसेबल या अनुपलब्ध है</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -3,8 +3,6 @@
     <string name="error_files_missing">Files aplikacija je deaktivirana ili nedostaje</string>
     <string name="error_details">Pojedinosti</string>
     <string name="open_subtitles">Učitaj titlove</string>
-    <string name="onboarding_open_description">Dodirni za otvaranje video datoteke. Dodirni dugo za učitavanje vanjskih titlova.</string>
-    <string name="onboarding_open_title">Odaberi video</string>
     <string name="video_orientation_sensor">Automatsko okretanje</string>
     <string name="video_orientation_video">Položaj videa</string>
     <string name="video_resize_crop">Obreži</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -6,8 +6,6 @@
     <string name="video_resize_fit">Illesztés</string>
     <string name="error_details">Részletek</string>
     <string name="open_subtitles">Feliratok betöltése</string>
-    <string name="onboarding_open_description">Koppintson egyszer videófájl megnyitásához. Tartsa nyomva feliratok megnyitásához.</string>
-    <string name="onboarding_open_title">Válasszon egy videót a lejátszáshoz</string>
     <string name="video_orientation_video">Videó tájolása</string>
     <string name="shortcut_videos">Videók</string>
 </resources>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -4,8 +4,6 @@
     <string name="video_resize_crop">Pangkas</string>
     <string name="video_orientation_video">Orientasi video</string>
     <string name="video_orientation_sensor">Rotasi otomatis</string>
-    <string name="onboarding_open_title">Pilih video untuk diputar</string>
-    <string name="onboarding_open_description">Ketuk untuk membuka file video. Ketuk panjang untuk memuat subtitle eksternal.</string>
     <string name="open_subtitles">Muat subtitle</string>
     <string name="error_details">Detail</string>
     <string name="error_files_missing">Aplikasi file dinonaktifkan atau hilang</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -3,8 +3,6 @@
     <string name="error_files_missing">L’applicazione File è disabilitata o mancante</string>
     <string name="error_details">Dettagli</string>
     <string name="open_subtitles">Carica i sottotitoli</string>
-    <string name="onboarding_open_description">Tocca per aprire un file video. Tocco lungo per caricare sottotitoli esterni.</string>
-    <string name="onboarding_open_title">Scegli un video da riprodurre</string>
     <string name="video_orientation_sensor">Rotazione automatica</string>
     <string name="video_orientation_video">Orientamento video</string>
     <string name="video_resize_crop">Ritaglia</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -6,8 +6,6 @@
     <string name="error_files_missing">ファイルアプリが無効化された、または見つからない</string>
     <string name="error_details">詳細</string>
     <string name="open_subtitles">字幕を読み込む</string>
-    <string name="onboarding_open_description">タップして動画ファイルを開く。長押して外部の字幕を読み込む。</string>
-    <string name="onboarding_open_title">再生する動画を選択</string>
     <string name="video_orientation_sensor">自動回転</string>
     <string name="video_orientation_video">映像の向き</string>
     <string name="video_resize_fit">丁度収める</string>

--- a/app/src/main/res/values-km/strings.xml
+++ b/app/src/main/res/values-km/strings.xml
@@ -5,8 +5,6 @@
     <string name="video_orientation_video">ការបង្វិលទិសវីដេអូ</string>
     <string name="video_orientation_sensor">ស្វ័យបង្វិល</string>
     <string name="video_orientation_system">ការបង្វិលទិសតាមឧបករណ៍</string>
-    <string name="onboarding_open_title">ជ្រើសវីដេអូ ដើម្បីចាក់</string>
-    <string name="onboarding_open_description">ចុច ដើម្បីបើកឯកសារវីដេអូ។ ប៉ះឱ្យជាប់ ដើម្បីផ្ទុកចំណងជើងរងខាងក្រៅ។</string>
     <string name="open_subtitles">ផ្ទុកចំណងជើងរង</string>
     <string name="error_details">លម្អិត</string>
     <string name="error_files_missing">កម្មវិធី“Files” ត្រូវបានផ្ដាច់ ឬបាត់កម្មវិធី</string>

--- a/app/src/main/res/values-ml/strings.xml
+++ b/app/src/main/res/values-ml/strings.xml
@@ -2,7 +2,6 @@
 <resources>
     <string name="delete_confirmation">ഇല്ലാതാക്കുക</string>
     <string name="video_resize_crop">വെട്ടുക</string>
-    <string name="onboarding_open_title">കളിക്കാനായി ഒരു വീഡിയോ തിരഞ്ഞെടുക്കുക</string>
     <string name="button_open">തുറക്കുക</string>
     <string name="button_crop">വലുപ്പം മാറ്റുക</string>
     <string name="button_rotate">തിരിക്കുക</string>

--- a/app/src/main/res/values-ms/strings.xml
+++ b/app/src/main/res/values-ms/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="onboarding_open_title">Pilih video untuk dimainkan</string>
     <string name="open_subtitles">Muat sari kata</string>
     <string name="pref_framerate_matching">Penyerasian kadar bidang automatik</string>
     <string name="pref_framerate_matching_off">Jangan ubah kadar segar semula paparan</string>
@@ -25,7 +24,6 @@
     <string name="pref_general_header">Umum</string>
     <string name="video_resize_crop">Pangkas</string>
     <string name="video_orientation_video">Orientasi video</string>
-    <string name="onboarding_open_description">Sentuh untuk membuka fail video. Sentuh lama untuk memuatkan sari kata luaran.</string>
     <string name="error_files_missing">Fail apl dinyahdayakan ataupun hilang</string>
     <string name="delete_query">Padam fail ini\?</string>
     <string name="pref_auto_pip_on">Ubah ke mod tetingkap ketika keluar apl</string>

--- a/app/src/main/res/values-nb-rNO/strings.xml
+++ b/app/src/main/res/values-nb-rNO/strings.xml
@@ -3,8 +3,6 @@
     <string name="error_files_missing">Filutforsker avskrudd eller manglende</string>
     <string name="error_details">Detaljer</string>
     <string name="open_subtitles">Last inn undertekster</string>
-    <string name="onboarding_open_description">Trykk for å åpne videofil. Trykk lenge for å laste eksterne undertekster.</string>
-    <string name="onboarding_open_title">Velg en video å spille</string>
     <string name="video_orientation_sensor">Roter automatisk</string>
     <string name="video_orientation_video">Skjermretning</string>
     <string name="video_resize_crop">Beskjør</string>

--- a/app/src/main/res/values-pa/strings.xml
+++ b/app/src/main/res/values-pa/strings.xml
@@ -3,7 +3,6 @@
     <string name="video_resize_crop">ਕਰੌਪ ਕਰੋ</string>
     <string name="video_orientation_video">ਵੀਡੀਓ ਓਰੀਐਂਟੇਸ਼ਨ</string>
     <string name="video_orientation_sensor">ਆਪਣੇ-ਆਪ ਘੁਮਾਓ</string>
-    <string name="onboarding_open_title">ਚਲਾਉਣ ਲਈ ਇੱਕ ਵੀਡੀਓ ਚੁਣੋ</string>
     <string name="open_subtitles">ਉਪਸਿਰਲੇਖ ਲੋਡ ਕਰੋ</string>
     <string name="error_details">ਵੇਰਵੇ</string>
     <string name="error_files_missing">Files ਐਪ ਡਿਸ-ਏਬਲ ਜਾਂ ਗੈਰ-ਮੌਜੂਦ ਹੈ</string>
@@ -40,7 +39,6 @@
     <string name="pref_tunneling">ਟਨਲ ਕੀਤਾ ਪਲੇਬੈਕ</string>
     <string name="video_orientation_system">ਡਿਵਾਈਸ ਓਰੀਐਂਟੇਸ਼ਨ</string>
     <string name="request_scope">ਬਾਹਰੀ ਉਪਸਿਰਲੇਖਾਂ ਨੂੰ ਸਵੈਚਲਿਤ ਤੌਰ \'ਤੇ ਲੋਡ ਕਰਨ ਲਈ ਜਾਂ ਡਾਇਰੈਕਟਰੀ ਵਿੱਚ ਅਗਲੀ ਫਾਈਲ \'ਤੇ ਜਾਣ ਲਈ, %s ਨੂੰ ਤੁਹਾਡੇ ਵੀਡੀਓਜ਼ (ਉਦਾਹਰਨ ਲਈ ਮੂਵੀਜ਼) ਵਾਲੇ ਸਭ ਤੋਂ ਉੱਚੇ ਫੋਲਡਰ ਤੱਕ ਪਹੁੰਚ ਦਿਓ।</string>
-    <string name="onboarding_open_description">ਵੀਡੀਓ ਫਾਈਲ ਖੋਲ੍ਹਣ ਲਈ ਟੈਪ ਕਰੋ। ਬਾਹਰੀ ਉਪਸਿਰਲੇਖਾਂ ਨੂੰ ਲੋਡ ਕਰਨ ਲਈ ਲੰਬਾ ਟੈਪ ਕਰੋ।</string>
     <string name="pref_skip_silence">ਚੁੱਪ ਛੱਡੋ</string>
     <string name="pref_skip_silence_on">ਆਡੀਓ ਸਟ੍ਰੀਮ \'ਤੇ ਚੁੱਪ ਵਾਲੇ ਹਿੱਸਿਆਂ ਨੂੰ ਛੱਡੋ</string>
     <string name="pref_general_header">ਆਮ</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -4,10 +4,8 @@
     <string name="video_orientation_video">Orientacja wideo</string>
     <string name="error_details">Szczegóły</string>
     <string name="open_subtitles">Wczytaj napisy</string>
-    <string name="onboarding_open_description">Dotknij aby otworzyć plik wideo. Przytrzymaj aby załadować zewnętrzne napisy.</string>
     <string name="video_resize_crop">Przytnij</string>
     <string name="video_orientation_sensor">Obrót automatyczny</string>
-    <string name="onboarding_open_title">Wybierz wideo do odtworzenia</string>
     <string name="error_files_missing">Aplikacja Pliki jest wyłączona lub jej brakuje</string>
     <string name="shortcut_videos">Filmy</string>
     <string name="delete_query">Czy chcesz usunąć ten plik\?</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -4,8 +4,6 @@
     <string name="video_resize_crop">Cortar</string>
     <string name="video_orientation_video">Seguir orientação do vídeo</string>
     <string name="video_orientation_sensor">Rotação automática</string>
-    <string name="onboarding_open_title">Escolha um vídeo para reproduzir</string>
-    <string name="onboarding_open_description">Toque para abrir um arquivo de vídeo. Toque longo para carregar legendas externas.</string>
     <string name="open_subtitles">Carregar legendas</string>
     <string name="error_files_missing">O aplicativo \"Arquivos\" está desativado ou ausente</string>
     <string name="error_details">Detalhes</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -6,8 +6,6 @@
     <string name="error_files_missing">Aplicação \'Ficheiros\' inativa ou em falta</string>
     <string name="error_details">Detalhes</string>
     <string name="open_subtitles">Carregar legendas</string>
-    <string name="onboarding_open_description">Toque para abrir um vídeo. Toque longo para carregar legendas.</string>
-    <string name="onboarding_open_title">Escolha o vídeo a reproduzir</string>
     <string name="video_orientation_sensor">Rotação automática</string>
     <string name="video_orientation_video">Orientação do vídeo</string>
     <string name="video_resize_crop">Recortar</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -5,8 +5,6 @@
     <string name="video_orientation_video">Orientare video</string>
     <string name="video_orientation_sensor">Rotire automată</string>
     <string name="video_orientation_system">Orientarea dispozitivului</string>
-    <string name="onboarding_open_title">Alegeți un videoclip pentru a reda</string>
-    <string name="onboarding_open_description">Atingeți pentru a deschide un fișier video. Atingeți lung pentru a încărca subtitrări externe.</string>
     <string name="open_subtitles">Încărcați subtitrări</string>
     <string name="error_details">Detalii</string>
     <string name="error_files_missing">Aplicația Files este dezactivată sau lipsește</string>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -5,8 +5,6 @@
     <string name="video_orientation_video">Orientácia videa</string>
     <string name="video_orientation_sensor">Automatické otáčanie</string>
     <string name="video_orientation_system">Orientácia zariadenia</string>
-    <string name="onboarding_open_title">Vyberte video, ktoré chcete prehrať</string>
-    <string name="onboarding_open_description">Ťuknutím na položku otvoríte súbor s videom. Dlhým podržaním načítate externé titulky.</string>
     <string name="open_subtitles">Načítať titulky</string>
     <string name="error_details">Podrobnosti</string>
     <string name="error_files_missing">Aplikácia Súbory je zakázaná alebo chýba</string>

--- a/app/src/main/res/values-sr/strings.xml
+++ b/app/src/main/res/values-sr/strings.xml
@@ -6,8 +6,6 @@
     <string name="error_files_missing">Aplikacija Datoteke je onemogucena ili nedostaje</string>
     <string name="error_details">Detalji</string>
     <string name="open_subtitles">Ucitaj titlove</string>
-    <string name="onboarding_open_description">Dodirni da otvoris video fajl. Zadrzi dugo da ucitas spoljne titlove.</string>
-    <string name="onboarding_open_title">Izaberi video za pokretanje</string>
     <string name="video_orientation_sensor">Automatska rotacija</string>
     <string name="video_orientation_video">Video orijentacija</string>
     <string name="video_resize_crop">Iseci</string>

--- a/app/src/main/res/values-ta/strings.xml
+++ b/app/src/main/res/values-ta/strings.xml
@@ -2,7 +2,6 @@
 <resources>
     <string name="video_resize_fit">பொருத்தம்</string>
     <string name="video_orientation_sensor">தானாக சுழற்று</string>
-    <string name="onboarding_open_title">விளையாட ஒரு வீடியோவைத் தேர்ந்தெடுக்கவும்</string>
     <string name="error_details">விவரங்கள்</string>
     <string name="delete_query">இந்தக் கோப்பை நீக்கவா\?</string>
     <string name="delete_confirmation">அழி</string>
@@ -17,7 +16,6 @@
     <string name="button_crop">அளவை மாற்றவும்</string>
     <string name="button_rotate">சுழற்று</string>
     <string name="button_pip">படத்தில்-படம்</string>
-    <string name="onboarding_open_description">வீடியோ கோப்பைத் திறக்க தட்டவும். வெளிப்புற வசனங்களை ஏற்ற நீண்ட நேரம் தட்டவும்.</string>
     <string name="open_subtitles">வசன வரிகளை ஏற்றவும்</string>
     <string name="error_files_missing">கோப்புகள் பயன்பாடு முடக்கப்பட்டுள்ளது அல்லது காணவில்லை</string>
     <string name="request_scope">வெளிப்புற வசனங்களைத் தானாக ஏற்ற அல்லது கோப்பகத்தில் அடுத்த கோப்பிற்குச் செல்வதை இயக்க, உங்கள் வீடியோக்கள் (எ.கா. திரைப்படங்கள்) உள்ள மேல்மட்ட கோப்புறைக்கு %s அணுகலை வழங்கவும்.</string>

--- a/app/src/main/res/values-th/strings.xml
+++ b/app/src/main/res/values-th/strings.xml
@@ -4,8 +4,6 @@
     <string name="error_files_missing">แอพไฟล์ถูกปิดใช้งานหรือหายไป</string>
     <string name="error_details">รายละเอียด</string>
     <string name="open_subtitles">โหลดคำบรรยาย</string>
-    <string name="onboarding_open_description">แตะเพื่อเปิดไฟล์วิดีโอ แตะค้างเพื่อโหลดคำบรรยายภายนอก</string>
-    <string name="onboarding_open_title">เลือกวิดีโอที่จะเล่น</string>
     <string name="video_orientation_sensor">หมุนอัตโนมัติ</string>
     <string name="video_resize_crop">พอดีกับหน้าจอ</string>
     <string name="video_resize_fit">พอดีที่สุด</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -4,8 +4,6 @@
     <string name="error_files_missing">Dosyalar uygulaması devre dışı veya yok</string>
     <string name="error_details">Ayrıntılar</string>
     <string name="open_subtitles">Alt yazıları yükle</string>
-    <string name="onboarding_open_description">Bir video dosyası açmak için dokunun. Harici alt yazıları yüklemek için uzun dokunun.</string>
-    <string name="onboarding_open_title">Oynatmak için bir video seçin</string>
     <string name="video_orientation_sensor">Otomatik döndür</string>
     <string name="video_resize_crop">Kırp</string>
     <string name="video_resize_fit">Sığdır</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -4,8 +4,6 @@
     <string name="video_resize_crop">Cắt bỏ</string>
     <string name="video_orientation_video">Hướng video</string>
     <string name="video_orientation_sensor">Tự động xoay</string>
-    <string name="onboarding_open_title">Chọn một video để phát</string>
-    <string name="onboarding_open_description">Nhấn để mở tệp video. Nhấn và giữ để tải phụ đề bên ngoài.</string>
     <string name="open_subtitles">Tải phụ đề</string>
     <string name="error_details">Thông tin chi tiết</string>
     <string name="error_files_missing">Ứng dụng tập tin bị tắt hoặc bị thiếu</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -3,8 +3,6 @@
     <string name="error_files_missing">文件应用处于禁用或缺失状态</string>
     <string name="error_details">详情</string>
     <string name="open_subtitles">加载字幕</string>
-    <string name="onboarding_open_description">轻按打开一个视频文件。长按加载外部视频。</string>
-    <string name="onboarding_open_title">选择要播放的文件</string>
     <string name="video_orientation_sensor">自动旋转</string>
     <string name="video_orientation_video">视频方向</string>
     <string name="video_resize_crop">裁剪</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -5,8 +5,6 @@
     <string name="video_orientation_video">影片方向</string>
     <string name="video_orientation_sensor">自動旋轉</string>
     <string name="video_orientation_system">裝置方向</string>
-    <string name="onboarding_open_title">選擇要播放的影片</string>
-    <string name="onboarding_open_description">輕觸即可開啟影片檔案，按住即可載入外掛字幕。</string>
     <string name="open_subtitles">載入字幕</string>
     <string name="error_details">資訊</string>
     <string name="error_files_missing">檔案應用程式已停用或遺失</string>


### PR DESCRIPTION
## Summary

The `v0.1.1` release build failed: `lintVitalLatestUniversalRelease` reported 63 `ExtraTranslation` errors for `onboarding_open_title` / `onboarding_open_description`.

Those first-launch empty-state strings were renamed in the default locale by the controls redesign (`onboarding_open_*` → `empty_state_*`), but the old keys remained in the translated `values-*` locales. Since they no longer exist in the default locale or in code, lint fails the release. Regular CI / debug builds don't run `lintVital`, so it only surfaced on the release tag.

## Changes

- Remove the orphaned `onboarding_open_title` / `onboarding_open_description` entries from all 33 translated `values-*/strings.xml` files (63 deletions).

## Testing

- `grep -r onboarding_open app/src/main/res` returns nothing after the change.
- No code references these keys.
