### PR TITLE
Add a settings entry point to the empty state

### DIFF
--- a/app/src/main/java/com/brouken/player/PlayerActivity.java
+++ b/app/src/main/java/com/brouken/player/PlayerActivity.java
@@ -4756,8 +4756,11 @@ public class PlayerActivity extends Activity {
         final TextView title = findViewById(R.id.empty_state_title);
         final TextView subtitle = findViewById(R.id.empty_state_subtitle);
         final View open = findViewById(R.id.empty_state_open);
+        final View settings = findViewById(R.id.empty_state_settings);
 
         open.setOnClickListener(v -> openFile(mPrefs.mediaUri));
+        settings.setOnClickListener(v ->
+                startActivityForResult(new Intent(this, SettingsActivity.class), REQUEST_SETTINGS));
         stopEmptyStatePulse();
 
         // TV is viewed from across the room; scale the phone-tuned sizes up, matching the
@@ -4773,6 +4776,11 @@ public class PlayerActivity extends Activity {
             final int padV = Utils.dpToPx(18);
             open.setPadding(Utils.dpToPx(30), padV, Utils.dpToPx(32), padV);
             open.setMinimumHeight(Utils.dpToPx(64));
+            setViewSize(findViewById(R.id.empty_state_settings_icon), 28);
+            ((TextView) findViewById(R.id.empty_state_settings_label))
+                    .setTextSize(TypedValue.COMPLEX_UNIT_SP, 20);
+            settings.setPadding(Utils.dpToPx(26), padV, Utils.dpToPx(28), padV);
+            settings.setMinimumHeight(Utils.dpToPx(64));
         } else if (ui.deviceClass != UiMetrics.DeviceClass.PHONE) {
             // Tablet: scale the phone XML defaults by the device-class factor (phone keeps the XML sizes).
             setViewSize(mark, ui.dpS(96));
@@ -4782,12 +4790,15 @@ public class PlayerActivity extends Activity {
             setViewSize(findViewById(R.id.empty_state_open_icon), ui.dpS(20));
             ((TextView) findViewById(R.id.empty_state_open_label))
                     .setTextSize(TypedValue.COMPLEX_UNIT_SP, ui.sp(16));
+            setViewSize(findViewById(R.id.empty_state_settings_icon), ui.dpS(20));
+            ((TextView) findViewById(R.id.empty_state_settings_label))
+                    .setTextSize(TypedValue.COMPLEX_UNIT_SP, ui.sp(15));
         }
 
         overlay.setVisibility(View.VISIBLE);
         overlay.bringToFront();
 
-        final View[] items = {mark, title, subtitle, open};
+        final View[] items = {mark, title, subtitle, open, settings};
 
         if (isReducedMotion()) {
             for (View v : items) {
@@ -4812,6 +4823,8 @@ public class PlayerActivity extends Activity {
         subtitle.setTranslationY(12 * density);
         open.setAlpha(0f);
         open.setTranslationY(16 * density);
+        settings.setAlpha(0f);
+        settings.setTranslationY(16 * density);
 
         mark.animate().alpha(1f).scaleX(1f).scaleY(1f)
                 .setStartDelay(0).setDuration(450).setInterpolator(easeOutExpo).start();
@@ -4825,6 +4838,8 @@ public class PlayerActivity extends Activity {
                     open.requestFocus();
                     startEmptyStatePulse(open);
                 }).start();
+        settings.animate().alpha(1f).translationY(0f)
+                .setStartDelay(320).setDuration(350).setInterpolator(easeOutExpo).start();
     }
 
     private void setViewSize(View view, int dp) {

--- a/app/src/main/res/drawable/bg_ghost_button.xml
+++ b/app/src/main/res/drawable/bg_ghost_button.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ripple xmlns:android="http://schemas.android.com/apk/res/android"
+    android:color="#33FFFFFF">
+
+    <item android:id="@android:id/background">
+        <selector>
+            <item android:state_focused="true">
+                <shape android:shape="rectangle">
+                    <solid android:color="#1AFFFFFF" />
+                    <corners android:radius="100dp" />
+                    <stroke
+                        android:width="3dp"
+                        android:color="@color/white" />
+                </shape>
+            </item>
+            <item>
+                <shape android:shape="rectangle">
+                    <solid android:color="@android:color/transparent" />
+                    <corners android:radius="100dp" />
+                </shape>
+            </item>
+        </selector>
+    </item>
+
+    <item android:id="@android:id/mask">
+        <shape android:shape="rectangle">
+            <solid android:color="@color/white" />
+            <corners android:radius="100dp" />
+        </shape>
+    </item>
+
+</ripple>

--- a/app/src/main/res/layout/activity_player.xml
+++ b/app/src/main/res/layout/activity_player.xml
@@ -99,6 +99,41 @@
 
         </LinearLayout>
 
+        <LinearLayout
+            android:id="@+id/empty_state_settings"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="14dp"
+            android:background="@drawable/bg_ghost_button"
+            android:clickable="true"
+            android:focusable="true"
+            android:gravity="center"
+            android:minHeight="48dp"
+            android:orientation="horizontal"
+            android:paddingStart="18dp"
+            android:paddingTop="10dp"
+            android:paddingEnd="20dp"
+            android:paddingBottom="10dp">
+
+            <ImageView
+                android:id="@+id/empty_state_settings_icon"
+                android:layout_width="20dp"
+                android:layout_height="20dp"
+                android:contentDescription="@null"
+                android:src="@drawable/ic_settings_24dp"
+                android:tint="#B3FFFFFF" />
+
+            <TextView
+                android:id="@+id/empty_state_settings_label"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="10dp"
+                android:text="@string/pref_title"
+                android:textColor="#B3FFFFFF"
+                android:textSize="15sp" />
+
+        </LinearLayout>
+
     </LinearLayout>
 
 </androidx.coordinatorlayout.widget.CoordinatorLayout>


### PR DESCRIPTION
The empty state offered no way into the app settings while nothing was playing — the gear only lives in the player controls, which are unavailable without media.

- A secondary "Settings" row under the "Open video" call to action, opening `SettingsActivity` through the same `REQUEST_SETTINGS` flow as the gear long-press.
- `bg_ghost_button`: transparent background with a white focus outline, so the row is visibly focusable on TV.
- Sized for TV and tablet alongside the existing empty-state scaling, and folded into the same staggered reveal animation.

Reuses the existing `pref_title` string, so no new translations are needed.