### PR TITLE
Player UX improvements

### DIFF
--- a/app/src/main/java/com/brouken/player/CustomPlayerView.java
+++ b/app/src/main/java/com/brouken/player/CustomPlayerView.java
@@ -55,6 +55,12 @@ public class CustomPlayerView extends PlayerView implements GestureDetector.OnGe
     private final ScaleGestureDetector mScaleDetector;
     private float mScaleFactor = 1.f;
     private float mScaleFactorFit;
+
+    // Hold-to-speed (YouTube-style): while the screen is long-pressed during playback, speed jumps to 2x
+    // and the previous speed is restored on release.
+    private static final float SPEED_BOOST = 2.f;
+    private boolean speedBoostActive = false;
+    private float speedBeforeBoost = 1.f;
     Rect systemGestureExclusionRect = new Rect();
 
     public final Runnable textClearRunnable = () -> {
@@ -116,6 +122,13 @@ public class CustomPlayerView extends PlayerView implements GestureDetector.OnGe
                 break;
             case MotionEvent.ACTION_UP:
             case MotionEvent.ACTION_CANCEL:
+                if (speedBoostActive) {
+                    speedBoostActive = false;
+                    if (PlayerActivity.player != null)
+                        PlayerActivity.player.setPlaybackSpeed(speedBeforeBoost);
+                    if (getContext() instanceof PlayerActivity)
+                        ((PlayerActivity) getContext()).setSpeedBoostIndicatorVisible(false);
+                }
                 if (handleTouch) {
                     if (gestureOrientation == Orientation.HORIZONTAL) {
                         setCustomErrorMessage(null);
@@ -284,6 +297,17 @@ public class CustomPlayerView extends PlayerView implements GestureDetector.OnGe
 
     @Override
     public void onLongPress(MotionEvent motionEvent) {
+        if (PlayerActivity.locked || mScaleDetector.isInProgress() || gestureOrientation != Orientation.UNKNOWN)
+            return;
+        if (!PlayerActivity.haveMedia || PlayerActivity.player == null || !PlayerActivity.player.isPlaying())
+            return;
+        speedBeforeBoost = PlayerActivity.player.getPlaybackParameters().speed;
+        speedBoostActive = true;
+        isHandledLongPress = true;
+        PlayerActivity.player.setPlaybackSpeed(SPEED_BOOST);
+        hideController();
+        if (getContext() instanceof PlayerActivity)
+            ((PlayerActivity) getContext()).setSpeedBoostIndicatorVisible(true);
     }
 
     // Toggles the touch lock (triggered by the lock button). While locked the controller stays hidden

--- a/app/src/main/java/com/brouken/player/CustomPlayerView.java
+++ b/app/src/main/java/com/brouken/player/CustomPlayerView.java
@@ -179,7 +179,8 @@ public class CustomPlayerView extends PlayerView implements GestureDetector.OnGe
         if (!PlayerActivity.controllerVisibleFully) {
             showController();
             return true;
-        } else if (PlayerActivity.haveMedia && PlayerActivity.player != null && PlayerActivity.player.isPlaying()) {
+        } else if (PlayerActivity.haveMedia && PlayerActivity.player != null) {
+            // Hide on tap even while paused, so the interface can be cleared for a clean screenshot.
             hideController();
             return true;
         }

--- a/app/src/main/java/com/brouken/player/CustomPlayerView.java
+++ b/app/src/main/java/com/brouken/player/CustomPlayerView.java
@@ -375,6 +375,28 @@ public class CustomPlayerView extends PlayerView implements GestureDetector.OnGe
                 (float)getWidth() / (float)getVideoSurfaceView().getWidth());
     }
 
+    // Applies a resize mode plus an optional forced display aspect ratio (>0). A forced ratio is set
+    // on the content frame directly; ratio 0 restores the video's natural AR (Media3 only recomputes
+    // that on the next video-size change, so we compute it here to switch out of a forced ratio at once).
+    public void applyAspectMode(int resizeMode, float forcedRatio) {
+        setScale(1.f);
+        setResizeMode(resizeMode);
+        final AspectRatioFrameLayout frame = findViewById(R.id.exo_content_frame);
+        final float ratio = forcedRatio > 0 ? forcedRatio : naturalVideoAspectRatio();
+        if (frame != null && ratio > 0)
+            frame.setAspectRatio(ratio);
+    }
+
+    private float naturalVideoAspectRatio() {
+        if (PlayerActivity.player == null)
+            return 0;
+        final androidx.media3.common.Format format = PlayerActivity.player.getVideoFormat();
+        if (format == null || format.width <= 0 || format.height <= 0)
+            return 0;
+        final float par = format.pixelWidthHeightRatio > 0 ? format.pixelWidthHeightRatio : 1f;
+        return format.width * par / format.height;
+    }
+
     private enum Orientation {
         HORIZONTAL, VERTICAL, UNKNOWN
     }

--- a/app/src/main/java/com/brouken/player/CustomPlayerView.java
+++ b/app/src/main/java/com/brouken/player/CustomPlayerView.java
@@ -87,16 +87,6 @@ public class CustomPlayerView extends PlayerView implements GestureDetector.OnGe
         exoProgress = findViewById(R.id.exo_progress);
 
         mScaleDetector = new ScaleGestureDetector(context, this);
-
-        if (!Utils.isTvBox(getContext())) {
-            exoErrorMessage.setOnClickListener(v -> {
-                if (PlayerActivity.locked) {
-                    PlayerActivity.locked = false;
-                    Utils.showText(CustomPlayerView.this, "", MESSAGE_TIMEOUT_LONG);
-                    setIconLock(false);
-                }
-            });
-        }
     }
 
     public void clearIcon() {
@@ -180,8 +170,9 @@ public class CustomPlayerView extends PlayerView implements GestureDetector.OnGe
 
     public boolean tap() {
         if (PlayerActivity.locked) {
-            Utils.showText(this, "", MESSAGE_TIMEOUT_LONG);
-            setIconLock(true);
+            if (getContext() instanceof PlayerActivity) {
+                ((PlayerActivity) getContext()).showSwipeToUnlock();
+            }
             return true;
         }
 
@@ -292,21 +283,17 @@ public class CustomPlayerView extends PlayerView implements GestureDetector.OnGe
 
     @Override
     public void onLongPress(MotionEvent motionEvent) {
-        if (PlayerActivity.locked || (getPlayer() != null && getPlayer().isPlaying())) {
-            toggleLock();
-        }
     }
 
-    // Toggles the touch lock (also reachable from the lock button in the header). While locked the
-    // controller stays hidden and gestures are ignored; a tap shows the lock icon, tapping which unlocks.
+    // Toggles the touch lock (triggered by the lock button). While locked the controller stays hidden
+    // and gestures are ignored; a tap re-shows the swipe-to-unlock bar, which unlocks when swiped.
     public void toggleLock() {
         PlayerActivity.locked = !PlayerActivity.locked;
         isHandledLongPress = true;
-        Utils.showText(this, "", MESSAGE_TIMEOUT_LONG);
-        setIconLock(PlayerActivity.locked);
         if (PlayerActivity.locked && PlayerActivity.controllerVisible) {
             hideController();
         }
+        // onLockChanged shows/hides the floating lock (at the button's spot) as visual feedback.
         if (getContext() instanceof PlayerActivity) {
             ((PlayerActivity) getContext()).onLockChanged();
         }
@@ -409,10 +396,6 @@ public class CustomPlayerView extends PlayerView implements GestureDetector.OnGe
 
     public void setIconBrightnessAuto() {
         exoErrorMessage.setCompoundDrawablesWithIntrinsicBounds(R.drawable.ic_brightness_auto_24dp, 0, 0, 0);
-    }
-
-    public void setIconLock(boolean locked) {
-        exoErrorMessage.setCompoundDrawablesWithIntrinsicBounds(locked ? R.drawable.ic_lock_24dp : R.drawable.ic_lock_open_24dp, 0, 0, 0);
     }
 
     public void setScale(final float scale) {

--- a/app/src/main/java/com/brouken/player/PlayerActivity.java
+++ b/app/src/main/java/com/brouken/player/PlayerActivity.java
@@ -87,6 +87,7 @@ import androidx.media3.common.C;
 import androidx.media3.common.ColorInfo;
 import androidx.media3.common.Format;
 import androidx.media3.common.MediaItem;
+import androidx.media3.common.VideoSize;
 import androidx.media3.common.MediaMetadata;
 import androidx.media3.common.MimeTypes;
 import androidx.media3.common.PlaybackException;
@@ -275,6 +276,9 @@ public class PlayerActivity extends Activity {
     private UiMetrics ui;
     private ImageButton buttonPiP;
     private ImageButton buttonAspectRatio;
+    // Forced display aspect ratio currently applied (0 = natural video AR). Persisted via Prefs.aspectRatio.
+    private float currentAspectRatio = 0f;
+    private List<AspectMode> aspectModes;
     private ImageButton buttonRotation;
     private ImageButton buttonLock;
     // Swipe-to-unlock bar shown over the video while the screen is locked; the only affordance for leaving
@@ -739,22 +743,18 @@ public class PlayerActivity extends Activity {
         buttonAspectRatio.setContentDescription(getString(R.string.button_crop));
         updatebuttonAspectRatioIcon();
         buttonAspectRatio.setOnClickListener(view -> {
-            playerView.setScale(1.f);
-            if (playerView.getResizeMode() == AspectRatioFrameLayout.RESIZE_MODE_FIT) {
-                playerView.setResizeMode(AspectRatioFrameLayout.RESIZE_MODE_ZOOM);
-                Utils.showText(playerView, getString(R.string.video_resize_crop));
-            } else {
-                // Default mode
-                playerView.setResizeMode(AspectRatioFrameLayout.RESIZE_MODE_FIT);
-                Utils.showText(playerView, getString(R.string.video_resize_fit));
-            }
-            updatebuttonAspectRatioIcon();
+            cycleAspectMode();
             resetHideCallbacks();
         });
         if (isTvBox && Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
             buttonAspectRatio.setOnLongClickListener(v -> {
                 scaleStart();
                 updatebuttonAspectRatioIcon();
+                return true;
+            });
+        } else {
+            buttonAspectRatio.setOnLongClickListener(v -> {
+                showAspectModePicker();
                 return true;
             });
         }
@@ -1851,7 +1851,9 @@ public class PlayerActivity extends Activity {
             ContextCompat.registerReceiver(this, mReceiver, new IntentFilter(ACTION_MEDIA_CONTROL), ContextCompat.RECEIVER_EXPORTED);
         } else {
             setSubtitleTextSize();
-            if (mPrefs.resizeMode == AspectRatioFrameLayout.RESIZE_MODE_ZOOM) {
+            if (mPrefs.aspectRatio > 0) {
+                playerView.applyAspectMode(mPrefs.resizeMode, mPrefs.aspectRatio);
+            } else if (mPrefs.resizeMode == AspectRatioFrameLayout.RESIZE_MODE_ZOOM) {
                 playerView.setScale(mPrefs.scale);
             }
             if (mReceiver != null) {
@@ -4488,8 +4490,10 @@ public class PlayerActivity extends Activity {
             }
 
             playerView.setResizeMode(mPrefs.resizeMode);
-
-            if (mPrefs.resizeMode == AspectRatioFrameLayout.RESIZE_MODE_ZOOM) {
+            currentAspectRatio = mPrefs.aspectRatio;
+            if (mPrefs.aspectRatio > 0) {
+                playerView.applyAspectMode(mPrefs.resizeMode, mPrefs.aspectRatio);
+            } else if (mPrefs.resizeMode == AspectRatioFrameLayout.RESIZE_MODE_ZOOM) {
                 playerView.setScale(mPrefs.scale);
             } else {
                 playerView.setScale(1.f);
@@ -4603,6 +4607,7 @@ public class PlayerActivity extends Activity {
                         getSelectedTrack(C.TRACK_TYPE_TEXT),
                         playerView.getResizeMode(),
                         playerView.getVideoSurfaceView().getScaleX(),
+                        currentAspectRatio,
                         player.getPlaybackParameters().speed);
             }
         }
@@ -4824,6 +4829,20 @@ public class PlayerActivity extends Activity {
     }
 
     private class PlayerListener implements Player.Listener {
+        @Override
+        public void onVideoSizeChanged(VideoSize videoSize) {
+            // Media3 resets the content-frame AR to the video's natural AR on every size change (e.g. a
+            // mid-stream video-track switch), silently dropping a forced ratio. Reassert it after that
+            // update (posted, so it wins).
+            // Skip while ZOOM is active: that means free pinch-zoom has taken over, and reasserting would
+            // fight it (adaptive streams fire this on every resolution switch).
+            if (currentAspectRatio > 0 && playerView != null
+                    && playerView.getResizeMode() == AspectRatioFrameLayout.RESIZE_MODE_FIT) {
+                playerView.post(() ->
+                        playerView.applyAspectMode(AspectRatioFrameLayout.RESIZE_MODE_FIT, currentAspectRatio));
+            }
+        }
+
         @Override
         public void onAudioSessionIdChanged(int audioSessionId) {
             try {
@@ -6090,6 +6109,84 @@ public class PlayerActivity extends Activity {
             playerView.setResizeMode(AspectRatioFrameLayout.RESIZE_MODE_FIT);
         }
         updatebuttonAspectRatioIcon();
+    }
+
+    // A scale mode = a Media3 resize mode plus an optional forced display aspect ratio (ratio 0 = natural).
+    // Indices 0..2 (Fit/Crop/Fill) are the tap cycle; the rest (forced ratios) are picker-only, like VLC.
+    private static final class AspectMode {
+        final int resizeMode;
+        final float ratio;
+        final String label;
+        AspectMode(int resizeMode, float ratio, String label) {
+            this.resizeMode = resizeMode;
+            this.ratio = ratio;
+            this.label = label;
+        }
+    }
+
+    private List<AspectMode> getAspectModes() {
+        if (aspectModes == null) {
+            aspectModes = new ArrayList<>();
+            aspectModes.add(new AspectMode(AspectRatioFrameLayout.RESIZE_MODE_FIT, 0f, getString(R.string.video_resize_fit)));
+            aspectModes.add(new AspectMode(AspectRatioFrameLayout.RESIZE_MODE_ZOOM, 0f, getString(R.string.video_resize_crop)));
+            aspectModes.add(new AspectMode(AspectRatioFrameLayout.RESIZE_MODE_FILL, 0f, getString(R.string.video_resize_fill)));
+            aspectModes.add(new AspectMode(AspectRatioFrameLayout.RESIZE_MODE_FIT, 16f / 9f, "16:9"));
+            aspectModes.add(new AspectMode(AspectRatioFrameLayout.RESIZE_MODE_FIT, 4f / 3f, "4:3"));
+            aspectModes.add(new AspectMode(AspectRatioFrameLayout.RESIZE_MODE_FIT, 16f / 10f, "16:10"));
+            aspectModes.add(new AspectMode(AspectRatioFrameLayout.RESIZE_MODE_FIT, 2f / 1f, "2:1"));
+            aspectModes.add(new AspectMode(AspectRatioFrameLayout.RESIZE_MODE_FIT, 2.35f, "2.35:1"));
+            aspectModes.add(new AspectMode(AspectRatioFrameLayout.RESIZE_MODE_FIT, 2.39f, "2.39:1"));
+            aspectModes.add(new AspectMode(AspectRatioFrameLayout.RESIZE_MODE_FIT, 5f / 4f, "5:4"));
+        }
+        return aspectModes;
+    }
+
+    private void applyAspectMode(int index) {
+        final AspectMode mode = getAspectModes().get(index);
+        currentAspectRatio = mode.ratio;
+        playerView.applyAspectMode(mode.resizeMode, mode.ratio);
+        Utils.showText(playerView, mode.label);
+        updatebuttonAspectRatioIcon();
+    }
+
+    // Tap: cycle Fit → Crop → Fill → 16:9 → 4:3. From any other picker-only ratio, a tap returns to Fit.
+    private static final int ASPECT_CYCLE_COUNT = 5;
+
+    private void cycleAspectMode() {
+        final List<AspectMode> modes = getAspectModes();
+        int current = -1;
+        for (int i = 0; i < ASPECT_CYCLE_COUNT; i++) {
+            if (isCurrentAspectMode(modes.get(i))) {
+                current = i;
+                break;
+            }
+        }
+        applyAspectMode((current + 1) % ASPECT_CYCLE_COUNT);
+    }
+
+    private void showAspectModePicker() {
+        final List<AspectMode> modes = getAspectModes();
+        final String[] labels = new String[modes.size()];
+        int checked = -1;
+        for (int i = 0; i < modes.size(); i++) {
+            labels[i] = modes.get(i).label;
+            if (isCurrentAspectMode(modes.get(i)))
+                checked = i;
+        }
+        final AlertDialog dialog = new AlertDialog.Builder(this)
+                .setTitle(R.string.button_crop)
+                .setSingleChoiceItems(labels, checked, (d, which) -> {
+                    applyAspectMode(which);
+                    d.dismiss();
+                })
+                .create();
+        showPickerDialog(dialog);
+    }
+
+    private boolean isCurrentAspectMode(AspectMode mode) {
+        if (mode.ratio > 0)
+            return Math.abs(mode.ratio - currentAspectRatio) < 0.001f;
+        return currentAspectRatio == 0 && playerView.getResizeMode() == mode.resizeMode;
     }
 
     private void updatebuttonAspectRatioIcon() {

--- a/app/src/main/java/com/brouken/player/PlayerActivity.java
+++ b/app/src/main/java/com/brouken/player/PlayerActivity.java
@@ -4955,17 +4955,6 @@ public class PlayerActivity extends Activity {
 
         @Override
         public void onEvents(Player player, Player.Events events) {
-            // Media3 re-enables/brightens the prev/next arrows on navigation events (timeline, position
-            // discontinuity, available commands) — exactly what fires while switching episodes. Re-assert
-            // the disabled look after that update (deferred, so it wins) while the video is loading.
-            if (episodeNavLoading && playerView != null) {
-                playerView.post(() -> {
-                    if (episodeNavLoading) {
-                        applyEpisodeNavEnabled(false);
-                    }
-                });
-            }
-
             // Media3 re-shows the subtitle button (greyed, disabled) on its own control updates while
             // loading. Re-assert our "hidden until subtitle tracks exist" rule afterwards (deferred so it wins),
             // but only on events that can actually touch the controls — not on every frequent event dispatch.
@@ -5921,7 +5910,7 @@ public class PlayerActivity extends Activity {
         setupEpisodeNavButton(exoNext, size, padding, margin);
         if (exoPrev != null) {
             exoPrev.setOnClickListener(v -> {
-                if (!episodeNavLoading && player != null) {
+                if (!episodeNavLoading && player != null && player.hasPreviousMediaItem()) {
                     player.seekToPrevious();
                     resetHideCallbacks();
                 }
@@ -5929,10 +5918,21 @@ public class PlayerActivity extends Activity {
         }
         if (exoNext != null) {
             exoNext.setOnClickListener(v -> {
-                if (!episodeNavLoading && player != null) {
+                if (!episodeNavLoading && player != null && player.hasNextMediaItem()) {
                     player.seekToNext();
                     resetHideCallbacks();
                 }
+            });
+        }
+        // Media3's PlayerControlView re-enables these arrows in updateNavigation()/updateAll() — on player
+        // events AND every time the controller is shown — based on command availability, which keeps "prev"
+        // enabled on the first item and "next" on the last. Enforcing our state via a posted re-assert lands
+        // one frame late (visible enable→disable flicker on load). Correcting it in a pre-draw pass instead
+        // fixes it before the frame is drawn, so Media3's transient enable is never rendered.
+        if (playerView != null) {
+            playerView.getViewTreeObserver().addOnPreDrawListener(() -> {
+                updateEpisodeNavButtons();
+                return true;
             });
         }
     }
@@ -5972,15 +5972,20 @@ public class PlayerActivity extends Activity {
     // styling (enabled state + opacity) as the other control buttons via Utils.setButtonEnabled.
     private void setEpisodeNavLoading(final boolean loading) {
         episodeNavLoading = loading;
-        applyEpisodeNavEnabled(!loading);
+        updateEpisodeNavButtons();
     }
 
-    private void applyEpisodeNavEnabled(final boolean enabled) {
-        if (exoPrev != null) {
-            Utils.setButtonEnabled(this, exoPrev, enabled);
+    // Enable each episode arrow only when that direction exists in the playlist: "prev" is disabled on the
+    // first item, "next" on the last. Both are additionally disabled while a switch is loading. Idempotent
+    // (only writes on an actual change) so the per-draw enforcer below can call it every frame cheaply.
+    private void updateEpisodeNavButtons() {
+        final boolean canPrev = !episodeNavLoading && player != null && player.hasPreviousMediaItem();
+        final boolean canNext = !episodeNavLoading && player != null && player.hasNextMediaItem();
+        if (exoPrev != null && exoPrev.isEnabled() != canPrev) {
+            Utils.setButtonEnabled(this, exoPrev, canPrev);
         }
-        if (exoNext != null) {
-            Utils.setButtonEnabled(this, exoNext, enabled);
+        if (exoNext != null && exoNext.isEnabled() != canNext) {
+            Utils.setButtonEnabled(this, exoNext, canNext);
         }
     }
 

--- a/app/src/main/java/com/brouken/player/PlayerActivity.java
+++ b/app/src/main/java/com/brouken/player/PlayerActivity.java
@@ -892,7 +892,9 @@ public class PlayerActivity extends Activity {
         headerClock = new OutlineTextClock(this);
         headerClock.setFormat12Hour("h:mm a");
         headerClock.setFormat24Hour("HH:mm");
-        headerClock.setTextColor(Color.WHITE);
+        // Dimmed white (matches the "until …" text); pure white read as too harsh. The black outline and
+        // bold weight keep it legible and as the anchor without the glare.
+        headerClock.setTextColor(0xB3FFFFFF);
         headerClock.setTypeface(Typeface.DEFAULT_BOLD);
         headerClock.setTextSize(TypedValue.COMPLEX_UNIT_SP, ui.textClock());
         final LinearLayout.LayoutParams headerClockLp = new LinearLayout.LayoutParams(
@@ -1087,7 +1089,8 @@ public class PlayerActivity extends Activity {
         overlayClock = new OutlineTextClock(this);
         overlayClock.setFormat12Hour("h:mm a");
         overlayClock.setFormat24Hour("HH:mm");
-        overlayClock.setTextColor(Color.WHITE);
+        // Same dimmed white as the header clock — the black outline keeps it readable over bright frames.
+        overlayClock.setTextColor(0xB3FFFFFF);
         overlayClock.setTypeface(Typeface.DEFAULT_BOLD);
         // Must match the header clock size (see below) so the two line up exactly when controls toggle.
         overlayClock.setTextSize(TypedValue.COMPLEX_UNIT_SP, ui.textClock());

--- a/app/src/main/java/com/brouken/player/PlayerActivity.java
+++ b/app/src/main/java/com/brouken/player/PlayerActivity.java
@@ -272,6 +272,13 @@ public class PlayerActivity extends Activity {
     // While a picker panel is open the app must stay out of immersive/fullscreen, otherwise OxygenOS/ColorOS
     // applies its fullscreen back-gesture guard ("swipe again to go back") and the panel needs two swipes.
     private boolean pickerDialogOpen;
+    // Media3 keeps the controller shown indefinitely while paused (it forces the auto-hide timeout to 0),
+    // so reuse the same CONTROLLER_TIMEOUT + hideController() to also clear the UI on pause. A tap re-shows
+    // and re-arms it, exactly like during playback (see scheduleHideControllerOnPause).
+    private final Runnable hideControllerAction = () -> {
+        if (player != null && !player.getPlayWhenReady() && controllerVisibleFully)
+            playerView.hideController();
+    };
     // Adaptive sizing source of truth (phone/tablet/TV). Computed in onCreate, recomputed on config change.
     private UiMetrics ui;
     private ImageButton buttonPiP;
@@ -1362,6 +1369,7 @@ public class PlayerActivity extends Activity {
                     stopEndsAtUpdates();
                 }
                 updateOverlayClock();
+                scheduleHideControllerOnPause();
 
                 if (PlayerActivity.restoreControllerTimeout) {
                     restoreControllerTimeout = false;
@@ -4996,6 +5004,10 @@ public class PlayerActivity extends Activity {
             } else {
                 stopSkipPolling();
             }
+
+            // Pausing while the controller is already visible doesn't change its visibility, so arm the
+            // pause auto-hide here too; resuming cancels it (guarded inside scheduleHideControllerOnPause).
+            scheduleHideControllerOnPause();
         }
 
         @SuppressLint("SourceLockedOrientationActivity")
@@ -6187,6 +6199,19 @@ public class PlayerActivity extends Activity {
         if (mode.ratio > 0)
             return Math.abs(mode.ratio - currentAspectRatio) < 0.001f;
         return currentAspectRatio == 0 && playerView.getResizeMode() == mode.resizeMode;
+    }
+
+    // Arms the pause auto-hide when the controller is fully visible and playback is paused (ready, not
+    // scrubbing/locked/in a picker). Called from the visibility listener and on play/pause transitions.
+    private void scheduleHideControllerOnPause() {
+        if (playerView == null)
+            return;
+        playerView.removeCallbacks(hideControllerAction);
+        if (controllerVisibleFully && haveMedia && player != null
+                && player.getPlaybackState() == Player.STATE_READY && !player.getPlayWhenReady()
+                && !locked && !pickerDialogOpen && !isScrubbing) {
+            playerView.postDelayed(hideControllerAction, CONTROLLER_TIMEOUT);
+        }
     }
 
     private void updatebuttonAspectRatioIcon() {

--- a/app/src/main/java/com/brouken/player/PlayerActivity.java
+++ b/app/src/main/java/com/brouken/player/PlayerActivity.java
@@ -277,6 +277,11 @@ public class PlayerActivity extends Activity {
     private ImageButton buttonAspectRatio;
     private ImageButton buttonRotation;
     private ImageButton buttonLock;
+    // Swipe-to-unlock bar shown over the video while the screen is locked; the only affordance for leaving
+    // the locked state (drag on touch, hold a D-pad key on TV).
+    private SwipeToUnlockView swipeToUnlock;
+    // Back-button guard while locked: the first Back arms this, a second Back within the window exits.
+    private boolean lockBackPressedOnce;
     private ObjectAnimator emptyStatePulse;
     private ImageButton exoSettings;
     private ImageButton exoSubtitle;
@@ -1052,6 +1057,27 @@ public class PlayerActivity extends Activity {
         // Whenever the in-header clock is (re)laid out, mirror its position onto the floating clock.
         headerClock.addOnLayoutChangeListener((v, l, t, r, b, ol, ot, or, ob) -> syncOverlayClockPosition());
 
+        // Swipe-to-unlock bar, shown while the screen is locked: the lock icon is dragged to the right edge
+        // to unlock. The only way out of the locked state, and touch only (the lock feature is not offered on
+        // TV). Centered near the bottom.
+        if (!isTvBox) {
+            swipeToUnlock = new SwipeToUnlockView(this);
+            swipeToUnlock.setVisibility(View.GONE);
+            final CoordinatorLayout.LayoutParams swipeLp = new CoordinatorLayout.LayoutParams(
+                    Utils.dpToPx(260), Utils.dpToPx(48));
+            swipeLp.gravity = Gravity.BOTTOM | Gravity.CENTER_HORIZONTAL;
+            swipeLp.bottomMargin = Utils.dpToPx(48);
+            swipeToUnlock.setLayoutParams(swipeLp);
+            swipeToUnlock.setOnUnlockListener(() -> playerView.toggleLock());
+            swipeToUnlock.setOnStartTouchingListener(() -> {
+                if (playerView != null) {
+                    playerView.removeCallbacks(swipeHider);
+                }
+            });
+            swipeToUnlock.setOnStopTouchingListener(this::rescheduleSwipeHide);
+            coordinatorLayout.addView(swipeToUnlock);
+        }
+
         topInfoPanel.setOnLongClickListener(view -> {
             // Prevent FileUriExposedException
             if (mPrefs.mediaUri != null && ContentResolver.SCHEME_FILE.equals(mPrefs.mediaUri.getScheme())) {
@@ -1291,7 +1317,8 @@ public class PlayerActivity extends Activity {
         exoBasicControls.addView(horizontalScrollView, horizontalScrollViewLp);
 
         // Lock sits isolated at the far-left of the bottom bar — prepended into the time row, away from the
-        // display cluster (MX-style) so it is no longer adjacent to the rotation button. Touch only.
+        // display cluster (MX-style) so it is no longer adjacent to the rotation button. Touch only (the lock
+        // feature is not offered on TV).
         if (!isTvBox) {
             final View exoTime = findViewById(R.id.exo_time);
             if (exoTime instanceof LinearLayout) {
@@ -1307,6 +1334,13 @@ public class PlayerActivity extends Activity {
                 lockLp.setMarginEnd(ui.lockMarginEnd());
                 buttonLock.setLayoutParams(lockLp);
                 ((LinearLayout) exoTime).addView(buttonLock, 0);
+
+                // exo_basic_controls (the right-hand cluster, holding a full-width HorizontalScrollView) is
+                // laid out after exo_time, so it sits on top of it and its empty left area swallows taps on
+                // the lock (a scroll view consumes touches for its own drag detection). Bring exo_time to the
+                // front so the lock wins its taps. The cluster's buttons sit to the right, clear of exo_time
+                // (which is ~494px wide and non-clickable outside the lock), so they and scrolling still work.
+                exoTime.bringToFront();
             }
         }
 
@@ -1476,6 +1510,17 @@ public class PlayerActivity extends Activity {
     @SuppressLint("GestureBackNavigation")
     @Override
     public void onBackPressed() {
+        // While locked, swallow the first Back (re-showing the unlock bar with a hint) and only exit if Back
+        // is pressed again within the window — so a stray Back can't drop out of a locked video.
+        if (locked && !lockBackPressedOnce) {
+            lockBackPressedOnce = true;
+            showSwipeToUnlock();
+            Utils.showText(playerView, getString(R.string.press_back_again), 2000);
+            if (playerView != null) {
+                playerView.postDelayed(() -> lockBackPressedOnce = false, 2000);
+            }
+            return;
+        }
         restorePlayStateAllowed = false;
         super.onBackPressed();
     }
@@ -1675,6 +1720,17 @@ public class PlayerActivity extends Activity {
 
     @Override
     public boolean dispatchKeyEvent(KeyEvent event) {
+        // While locked, swallow every key at the earliest point — before the view hierarchy,
+        // onKeyDown, and the window's default (MediaSession-backed) volume handling — so hardware
+        // volume/media/seek keys can't act. BACK is excluded so the normal lock-aware exit path
+        // still works. Re-show the unlock hint on the first press, mirroring the touch tap().
+        if (locked && event.getKeyCode() != KeyEvent.KEYCODE_BACK) {
+            if (event.getAction() == KeyEvent.ACTION_DOWN && event.getRepeatCount() == 0) {
+                showSwipeToUnlock();
+            }
+            return true;
+        }
+
         if (isScaling) {
             final int keyCode = event.getKeyCode();
             if (event.getAction() == KeyEvent.ACTION_DOWN) {
@@ -1739,6 +1795,9 @@ public class PlayerActivity extends Activity {
 
     @Override
     public boolean onGenericMotionEvent(MotionEvent event) {
+        if (locked) {
+            return true;
+        }
         if (0 != (event.getSource() & InputDevice.SOURCE_CLASS_POINTER)) {
             switch (event.getAction()) {
                 case MotionEvent.ACTION_SCROLL:
@@ -2376,12 +2435,41 @@ public class PlayerActivity extends Activity {
     // showSkipButton/showSkipNotification keep them suppressed until unlock, after which the next
     // skip poll restores the button if a segment is still active.
     void onLockChanged() {
-        if (buttonLock != null) {
-            buttonLock.setSelected(locked);
+        if (locked) {
+            lockScreen();
+        } else {
+            unlockScreen();
         }
         if (locked && mPrefs != null && mPrefs.skipHideWhenLocked) {
             hideSkipButton();
             hideSkipNotification();
+        }
+    }
+
+    // Entering the lock: pin the current orientation (restored on unlock), arm the swipe bar and reset the
+    // Back guard. The controller is already hidden by CustomPlayerView.toggleLock().
+    private void lockScreen() {
+        setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_LOCKED);
+        lockBackPressedOnce = false;
+        showSwipeToUnlock();
+    }
+
+    // Leaving the lock: hide the bar and restore the user's orientation preference.
+    private void unlockScreen() {
+        hideSwipeToUnlock();
+        lockBackPressedOnce = false;
+        if (mPrefs != null) {
+            Utils.setOrientation(this, mPrefs.orientation);
+        }
+    }
+
+    // Some paths flip `locked` directly (new media, playback stopped) without going through onLockChanged;
+    // the lock does not persist, so undo its UI (bar + orientation pin) here too.
+    private void clearLockUi() {
+        hideSwipeToUnlock();
+        lockBackPressedOnce = false;
+        if (mPrefs != null) {
+            Utils.setOrientation(this, mPrefs.orientation);
         }
     }
 
@@ -2941,6 +3029,35 @@ public class PlayerActivity extends Activity {
             lp.topMargin = top;
             overlayClock.setLayoutParams(lp);
         }
+    }
+
+    private final Runnable swipeHider = this::hideSwipeToUnlock;
+
+    // Reveal the swipe-to-unlock bar and auto-hide it after the standard long-touch timeout. While the user
+    // is actively dragging (onStartTouching) the auto-hide is cancelled and rescheduled on release.
+    void showSwipeToUnlock() {
+        if (swipeToUnlock == null) {
+            return;
+        }
+        swipeToUnlock.setVisibility(View.VISIBLE);
+        rescheduleSwipeHide();
+    }
+
+    private void rescheduleSwipeHide() {
+        if (playerView != null) {
+            playerView.removeCallbacks(swipeHider);
+            playerView.postDelayed(swipeHider, CustomPlayerView.MESSAGE_TIMEOUT_LONG);
+        }
+    }
+
+    void hideSwipeToUnlock() {
+        if (swipeToUnlock == null) {
+            return;
+        }
+        if (playerView != null) {
+            playerView.removeCallbacks(swipeHider);
+        }
+        swipeToUnlock.setVisibility(View.GONE);
     }
 
     private void copyLaunchIntentToClipboard() {
@@ -4359,6 +4476,7 @@ public class PlayerActivity extends Activity {
         playerView.setControllerShowTimeoutMs(-1);
 
         locked = false;
+        clearLockUi();
 
         if (haveMedia) {
             hideEmptyState();
@@ -4849,8 +4967,9 @@ public class PlayerActivity extends Activity {
                 }
             }
 
-            if (!isPlaying) {
+            if (!isPlaying && PlayerActivity.locked) {
                 PlayerActivity.locked = false;
+                clearLockUi();
             }
 
             if (isPlaying) {

--- a/app/src/main/java/com/brouken/player/PlayerActivity.java
+++ b/app/src/main/java/com/brouken/player/PlayerActivity.java
@@ -1063,7 +1063,7 @@ public class PlayerActivity extends Activity {
             skipDoneIcon.setBounds(0, 0, skipDoneIconSize, skipDoneIconSize);
             notificationSkip.setCompoundDrawablesRelative(skipDoneIcon, null, null, null);
             notificationSkip.setCompoundDrawablePadding(Utils.dpToPx(6));
-            notificationSkip.setCompoundDrawableTintList(ColorStateList.valueOf(Color.WHITE));
+            notificationSkip.setCompoundDrawableTintList(ColorStateList.valueOf(brandColor()));
         }
 
         final GradientDrawable notificationBackground = new GradientDrawable();
@@ -1968,7 +1968,10 @@ public class PlayerActivity extends Activity {
             skipManager = new SkipManager();
         }
         skipBuilt = false;
-        hideSkipNotification();
+        // Do not hide the auto-skip notification here: when a skip lands at the very end of an item, the
+        // next item auto-advances through onMediaItemTransition -> setupSkipSource almost immediately, and
+        // hiding here would cut the notification short. Its own 3s timer governs it, so it rides across the
+        // transition ("carry-through") and disappears on schedule.
         final String json = currentSegmentsJson();
         skipManager.setSource(json != null && !json.isEmpty() ? new IntentSegmentsSource(json) : null);
         // Source (re)set → the manager holds no segments until rebuildSkip() runs against the new
@@ -2555,7 +2558,7 @@ public class PlayerActivity extends Activity {
         }
         notificationSkip.setVisibility(View.VISIBLE);
         playerView.removeCallbacks(skipNotificationHider);
-        playerView.postDelayed(skipNotificationHider, 5000);
+        playerView.postDelayed(skipNotificationHider, 3000);
     }
 
     private void hideSkipNotification() {

--- a/app/src/main/java/com/brouken/player/PlayerActivity.java
+++ b/app/src/main/java/com/brouken/player/PlayerActivity.java
@@ -434,6 +434,8 @@ public class PlayerActivity extends Activity {
     Button buttonSkip;
     ClipDrawable skipButtonProgress;
     TextView notificationSkip;
+    // Top-center pill shown while hold-to-speed (2x) is active. Non-clickable so it never intercepts the hold.
+    TextView speedBoostIndicator;
     final Runnable skipNotificationHider = new Runnable() {
         @Override
         public void run() {
@@ -1007,6 +1009,41 @@ public class PlayerActivity extends Activity {
         buttonSkip.setLayoutParams(skipButtonParams);
         buttonSkip.setVisibility(View.GONE);
         coordinatorLayout.addView(buttonSkip);
+
+        // Hold-to-speed (2x) indicator: the same rounded dark pill as the auto-skip notification
+        // (fast-forward icon + label), floating top-centre. Non-clickable so it never intercepts the hold.
+        speedBoostIndicator = new TextView(this);
+        speedBoostIndicator.setText("2×");
+        speedBoostIndicator.setAllCaps(false);
+        speedBoostIndicator.setTextColor(Color.WHITE);
+        speedBoostIndicator.setTextSize(TypedValue.COMPLEX_UNIT_SP, ui.textSkip());
+        speedBoostIndicator.setTypeface(Typeface.DEFAULT_BOLD);
+        speedBoostIndicator.setGravity(Gravity.CENTER_VERTICAL);
+        speedBoostIndicator.setPadding(Utils.dpToPx(14), Utils.dpToPx(9), Utils.dpToPx(16), Utils.dpToPx(9));
+        speedBoostIndicator.setClickable(false);
+        speedBoostIndicator.setFocusable(false);
+
+        final Drawable speedBoostIcon = ContextCompat.getDrawable(this, R.drawable.exo_icon_fastforward);
+        if (speedBoostIcon != null) {
+            final int speedBoostIconSize = Utils.dpToPx(18);
+            speedBoostIcon.setBounds(0, 0, speedBoostIconSize, speedBoostIconSize);
+            speedBoostIndicator.setCompoundDrawablesRelative(speedBoostIcon, null, null, null);
+            speedBoostIndicator.setCompoundDrawablePadding(Utils.dpToPx(6));
+            speedBoostIndicator.setCompoundDrawableTintList(ColorStateList.valueOf(brandColor()));
+        }
+
+        final GradientDrawable speedBoostBackground = new GradientDrawable();
+        speedBoostBackground.setColor(Color.argb(0xF0, 0x16, 0x16, 0x16));
+        speedBoostBackground.setCornerRadius(skipCornerRadius);
+        speedBoostIndicator.setBackground(speedBoostBackground);
+
+        final CoordinatorLayout.LayoutParams speedBoostParams = new CoordinatorLayout.LayoutParams(
+                ViewGroup.LayoutParams.WRAP_CONTENT, ViewGroup.LayoutParams.WRAP_CONTENT);
+        speedBoostParams.gravity = Gravity.TOP | Gravity.CENTER_HORIZONTAL;
+        speedBoostParams.setMargins(0, Utils.dpToPx(28), 0, 0);
+        speedBoostIndicator.setLayoutParams(speedBoostParams);
+        speedBoostIndicator.setVisibility(View.GONE);
+        coordinatorLayout.addView(speedBoostIndicator);
 
         // Toast-style notification shown after an automatic skip: the same solid dark pill as the Skip
         // button (bell icon + label, no progress underline), floating top-centre. Auto-hides after 5s or
@@ -6199,6 +6236,11 @@ public class PlayerActivity extends Activity {
         if (mode.ratio > 0)
             return Math.abs(mode.ratio - currentAspectRatio) < 0.001f;
         return currentAspectRatio == 0 && playerView.getResizeMode() == mode.resizeMode;
+    }
+
+    public void setSpeedBoostIndicatorVisible(boolean visible) {
+        if (speedBoostIndicator != null)
+            speedBoostIndicator.setVisibility(visible ? View.VISIBLE : View.GONE);
     }
 
     // Arms the pause auto-hide when the controller is fully visible and playback is paused (ready, not

--- a/app/src/main/java/com/brouken/player/Prefs.java
+++ b/app/src/main/java/com/brouken/player/Prefs.java
@@ -33,6 +33,7 @@ class Prefs {
     private static final String PREF_KEY_RESIZE_MODE = "resizeMode";
     private static final String PREF_KEY_ORIENTATION = "orientation";
     private static final String PREF_KEY_SCALE = "scale";
+    private static final String PREF_KEY_ASPECT_RATIO = "aspectRatio";
     private static final String PREF_KEY_SCOPE_URI = "scopeUri";
     private static final String PREF_KEY_ASK_SCOPE = "askScope";
     private static final String PREF_KEY_AUTO_PIP = "autoPiP";
@@ -75,6 +76,7 @@ class Prefs {
     public int resizeMode = AspectRatioFrameLayout.RESIZE_MODE_FIT;
     public Utils.Orientation orientation = Utils.Orientation.UNSPECIFIED;
     public float scale = 1.f;
+    public float aspectRatio = 0f; // 0 = natural video AR; >0 = forced display AR (16:9, 4:3, …)
     public float speed = 1.f;
 
     public String subtitleTrackId;
@@ -136,6 +138,7 @@ class Prefs {
             resizeMode = mSharedPreferences.getInt(PREF_KEY_RESIZE_MODE, resizeMode);
         orientation = Utils.Orientation.values()[mSharedPreferences.getInt(PREF_KEY_ORIENTATION, orientation.value)];
         scale = mSharedPreferences.getFloat(PREF_KEY_SCALE, scale);
+        aspectRatio = mSharedPreferences.getFloat(PREF_KEY_ASPECT_RATIO, aspectRatio);
         if (mSharedPreferences.contains(PREF_KEY_SCOPE_URI))
             scopeUri = Uri.parse(mSharedPreferences.getString(PREF_KEY_SCOPE_URI, null));
         askScope = mSharedPreferences.getBoolean(PREF_KEY_ASK_SCOPE, askScope);
@@ -172,7 +175,7 @@ class Prefs {
         mediaUri = uri;
         mediaType = type;
         updateSubtitle(null);
-        updateMeta(null, null, AspectRatioFrameLayout.RESIZE_MODE_FIT, 1.f, 1.f);
+        updateMeta(null, null, AspectRatioFrameLayout.RESIZE_MODE_FIT, 1.f, 0f, 1.f);
 
         if (mediaType != null && mediaType.endsWith("/*")) {
             mediaType = null;
@@ -326,11 +329,12 @@ class Prefs {
         sharedPreferencesEditor.apply();
     }
 
-    public void updateMeta(final String audioTrackId, final String subtitleTrackId, final int resizeMode, final float scale, final float speed) {
+    public void updateMeta(final String audioTrackId, final String subtitleTrackId, final int resizeMode, final float scale, final float aspectRatio, final float speed) {
         this.audioTrackId = audioTrackId;
         this.subtitleTrackId = subtitleTrackId;
         this.resizeMode = resizeMode;
         this.scale = scale;
+        this.aspectRatio = aspectRatio;
         this.speed = speed;
         if (persistentMode) {
             final SharedPreferences.Editor sharedPreferencesEditor = mSharedPreferences.edit();
@@ -344,6 +348,7 @@ class Prefs {
                 sharedPreferencesEditor.putString(PREF_KEY_SUBTITLE_TRACK_ID, subtitleTrackId);
             sharedPreferencesEditor.putInt(PREF_KEY_RESIZE_MODE, resizeMode);
             sharedPreferencesEditor.putFloat(PREF_KEY_SCALE, scale);
+            sharedPreferencesEditor.putFloat(PREF_KEY_ASPECT_RATIO, aspectRatio);
             sharedPreferencesEditor.putFloat(PREF_KEY_SPEED, speed);
             sharedPreferencesEditor.apply();
         }

--- a/app/src/main/java/com/brouken/player/SwipeToUnlockView.java
+++ b/app/src/main/java/com/brouken/player/SwipeToUnlockView.java
@@ -1,0 +1,160 @@
+package com.brouken.player;
+
+import android.animation.ValueAnimator;
+import android.content.Context;
+import android.graphics.drawable.GradientDrawable;
+import android.text.TextUtils;
+import android.view.Gravity;
+import android.view.MotionEvent;
+import android.widget.FrameLayout;
+import android.widget.ImageView;
+import android.widget.TextView;
+
+import androidx.core.content.ContextCompat;
+
+// Swipe-to-unlock bar shown while the screen is locked, ported from VLC's SwipeToUnlockView. A lock icon
+// pinned to the left is dragged to the right edge to unlock. Touch only (the lock feature is not offered on
+// TV). It is the only affordance for leaving the locked state.
+public class SwipeToUnlockView extends FrameLayout {
+
+    private static final long ANIMATE_BACK_MS = 250;
+
+    private final ImageView swipeIcon;
+    private final TextView swipeText;
+
+    private boolean unlocking;
+
+    // Callbacks: fired while dragging starts/stops (to hold/release the overlay auto-hide) and on unlock.
+    private Runnable onStartTouching;
+    private Runnable onStopTouching;
+    private Runnable onUnlock;
+
+    public SwipeToUnlockView(Context context) {
+        super(context);
+
+        final GradientDrawable pill = new GradientDrawable();
+        pill.setColor(ContextCompat.getColor(context, R.color.ui_controls_background));
+        pill.setCornerRadius(Utils.dpToPx(24));
+        setBackground(pill);
+        setClipToOutline(true);
+        final int padH = Utils.dpToPx(10);
+        final int padV = Utils.dpToPx(8);
+        setPadding(padH, padV, padH, padV);
+
+        final int iconSize = Utils.dpToPx(28);
+
+        // Single line, centered, and inset on both sides so it clears the resting icon and never wraps.
+        swipeText = new TextView(context);
+        swipeText.setTextColor(0xFFFFFFFF);
+        swipeText.setTextSize(13);
+        swipeText.setSingleLine(true);
+        swipeText.setMaxLines(1);
+        swipeText.setEllipsize(TextUtils.TruncateAt.END);
+        swipeText.setGravity(Gravity.CENTER);
+        swipeText.setText(R.string.swipe_unlock);
+        final int textInset = iconSize + Utils.dpToPx(6);
+        final LayoutParams textLp = new LayoutParams(
+                LayoutParams.MATCH_PARENT, LayoutParams.WRAP_CONTENT);
+        textLp.gravity = Gravity.CENTER;
+        textLp.leftMargin = textInset;
+        textLp.rightMargin = textInset;
+        addView(swipeText, textLp);
+
+        swipeIcon = new ImageView(context);
+        swipeIcon.setImageResource(R.drawable.ic_lock_24dp);
+        swipeIcon.setImageTintList(ContextCompat.getColorStateList(context, R.color.control_icon_tint));
+        final LayoutParams iconLp = new LayoutParams(iconSize, iconSize);
+        iconLp.gravity = Gravity.START | Gravity.CENTER_VERTICAL;
+        addView(swipeIcon, iconLp);
+    }
+
+    public void setOnStartTouchingListener(Runnable r) {
+        onStartTouching = r;
+    }
+
+    public void setOnStopTouchingListener(Runnable r) {
+        onStopTouching = r;
+    }
+
+    public void setOnUnlockListener(Runnable r) {
+        onUnlock = r;
+    }
+
+    // Distance the icon can travel from its left resting spot to the right inner edge.
+    private float getMaxTranslation() {
+        final float span = getWidth() - getPaddingLeft() - getPaddingRight() - swipeIcon.getWidth();
+        return span > 0 ? span : 0;
+    }
+
+    private void playStep(float tx) {
+        final float max = getMaxTranslation();
+        swipeIcon.setTranslationX(tx);
+        swipeText.setAlpha(max > 0 ? 1f - tx / max : 1f);
+    }
+
+    @Override
+    public boolean onTouchEvent(MotionEvent event) {
+        if (unlocking) {
+            return false;
+        }
+        final float max = getMaxTranslation();
+        switch (event.getActionMasked()) {
+            case MotionEvent.ACTION_DOWN:
+                if (onStartTouching != null) {
+                    onStartTouching.run();
+                }
+                return true;
+            case MotionEvent.ACTION_MOVE: {
+                float tx = event.getX() - getPaddingLeft() - swipeIcon.getWidth() / 2f;
+                if (tx < 0) {
+                    tx = 0;
+                } else if (tx > max) {
+                    tx = max;
+                }
+                if (max > 0 && tx >= max - Utils.dpToPx(2)) {
+                    unlock();
+                } else {
+                    playStep(tx);
+                }
+                return true;
+            }
+            case MotionEvent.ACTION_UP:
+            case MotionEvent.ACTION_CANCEL:
+                animateBack();
+                if (onStopTouching != null) {
+                    onStopTouching.run();
+                }
+                return true;
+        }
+        return super.onTouchEvent(event);
+    }
+
+    private void animateBack() {
+        final float from = swipeIcon.getTranslationX();
+        if (from <= 0) {
+            playStep(0);
+            return;
+        }
+        final ValueAnimator animator = ValueAnimator.ofFloat(from, 0);
+        animator.setDuration(ANIMATE_BACK_MS);
+        animator.addUpdateListener(a -> playStep((float) a.getAnimatedValue()));
+        animator.start();
+    }
+
+    private void unlock() {
+        unlocking = true;
+        if (onUnlock != null) {
+            onUnlock.run();
+        }
+        setVisibility(GONE);
+    }
+
+    @Override
+    public void setVisibility(int visibility) {
+        super.setVisibility(visibility);
+        if (visibility == VISIBLE) {
+            unlocking = false;
+            playStep(0);
+        }
+    }
+}

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -69,6 +69,8 @@
     <string name="button_rotate">Повернуть</string>
     <string name="button_pip">Картинка в картинке</string>
     <string name="button_lock">Блокировка</string>
+    <string name="swipe_unlock">Проведите</string>
+    <string name="press_back_again">Нажмите «Назад» ещё раз для выхода</string>
     <string name="button_quality">Качество видео</string>
     <string name="button_audio_track">Аудио</string>
     <string name="button_more">Ещё</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -13,6 +13,7 @@
     <string name="video_orientation_video">Ориентация видео</string>
     <string name="video_resize_crop">Обрезать</string>
     <string name="video_resize_fit">Подогнать</string>
+    <string name="video_resize_fill">Заполнить</string>
     <string name="delete_confirmation">Удалить</string>
     <string name="delete_query">Удалить этот файл\?</string>
     <string name="request_scope">Чтобы автоматически загружать внешние субтитры или переходить к следующему файлу в каталоге, предоставьте %s доступ к самой верхней папке, содержащей ваши видео (например, Movies).</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -2,6 +2,7 @@
 <resources>
     <string name="video_resize_fit">Підігнати</string>
     <string name="video_resize_crop">Обрізати</string>
+    <string name="video_resize_fill">Заповнити</string>
     <string name="video_orientation_video">Орієнтація відео</string>
     <string name="video_orientation_sensor">Автоповорот</string>
     <string name="video_orientation_system">Орієнтація пристрою</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -73,6 +73,8 @@
     <string name="button_rotate">Повернути</string>
     <string name="button_pip">Картинка в картинці</string>
     <string name="button_lock">Блокування</string>
+    <string name="swipe_unlock">Проведіть</string>
+    <string name="press_back_again">Натисніть «Назад» ще раз для виходу</string>
     <string name="button_quality">Якість відео</string>
     <string name="button_audio_track">Аудіо</string>
     <string name="button_more">Ще</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -90,6 +90,8 @@
     <string name="button_rotate">Rotate</string>
     <string name="button_pip">Picture-in-picture</string>
     <string name="button_lock">Lock</string>
+    <string name="swipe_unlock">Swipe</string>
+    <string name="press_back_again">Press back again to exit</string>
     <string name="button_quality">Video quality</string>
     <string name="button_audio_track">Audio</string>
     <string name="button_more">More</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -3,6 +3,7 @@
     <string name="app_name" translatable="false">Just+ Player</string>
     <string name="video_resize_fit">Fit</string>
     <string name="video_resize_crop">Crop</string>
+    <string name="video_resize_fill">Fill</string>
     <string name="video_orientation_video">Video orientation</string>
     <string name="video_orientation_sensor">Auto-rotate</string>
     <string name="video_orientation_system">Device orientation</string>


### PR DESCRIPTION
A batch of player UX improvements.

## Changes
- **VLC-style scaling modes** — the aspect button now cycles Fit → Crop → Fill → 16:9 → 4:3; long-press opens a picker with the full set (16:10, 2:1, 2.35:1, 2.39:1, 5:4). Forced ratios use `AspectRatioFrameLayout.setAspectRatio()`, persist, and are reasserted on video-size changes. TV long-press still enters D-pad scaling.
- **Hide controls while paused** — a tap now hides the controller even when paused (Media3 otherwise keeps it shown indefinitely), and a paused controller auto-hides after the same timeout used during playback. Lets the interface be cleared for a clean screenshot on pause.
- **Hold-to-speed 2x** — press and hold anywhere during playback to temporarily play at 2x; releasing restores the previous speed (not persisted). A brand-styled pill, matching the auto-skip notification, is shown for the duration of the hold.
- **Auto-skip notification** — brand-coloured icon to match the hold-to-speed pill, auto-hide shortened to 3s, and it now carries through a media transition instead of being cut short when a skip lands at the end of an item.
- **Dimmed clock** — the top-right clock uses the same 70% white as the adjacent "until …" text; the black outline and bold weight keep it legible without the glare users reported.
- **Episode arrows at boundaries** — "previous" is disabled on the first playlist item and "next" on the last, enforced in a pre-draw pass so Media3's own re-enabling never flickers through.
- **Swipe-to-unlock lock mode** — dedicated lock mode that blocks input while locked.

## Testing
Built (`assembleLatestUniversalDebug`, JDK 17) and manually verified on a phone: scaling cycle + picker, pause hide (tap and timer), hold-to-2x with indicator, auto-skip notification styling/carry-through, clock brightness, and episode-arrow boundary states without flicker.