### PR TITLE
Stop the error report from reopening itself after a fatal failure

### DIFF
--- a/app/src/main/java/com/brouken/player/PlayerActivity.java
+++ b/app/src/main/java/com/brouken/player/PlayerActivity.java
@@ -236,6 +236,12 @@ public class PlayerActivity extends Activity {
     private boolean forceHevcForDolbyVision;
     private boolean pendingStuckRecovery;
     private String stuckRecoveryAttemptedUri;
+    // A fatal report has just been shown for the current clip. onStart re-initialises the player every
+    // time the activity comes back, so without this the clip is prepared again the moment the report is
+    // closed, fails the same way and reopens it — a window that cannot be dismissed. Fall back to the
+    // empty state instead, as the media-gone path does. One-shot: consumed by that next initialisation,
+    // so re-opening the same clip, or picking another one, plays normally.
+    private boolean skipMediaAfterFatalError;
     // Re-reads spent on network source errors this session (see recoverFromSourceError), reset per player
     // build so a chronically bad stream costs a bounded number of re-prepares instead of one per resume.
     private int sourceRetries;
@@ -4401,6 +4407,10 @@ public class PlayerActivity extends Activity {
     public void initializePlayer() {
         boolean isNetworkUri = Utils.isSupportedNetworkUri(mPrefs.mediaUri);
         haveMedia = mPrefs.mediaUri != null;
+        if (skipMediaAfterFatalError) {
+            skipMediaAfterFatalError = false;
+            haveMedia = false;
+        }
 
         // Unless this is the stuck-playback recovery rebuild (which must keep forceHevcForDolbyVision),
         // clear the one-shot Dolby Vision recovery state so a normal open plays DV through its regular
@@ -5968,6 +5978,9 @@ public class PlayerActivity extends Activity {
     }
 
     private void showErrorScreen(final String summary, final String report) {
+        // Every full-screen report from the player passes through here, so this is the one place that has
+        // to keep the next resume from walking straight back into the failure (see the field's comment).
+        skipMediaAfterFatalError = true;
         startActivity(new Intent(this, ErrorActivity.class)
                 .putExtra(ErrorActivity.EXTRA_SUMMARY, summary)
                 .putExtra(ErrorActivity.EXTRA_REPORT, report));


### PR DESCRIPTION
Falling back to the empty state when the remembered video was gone (#27) fixed the undismissable report only for a clip that could not be opened at all — a revoked grant or a missing file. Every other fatal failure still looped: a malformed rip, an unsupported container, a stalled device decoder left the URI remembered, so closing the report resumed the activity, `onStart` re-prepared the same clip, it failed the same way and the report came straight back.

The loop lives in the resume rather than in any single error class, so it is broken where they all pass through. Showing a full-screen report now marks the clip as not to be prepared by the next initialisation, which falls back to the empty state instead.

The mark is one-shot. Opening the clip again — a fresh intent, or picking it in the chooser — still tries it and reports honestly, and picking anything else plays normally. Nothing is forgotten in prefs: the URI and the playback position survive, unlike the media-gone path where the clip is dropped because it can never be opened again.

Verified on a device with a file that no extractor can read (`ERROR_CODE_PARSING_CONTAINER_UNSUPPORTED`) opened through a `content://` URI: before, closing the report reopened it indefinitely; now it lands on the empty state, and re-sending the same intent shows the report once more.