### PR TITLE
Stop treating a surface detach timeout as a playback failure

### DIFF
--- a/app/src/main/java/com/brouken/player/PlayerActivity.java
+++ b/app/src/main/java/com/brouken/player/PlayerActivity.java
@@ -101,6 +101,7 @@ import androidx.media3.datasource.DefaultHttpDataSource;
 import androidx.media3.exoplayer.DefaultRenderersFactory;
 import androidx.media3.exoplayer.ExoPlaybackException;
 import androidx.media3.exoplayer.ExoPlayer;
+import androidx.media3.exoplayer.ExoTimeoutException;
 import androidx.media3.exoplayer.Renderer;
 import androidx.media3.exoplayer.RenderersFactory;
 import androidx.media3.exoplayer.SeekParameters;
@@ -5247,11 +5248,25 @@ public class PlayerActivity extends Activity {
                     && recoverFromContainerError()) {
                 return;
             }
-            // A mid-playback stall: Media3's StuckPlayerDetector reports "no progress" as a
-            // TYPE_UNEXPECTED error with ERROR_CODE_TIMEOUT. Not an app bug — the device decoder wedged
-            // (commonly a Dolby Vision stream its DV decoder can't handle). Try a one-shot recovery that
-            // re-decodes DV as plain HEVC; if not applicable / already tried, show a friendly message.
+            // Media3 reports two unrelated failures as ERROR_CODE_TIMEOUT, and only one of them is a
+            // playback problem.
+            //
+            // An ExoTimeoutException is the player's own lifecycle plumbing giving up. Leaving the
+            // player (Back, or opening the settings screen) makes the window invisible, which destroys
+            // the SurfaceView the player is still attached to; on a slow box the decoder does not hand
+            // the surface back inside Media3's 2 s budget, so this lands here about two seconds after
+            // the user has already moved on — an error window popping up over whatever they went back
+            // to. Nothing failed for them: the position was saved in onPause, and onStart builds a new
+            // player from scratch, so there is nothing to say and nothing to report.
+            //
+            // A StuckPlayerException is the real thing: Media3's StuckPlayerDetector reporting "no
+            // progress" mid-playback because the device decoder wedged (commonly a Dolby Vision stream
+            // its DV decoder can't handle). Try a one-shot recovery that re-decodes DV as plain HEVC;
+            // if not applicable / already tried, show a friendly message.
             if (error.errorCode == PlaybackException.ERROR_CODE_TIMEOUT) {
+                if (error.getCause() instanceof ExoTimeoutException) {
+                    return;
+                }
                 if (recoverFromStuckPlayback()) {
                     return;
                 }


### PR DESCRIPTION
## Problem

Reported on an Android TV box: pressing **Back** during a movie returns to the source app as expected, then 1–2 s later the full-screen error window pops up over it — *"Something went wrong. This video couldn't be played. The app is fine — go back and try again."* Same on exiting the player and on opening the settings screen while a video is playing. Not reproducible on a phone, nor on a different TV box.

## Cause

Media3 reports two unrelated failures as `PlaybackException.ERROR_CODE_TIMEOUT`, and `onPlayerError` treated them as one:

- `StuckPlayerException` — a real mid-playback stall (wedged decoder, commonly Dolby Vision). This is what the branch was written for.
- `ExoTimeoutException` — the player's own lifecycle plumbing giving up.

Leaving the player makes the window invisible, which destroys the `SurfaceView` the player is still attached to. ExoPlayer registers itself as the `SurfaceHolder.Callback`, so `surfaceDestroyed` lands in `setVideoOutputInternal(null)`, which waits for the decoder to hand the surface back — up to Media3's `DEFAULT_DETACH_SURFACE_TIMEOUT_MS` of 2000 ms, hence the 1–2 s delay. On a slow box the decoder misses that budget, the timeout throws, and the error reaches `onPlayerError` after the user has already moved on. `releasePlayer` has not run yet at that point, so the listener is still registered.

`ErrorActivity` is declared `taskAffinity=""`, so it starts in its own task and survives the finishing player instead of dying with it — which is why it appears on top of whatever the user went back to.

The timeout itself is a hardware race and benign. The bug is the classification.

## Fix

Ignore `ExoTimeoutException` in that branch. Nothing has to be repaired: the position was saved in `onPause` before the timeout, `onStop` releases the player moments later, and `onStart` builds a brand-new `ExoPlayer`, so an internally stopped instance never survives.

Kept narrow on purpose — `StuckPlayerException` is a different class in a different package, so real stalls still take the DV→HEVC recovery path and still report. The 30 s load watchdog is separate and untouched.

## Test plan

- `./gradlew assembleLatestUniversalDebug` passes (this also confirms `ExoTimeoutException` is public in the prebuilt `lib-exoplayer-release.aar`).
- On a low-end Android 9 box, play a network MP4 (a 2160p stream is what reproduced it) → press Back → returns to the source app with no error screen after 2 s.
- Play a video → long-press the gear → Settings → back to the player: no error screen, playback resumes at the saved position.
- Regression: a real stall must still surface. Force the branch (a build returning `false` from `recoverFromStuckPlayback`) and confirm the `Stall class: device_decoder` screen and the report still appear.

## Out of scope

The detach timeout leaves the player `IDLE`, so `releasePlayer`'s `player.isPlaying() && restorePlayStateAllowed` check never arms `restorePlayState` — returning from Settings on this box lands paused instead of playing. Pre-existing on that device and cosmetic; fixing it needs play-state tracking that the timeout destroys.
