### PR TITLE
Fall back to the empty state when the remembered video is gone

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -699,9 +699,17 @@
                 android:name="android.app.shortcuts"
                 android:resource="@xml/shortcuts" />
         </activity>
+        <!-- The crash handler starts this with NEW_TASK, and taskAffinity="" then puts that instance in
+             its own task instead of leaving it parked in the player's task, where it stayed after the
+             process died and resurfaced under a freshly launched player (Back landed on a stale error).
+             excludeFromRecents keeps that crash task out of the recents list. A playback error starts
+             this without NEW_TASK, so it still opens in the player's own task, where neither attribute
+             applies. -->
         <activity
             android:name=".ErrorActivity"
+            android:excludeFromRecents="true"
             android:exported="false"
+            android:taskAffinity=""
             android:theme="@style/Theme.Error" />
         <activity
             android:name=".MediaStoreChooserActivity"

--- a/app/src/main/java/com/brouken/player/ErrorActivity.java
+++ b/app/src/main/java/com/brouken/player/ErrorActivity.java
@@ -97,6 +97,11 @@ public class ErrorActivity extends AppCompatActivity {
         final Thread.UncaughtExceptionHandler previous = Thread.getDefaultUncaughtExceptionHandler();
         Thread.setDefaultUncaughtExceptionHandler((thread, throwable) -> {
             try {
+                // This activity's empty taskAffinity puts the crash screen in a task of its own, so the
+                // app's task keeps its history and is restored as the player. CLEAR_TASK then clears that
+                // crash task rather than the app's — needed because a second crash would otherwise reuse
+                // the existing task (same affinity, intents equal apart from extras) and, with no
+                // onNewIntent handling, relaunch the FIRST crash's report.
                 app.startActivity(new Intent(app, ErrorActivity.class)
                         .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TASK)
                         .putExtra(EXTRA_MESSAGE, app.getString(R.string.error_crash_message))

--- a/app/src/main/java/com/brouken/player/PlayerActivity.java
+++ b/app/src/main/java/com/brouken/player/PlayerActivity.java
@@ -138,6 +138,7 @@ import com.bumptech.glide.request.target.Target;
 import com.google.android.material.snackbar.Snackbar;
 
 import java.io.File;
+import java.io.FileNotFoundException;
 import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -3328,6 +3329,7 @@ public class PlayerActivity extends Activity {
                 if (player != null) {
                     player.seekToDefaultPosition(index);
                     player.setPlayWhenReady(true);
+                    prepareIfIdle();
                 }
                 if (playlistDialog != null) {
                     playlistDialog.dismiss();
@@ -4381,6 +4383,10 @@ public class PlayerActivity extends Activity {
         containerTracks.clear();
         resolvedTrackNames.clear();
 
+        // Also drops a deferred error here, not only in releasePlayer: onNewIntent (sharing a video into
+        // the running player) reaches this inline teardown instead, and the stashed error would then
+        // surface over the new clip.
+        errorToShow = null;
         if (player != null) {
             player.removeListener(playerListener);
             player.clearMediaItems();
@@ -4834,6 +4840,10 @@ public class PlayerActivity extends Activity {
 
     public void releasePlayer(boolean save) {
         cancelLoadWatchdog();
+        // An error deferred until the controller is fully visible belongs to the playback session being
+        // torn down here. Kept around, it would surface over whatever plays next — an error screen for a
+        // clip the user already moved on from.
+        errorToShow = null;
         if (save) {
             savePlayer();
         }
@@ -5232,6 +5242,41 @@ public class PlayerActivity extends Activity {
                     }
                 });
                 releasePlayer(false);
+                return;
+            }
+            // The remembered clip can no longer be opened: a foreign app's one-off URI grant has
+            // expired (a video streamed from a messenger, reopened after that app restarted) or the
+            // file is gone. Expected external state, not an app bug — forget the clip so it stops
+            // failing on every launch, fall back to the empty state, and report nothing.
+            // Forgetting also breaks the loop where closing the error screen resumes the activity,
+            // onStart re-prepares the same dead URI and the error screen comes straight back, which
+            // reads as a window that cannot be dismissed. For an API session (persistentMode off)
+            // updateMedia only drops the in-memory URI, so nothing remembered in prefs is lost.
+            final int unavailable = mediaUnavailableMessage(error);
+            if (unavailable != 0) {
+                // A playlist keeps everything: the other episodes are still watchable, and the user may
+                // want to step back to the one they were on (an accidental switch, say). So never tear the
+                // view down and never walk the list on its own — that would march past every episode with
+                // a message each time (a modal dialog each time on TV) and lose the user's place. Stay on
+                // this episode and re-enable the arrows, which are gated while loading and would otherwise
+                // only be cleared by STATE_READY or releasePlayer.
+                if (player != null && player.getMediaItemCount() > 1) {
+                    setEpisodeNavLoading(false);
+                    showSnack(getString(unavailable), null);
+                    return;
+                }
+                releasePlayer(false);
+                // Forget the clip only when nothing entitles us to it any more: a one-off grant from
+                // another app is gone for good, so retrying it on every launch is pointless. A URI we hold
+                // a persisted grant for may just be unreachable right now (cloud provider offline, card
+                // ejected), so keep it and let the next launch try again.
+                if (!holdsPersistedGrant(mPrefs.mediaUri)) {
+                    mPrefs.updateMedia(PlayerActivity.this, null, null);
+                }
+                // Before the snackbar: showEmptyState() brings the opaque overlay to the front, and
+                // the Snackbar is only added to the CoordinatorLayout afterwards, so it stays on top.
+                showEmptyStateWithoutMedia();
+                showSnack(getString(unavailable), null);
                 return;
             }
             // Enrich via the per-capture ScopeCallback overload (not withScope) so the tag/extra land
@@ -5678,6 +5723,38 @@ public class PlayerActivity extends Activity {
         showErrorScreen(errorSummary(error), errorReport(error));
     }
 
+    // Whether a SAF grant we took ourselves still covers this uri, i.e. it is ours to retry later.
+    private boolean holdsPersistedGrant(final Uri uri) {
+        if (uri == null) {
+            return false;
+        }
+        for (final UriPermission permission : getContentResolver().getPersistedUriPermissions()) {
+            if (permission.getUri().equals(uri)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    // The message for a clip that can no longer be opened, or 0 when this is a different failure.
+    // Matching on errorCode is not enough: a revoked grant arrives as ERROR_CODE_IO_UNSPECIFIED
+    // because Loader wraps the SecurityException, so walk the cause chain. Network media is excluded:
+    // HTTP failures are transient and belong on the normal error path.
+    private int mediaUnavailableMessage(PlaybackException error) {
+        if (Utils.isSupportedNetworkUri(currentMediaUri())) {
+            return 0;
+        }
+        for (Throwable t = error; t != null; t = t.getCause()) {
+            if (t instanceof SecurityException) {
+                return R.string.error_media_access_expired;
+            }
+            if (t instanceof FileNotFoundException) {
+                return R.string.error_media_missing;
+            }
+        }
+        return 0;
+    }
+
     // Short, human-facing text for the error screen's panel: the stable ExoPlayer error-code name, the
     // underlying error text, and the network URL that was being played (sanitised). No internal codes.
     private String errorSummary(PlaybackException error) {
@@ -5933,7 +6010,11 @@ public class PlayerActivity extends Activity {
         if (exoPrev != null) {
             exoPrev.setOnClickListener(v -> {
                 if (!episodeNavLoading && player != null && player.hasPreviousMediaItem()) {
-                    player.seekToPrevious();
+                    if (player.getPlaybackState() == Player.STATE_IDLE) {
+                        stepEpisodeWhileIdle(-1);
+                    } else {
+                        player.seekToPrevious();
+                    }
                     resetHideCallbacks();
                 }
             });
@@ -5941,7 +6022,11 @@ public class PlayerActivity extends Activity {
         if (exoNext != null) {
             exoNext.setOnClickListener(v -> {
                 if (!episodeNavLoading && player != null && player.hasNextMediaItem()) {
-                    player.seekToNext();
+                    if (player.getPlaybackState() == Player.STATE_IDLE) {
+                        stepEpisodeWhileIdle(1);
+                    } else {
+                        player.seekToNext();
+                    }
                     resetHideCallbacks();
                 }
             });
@@ -5995,6 +6080,25 @@ public class PlayerActivity extends Activity {
     private void setEpisodeNavLoading(final boolean loading) {
         episodeNavLoading = loading;
         updateEpisodeNavButtons();
+    }
+
+    // Picking an episode after a fatal error has to reload it: the player is left idle with its timeline
+    // intact, so a seek alone would move the index without ever loading anything.
+    private void prepareIfIdle() {
+        if (player != null && player.getPlaybackState() == Player.STATE_IDLE) {
+            player.prepare();
+        }
+    }
+
+    // Stepping episodes out of that idle state: seekToPrevious would restart the failed item once past its
+    // first seconds, and under the repeat-one toggle seekToNext/Previous target the current item as well.
+    // Move by index instead so the arrows really leave a broken episode, then reload.
+    private void stepEpisodeWhileIdle(final int delta) {
+        final int target = player.getCurrentMediaItemIndex() + delta;
+        if (target >= 0 && target < player.getMediaItemCount()) {
+            player.seekToDefaultPosition(target);
+            player.prepare();
+        }
     }
 
     // Enable each episode arrow only when that direction exists in the playlist: "prev" is disabled on the
@@ -6079,10 +6183,7 @@ public class PlayerActivity extends Activity {
             releasePlayer();
             deleteMedia();
             if (nextUri == null) {
-                haveMedia = false;
-                setEndControlsVisible(false);
-                playerView.setControllerShowTimeoutMs(-1);
-                showEmptyState();
+                showEmptyStateWithoutMedia();
             } else {
                 skipToNext();
             }
@@ -6090,6 +6191,14 @@ public class PlayerActivity extends Activity {
         builder.setNegativeButton(android.R.string.cancel, (dialog, which) -> {});
         final AlertDialog dialog = builder.create();
         dialog.show();
+    }
+
+    // Nothing left to play: drop the end controls and hand the screen over to the empty state.
+    private void showEmptyStateWithoutMedia() {
+        haveMedia = false;
+        setEndControlsVisible(false);
+        playerView.setControllerShowTimeoutMs(-1);
+        showEmptyState();
     }
 
     void deleteMedia() {

--- a/app/src/main/java/com/brouken/player/Prefs.java
+++ b/app/src/main/java/com/brouken/player/Prefs.java
@@ -182,7 +182,8 @@ class Prefs {
         }
 
         if (mediaType == null) {
-            if (ContentResolver.SCHEME_CONTENT.equals(mediaUri.getScheme())) {
+            // A null uri clears the remembered media (handled by the persist block below).
+            if (mediaUri != null && ContentResolver.SCHEME_CONTENT.equals(mediaUri.getScheme())) {
                 mediaType = context.getContentResolver().getType(mediaUri);
             }
         }

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -5,6 +5,8 @@
     <string name="error_playback_general">Не удалось воспроизвести это видео.</string>
     <string name="error_playback_timeout">Воспроизведение слишком долго не начинается. Попробуйте ещё раз.</string>
     <string name="error_playback_stalled">Воспроизведение остановилось — это устройство, возможно, не может декодировать этот файл.</string>
+    <string name="error_media_access_expired">Доступ к этому видео истёк. Откройте его снова из того приложения.</string>
+    <string name="error_media_missing">Этого видео больше нет.</string>
     <string name="error_details">Подробности</string>
     <string name="error_screen_title">Что-то пошло не так</string>
     <string name="error_screen_message">Не удалось воспроизвести это видео. С приложением всё в порядке — вернитесь назад и попробуйте снова.</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -15,6 +15,8 @@
     <string name="error_playback_general">Не вдалося відтворити це відео.</string>
     <string name="error_playback_timeout">Відтворення надто довго не починається. Спробуйте ще раз.</string>
     <string name="error_playback_stalled">Відтворення зупинилося — цей пристрій, можливо, не може декодувати цей файл.</string>
+    <string name="error_media_access_expired">Доступ до цього відео закінчився. Відкрийте його знову із застосунку, звідки поділилися.</string>
+    <string name="error_media_missing">Цього відео більше немає.</string>
     <string name="error_screen_title">Щось пішло не так</string>
     <string name="error_screen_message">Не вдалося відтворити це відео. З додатком усе гаразд — поверніться назад і спробуйте ще раз.</string>
     <string name="error_crash_message">У додатку сталася проблема. Відкрийте його знову та спробуйте ще раз.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -16,6 +16,8 @@
     <string name="error_playback_general">Couldn\'t play this video.</string>
     <string name="error_playback_timeout">Playback took too long to start. Please try again.</string>
     <string name="error_playback_stalled">Playback stalled — this device may not be able to decode this file.</string>
+    <string name="error_media_access_expired">Access to this video has expired. Open it again from the app you shared it from.</string>
+    <string name="error_media_missing">This video is no longer available.</string>
     <string name="error_screen_title">Something went wrong</string>
     <string name="error_screen_message">This video couldn\'t be played. The app is fine — go back and try again.</string>
     <string name="error_crash_message">The app ran into a problem. Please reopen it and try again.</string>


### PR DESCRIPTION
A clip opened from another app — a video streamed from a messenger, or one passed in with API extras — is remembered as the last media, but its URI grant is one-off. On the next launch ContentDataSource fails with a SecurityException that Loader wraps into ERROR_CODE_IO_UNSPECIFIED, so the full-screen error report opened and, because the stale URI was never dropped, kept opening on every launch. Closing it resumed the activity, onStart re-prepared the same dead URI and the report came straight back, which reads as a window that cannot be dismissed.

A SecurityException or FileNotFoundException on non-network media is now treated as expected external state: fall back to the branded empty state with a short explanation and report nothing to Sentry. Network failures keep the normal error path. The clip is forgotten only when no persisted grant covers it — a one-off grant from another app is gone for good, while a URI we picked ourselves may be unreachable only for now (a cloud provider offline, an ejected card), so it stays and the next launch tries again. Prefs.updateMedia accepts a null uri for that; the playback position is keyed separately and survives, so re-sharing the same video resumes it.

A playlist keeps everything: the other episodes are still watchable and the user may want to step back to the one they were on, so the player, the playlist and the controls stay, and only the episode arrows are re-enabled. Episode navigation now reloads out of the idle state a fatal error leaves behind, stepping by index because seekToPrevious restarts the current item once past its first seconds and the repeat-one toggle makes seekToNext/Previous target it as well.

Two stale error surfaces are fixed alongside. A deferred error is dropped when the player is released or torn down inline, so it can no longer surface over whatever plays next. And the crash handler's error screen gets its own task, so it stops being parked in the app's task where a freshly launched player stacked on top of it and Back landed on a stale report.