### PR TITLE
Decode HTML-escaped titles passed through intent extras

### DIFF
--- a/app/src/main/java/com/brouken/player/PlayerActivity.java
+++ b/app/src/main/java/com/brouken/player/PlayerActivity.java
@@ -555,7 +555,10 @@ public class PlayerActivity extends Activity {
                     } else if (bundle.containsKey(API_TITLE)) {
                         apiAccessPartial = true;
                     }
-                    apiTitle = bundle.getString(API_TITLE);
+                    // Read as CharSequence: some senders pass a Spanned/CharSequence title,
+                    // which getString() would silently drop.
+                    final CharSequence titleExtra = bundle.getCharSequence(API_TITLE);
+                    apiTitle = Utils.unescapeHtml(titleExtra == null ? null : titleExtra.toString());
                     final String thumbnail = bundle.getString(API_THUMBNAIL);
                     if (thumbnail != null) {
                         apiThumbnailUri = Uri.parse(thumbnail);
@@ -2665,6 +2668,7 @@ public class PlayerActivity extends Activity {
             if (title == null || title.isEmpty()) {
                 title = filenames != null && i < filenames.length ? filenames[i] : null;
             }
+            title = Utils.unescapeHtml(title);
             if (title == null || title.isEmpty()) {
                 title = uri.getLastPathSegment();
             }

--- a/app/src/main/java/com/brouken/player/Utils.java
+++ b/app/src/main/java/com/brouken/player/Utils.java
@@ -43,6 +43,7 @@ import android.widget.FrameLayout;
 import android.widget.ImageButton;
 
 import androidx.annotation.RequiresApi;
+import androidx.core.text.HtmlCompat;
 import androidx.documentfile.provider.DocumentFile;
 import androidx.media3.common.Format;
 import androidx.media3.common.MimeTypes;
@@ -182,6 +183,14 @@ class Utils {
             e.printStackTrace();
         }
         return result;
+    }
+
+    // Some senders pass HTML-escaped text in intent extras (e.g. "В&#039;язниця").
+    public static String unescapeHtml(String text) {
+        if (text == null || text.indexOf('&') < 0) {
+            return text;
+        }
+        return HtmlCompat.fromHtml(text, HtmlCompat.FROM_HTML_MODE_LEGACY).toString().trim();
     }
 
     public static boolean isVolumeMin(final AudioManager audioManager) {


### PR DESCRIPTION
Some senders escape the title text in the `title` intent extra, e.g. `В'язниця для кішок` arrives as `В&#039;язниця для кішок`. Nothing decoded it, so the raw entity showed up in the info panel, the episode list and the media session (notification / lockscreen).

Why it looked device-dependent: the render path is identical everywhere, so the difference is in the input. Either the title arrives already clean (different sender version or source), or there is no `title` extra at all and it falls back to the file name — or the extra is passed as a `CharSequence` rather than a `String`, in which case `Bundle.getString()` returns null and the file name is shown instead. The same tolerance already exists for the playlist arrays (`getSmartStringArray`).

Changes:
- `Utils.unescapeHtml()` — `HtmlCompat.fromHtml`, skipped entirely when the text contains no `&`, so unaffected titles stay byte-exact.
- The single-media `title` extra is read as a `CharSequence` and unescaped.
- Episode titles from `video_list.name` / `video_list.filename` are unescaped before the last-path-segment fallback.

Decoding happens on the way in, not at the UI sinks, so titles derived from file names (`AT&T.mkv`) are untouched. Known limitation: `fromHtml` also strips markup, so a title with both literal angle brackets and an `&` loses the bracketed part.

Verified with `assembleLatestUniversalDebug` and:
```
adb shell am start -a android.intent.action.VIEW -n com.justplus.player/com.brouken.player.PlayerActivity   -d "https://example.com/video.mp4" -e title 'В&#039;язниця для кішок'
```