### PR TITLE
Carry device, runtime and player state in the error report

### DIFF
--- a/app/src/main/java/com/brouken/player/App.java
+++ b/app/src/main/java/com/brouken/player/App.java
@@ -1,6 +1,7 @@
 package com.brouken.player;
 
 import android.app.Application;
+import android.os.SystemClock;
 import android.preference.PreferenceManager;
 
 import io.sentry.SentryEvent;
@@ -11,6 +12,13 @@ import io.sentry.protocol.SentryException;
 import java.util.List;
 
 public class App extends Application {
+
+    /**
+     * Process start, captured when this class is loaded — the first app code to run. Used by the error
+     * report's uptime line; a static beats Process.getStartElapsedRealtime() only in that it needs no
+     * API-level branch (that call arrived in API 24, this app supports 23).
+     */
+    static final long START_ELAPSED = SystemClock.elapsedRealtime();
 
     @Override
     public void onCreate() {

--- a/app/src/main/java/com/brouken/player/ErrorActivity.java
+++ b/app/src/main/java/com/brouken/player/ErrorActivity.java
@@ -1,15 +1,23 @@
 package com.brouken.player;
 
+import android.app.ActivityManager;
 import android.content.ClipData;
 import android.content.ClipboardManager;
 import android.content.Context;
 import android.content.Intent;
+import android.content.res.Configuration;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
+import android.hardware.display.DisplayManager;
 import android.os.Build;
 import android.os.Bundle;
 import android.os.Process;
+import android.os.StatFs;
+import android.os.SystemClock;
+import android.preference.PreferenceManager;
 import android.provider.Settings;
+import android.util.DisplayMetrics;
+import android.view.Display;
 import android.view.View;
 import android.widget.ImageView;
 import android.widget.ProgressBar;
@@ -29,6 +37,7 @@ import java.net.URLEncoder;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.Locale;
+import java.util.TimeZone;
 
 /**
  * Friendly, full-screen surface for a playback error. The on-screen panel shows only the error code
@@ -146,14 +155,94 @@ public class ErrorActivity extends AppCompatActivity {
 
     private String buildReport(final String body) {
         // Header mirrors the metadata Sentry attaches (release, dist, environment, timestamp) so a
-        // pasted/shared report carries at least as much context as a Sentry event.
+        // pasted/shared report carries at least as much context as a Sentry event. The device and
+        // runtime blocks below carry what Sentry's device/app contexts did — they are what makes a
+        // manually pasted report a viable replacement for automatic reporting.
         final String time = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss Z", Locale.US).format(new Date());
-        return BuildConfig.APPLICATION_ID + "@" + BuildConfig.VERSION_NAME
-                + " (build " + BuildConfig.VERSION_CODE + ", " + (BuildConfig.DEBUG ? "debug" : "release") + ")\n"
-                + "Device: " + Build.MANUFACTURER + " " + Build.MODEL
-                + " (Android " + Build.VERSION.RELEASE + ", API " + Build.VERSION.SDK_INT + ")\n"
-                + "Time: " + time + "\n\n"
-                + (body != null ? body : "");
+        final StringBuilder sb = new StringBuilder();
+        sb.append(BuildConfig.APPLICATION_ID).append('@').append(BuildConfig.VERSION_NAME)
+                .append(" (build ").append(BuildConfig.VERSION_CODE)
+                .append(", ").append(BuildConfig.FLAVOR)
+                .append(' ').append(BuildConfig.DEBUG ? "debug" : "release").append(")\n");
+        sb.append("Device: ").append(Build.MANUFACTURER).append(' ').append(Build.MODEL)
+                .append(" (Android ").append(Build.VERSION.RELEASE)
+                .append(", API ").append(Build.VERSION.SDK_INT).append(")\n");
+        sb.append("Time: ").append(time).append('\n');
+        appendDevice(sb);
+        appendRuntime(sb);
+        sb.append('\n').append(body != null ? body : "");
+        return sb.toString();
+    }
+
+    /**
+     * Firmware, hardware and display detail — all of it from Build/Resources, so no permission is
+     * involved. The fingerprint pins the exact OEM build (crashes cluster per firmware, not per model);
+     * refresh rate and form factor matter because of frame-rate matching and the TV layout.
+     */
+    private void appendDevice(final StringBuilder sb) {
+        sb.append("Build: ").append(Build.FINGERPRINT).append('\n');
+        sb.append("Hardware: ").append(Build.DEVICE).append('/').append(Build.HARDWARE);
+        if (Build.VERSION.SDK_INT >= 31) {
+            sb.append(' ').append(Build.SOC_MODEL);
+        }
+        sb.append(", ").append(Build.SUPPORTED_ABIS.length > 0 ? Build.SUPPORTED_ABIS[0] : "?")
+                .append(", patch ").append(Build.VERSION.SECURITY_PATCH).append('\n');
+        final DisplayMetrics metrics = getResources().getDisplayMetrics();
+        sb.append("Display: ").append(metrics.widthPixels).append('x').append(metrics.heightPixels)
+                .append(" @").append(metrics.densityDpi).append("dpi ")
+                .append(String.format(Locale.US, "%.2fHz", refreshRate())).append(", ")
+                .append(Utils.isTvBox(this) ? "tv" : Utils.isTablet(this) ? "tablet" : "phone")
+                .append(getResources().getConfiguration().orientation == Configuration.ORIENTATION_LANDSCAPE
+                        ? ", landscape" : ", portrait").append('\n');
+        sb.append("Locale: ").append(Locale.getDefault()).append(", ")
+                .append(TimeZone.getDefault().getID()).append('\n');
+    }
+
+    /**
+     * How the app was installed, how long it had been running and how much headroom it had — the
+     * difference between "playback failed" and "playback failed 4 seconds in with the heap nearly full".
+     */
+    private void appendRuntime(final StringBuilder sb) {
+        sb.append("Runtime: up ").append((SystemClock.elapsedRealtime() - App.START_ELAPSED) / 1000)
+                .append("s, installer ").append(installer()).append('\n');
+        final Runtime runtime = Runtime.getRuntime();
+        sb.append("Memory: heap ").append((runtime.totalMemory() - runtime.freeMemory()) >> 20)
+                .append('/').append(runtime.maxMemory() >> 20).append(" MB");
+        final ActivityManager am = (ActivityManager) getSystemService(Context.ACTIVITY_SERVICE);
+        if (am != null) {
+            final ActivityManager.MemoryInfo memory = new ActivityManager.MemoryInfo();
+            am.getMemoryInfo(memory);
+            sb.append(", device ").append(memory.availMem >> 20).append(" MB free")
+                    .append(memory.lowMemory ? " (low)" : "");
+        }
+        sb.append(", storage ").append(new StatFs(getFilesDir().getAbsolutePath()).getAvailableBytes() >> 20)
+                .append(" MB free\n");
+        // Same SharedPreferences read App.initSentry() uses — cheaper than building a Prefs, which
+        // would also load unrelated playback state.
+        final android.content.SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(this);
+        sb.append("Prefs: file access ").append(prefs.getString("fileAccess", "auto"))
+                .append(prefs.getBoolean("crashReporting", true) ? ", crash reporting on" : ", crash reporting off")
+                .append('\n');
+    }
+
+    private float refreshRate() {
+        final DisplayManager dm = (DisplayManager) getSystemService(Context.DISPLAY_SERVICE);
+        final Display display = dm != null ? dm.getDisplay(Display.DEFAULT_DISPLAY) : null;
+        return display != null ? display.getRefreshRate() : 0f;
+    }
+
+    // Deprecated since API 30 in favour of getInstallSourceInformation(), itself replaced by
+    // getInstallSourceInfo() in API 36 — this one call still answers "store install or sideload?" on
+    // every supported level, which is all the report needs.
+    @SuppressWarnings("deprecation")
+    private String installer() {
+        try {
+            final String name = getPackageManager().getInstallerPackageName(getPackageName());
+            // No installer at all means adb / a raw APK, which is worth telling apart from a store install.
+            return name != null ? name : "none (sideloaded)";
+        } catch (Exception e) {
+            return "?";
+        }
     }
 
     private void animateIn() {

--- a/app/src/main/java/com/brouken/player/PlayerActivity.java
+++ b/app/src/main/java/com/brouken/player/PlayerActivity.java
@@ -5936,8 +5936,68 @@ public class PlayerActivity extends Activity {
         final Uri uri = currentMediaUri();
         if (Utils.isSupportedNetworkUri(uri)) {
             sb.append("\nMedia: ").append(Utils.uriToReportString(uri));
+        } else if (uri != null) {
+            // Local media: the scheme only. A path or file name can identify the user's library, so it
+            // never leaves the device — the formats below say everything a decoder bug needs anyway.
+            sb.append("\nMedia: ").append(uri.getScheme()).append(" (local)");
         }
+        appendPlayerState(sb);
         return sb.append("\n\n").append(ErrorActivity.stackTrace(error)).toString();
+    }
+
+    /**
+     * Player-side state for the error report — the part no crash reporter can see: which formats were
+     * actually selected, where playback had got to, and which decoder-affecting settings and recovery
+     * flags were in effect. Absent when the player is already gone (a process crash reaches
+     * ErrorActivity through its own handler, with no player to ask).
+     */
+    private void appendPlayerState(final StringBuilder sb) {
+        if (player == null) {
+            return;
+        }
+        int video = 0, audio = 0, text = 0;
+        Format subtitle = null;
+        for (Tracks.Group group : player.getCurrentTracks().getGroups()) {
+            switch (group.getType()) {
+                case C.TRACK_TYPE_VIDEO:
+                    video++;
+                    break;
+                case C.TRACK_TYPE_AUDIO:
+                    audio++;
+                    break;
+                case C.TRACK_TYPE_TEXT:
+                    text++;
+                    if (group.isSelected()) {
+                        subtitle = group.getMediaTrackGroup().getFormat(0);
+                    }
+                    break;
+            }
+        }
+        sb.append("\nVideo: ").append(Format.toLogString(player.getVideoFormat()));
+        sb.append("\nAudio: ").append(Format.toLogString(player.getAudioFormat()));
+        sb.append("\nSubtitle: ").append(subtitle != null ? Format.toLogString(subtitle) : "none");
+        sb.append("\nTracks: ").append(video).append(" video, ").append(audio).append(" audio, ")
+                .append(text).append(" subtitle");
+        final long duration = player.getDuration();
+        sb.append("\nPosition: ").append(player.getCurrentPosition()).append('/')
+                .append(duration == C.TIME_UNSET ? "unknown" : String.valueOf(duration))
+                .append(" ms, buffered ").append(player.getBufferedPosition())
+                .append(" ms, state ").append(player.getPlaybackState())
+                .append(player.isPlaying() ? " (playing)" : " (paused)")
+                .append(", item ").append(player.getCurrentMediaItemIndex() + 1)
+                .append('/').append(player.getMediaItemCount());
+        sb.append("\nPlayback: decoder priority ").append(mPrefs.decoderPriority)
+                .append(", speed ").append(mPrefs.speed)
+                .append(", resize ").append(mPrefs.resizeMode)
+                .append(mPrefs.tunneling ? ", tunneling" : "")
+                .append(mPrefs.frameRateMatching ? ", frame rate matching" : "")
+                .append(mPrefs.skipSilence ? ", skip silence" : "")
+                .append(mPrefs.mapDV7ToHevc ? ", map DV7" : "");
+        if (forceHevcForDolbyVision || stuckRecoveryAttemptedUri != null) {
+            sb.append("\nRecovery: ")
+                    .append(forceHevcForDolbyVision ? "forced HEVC for Dolby Vision" : "none")
+                    .append(stuckRecoveryAttemptedUri != null ? ", after stuck playback" : "");
+        }
     }
 
     private Uri currentMediaUri() {


### PR DESCRIPTION
The report a user copies, shares or uploads from the error screen held four header lines — package, version, model, timestamp — and a stack trace, while an automatic crash event carried a full device and app context on top of that. Anyone reading a pasted report had to ask back for the firmware, the form factor, or what the player was actually doing at the time.

The header now also states the exact firmware build, SoC and ABI, the display (size, density, refresh rate, form factor, orientation), locale and time zone, plus how the app was installed, how long it had been running, and its heap, device memory and storage headroom. All of it comes from `Build`, `Resources` and the app's own runtime, so no new permission is involved.

Playback errors additionally carry what no crash reporter can see: the video, audio and subtitle formats that were actually selected, the track counts per type, position, duration, buffered position and playback state, the decoder-affecting settings, and the Dolby Vision recovery flags when they are set. `Format.toLogString` renders each format, so a codec, resolution, bitrate and channel count fit on one line per track.

Privacy is unchanged. Local media still reports its scheme only — a path or file name can identify the user's library — network media keeps going through the existing sanitisation that drops query strings, and the whole body still passes `Utils.stripUrlQuery` in `ErrorActivity`.

Network type is deliberately left out: `ConnectivityManager` needs `ACCESS_NETWORK_STATE`, which this app does not declare, and the source type is already visible from the URI scheme.