### PR TITLE
Open on the empty state when a launch brings no media

### DIFF
--- a/app/src/main/java/com/brouken/player/PlayerActivity.java
+++ b/app/src/main/java/com/brouken/player/PlayerActivity.java
@@ -547,6 +547,10 @@ public class PlayerActivity extends Activity {
             }
         } else if (launchIntent.getData() != null) {
             handleViewIntent(launchIntent);
+        } else {
+            // Nothing came in — a launcher start opens on the empty state instead of resuming
+            // whatever was last watched.
+            mPrefs.suppressResume = true;
         }
 
         coordinatorLayout = findViewById(R.id.coordinatorLayout);
@@ -4406,7 +4410,7 @@ public class PlayerActivity extends Activity {
 
     public void initializePlayer() {
         boolean isNetworkUri = Utils.isSupportedNetworkUri(mPrefs.mediaUri);
-        haveMedia = mPrefs.mediaUri != null;
+        haveMedia = mPrefs.mediaUri != null && !mPrefs.suppressResume;
         if (skipMediaAfterFatalError) {
             skipMediaAfterFatalError = false;
             haveMedia = false;

--- a/app/src/main/java/com/brouken/player/Prefs.java
+++ b/app/src/main/java/com/brouken/player/Prefs.java
@@ -71,6 +71,10 @@ class Prefs {
     final SharedPreferences mSharedPreferences;
 
     public Uri mediaUri;
+    // Set for a launch that brought no media of its own: the remembered clip stays on disk
+    // (the picker starts there, its position is kept) but the player must not resume it by
+    // itself. Cleared by updateMedia, i.e. as soon as any media is actually opened.
+    public boolean suppressResume;
     public Uri subtitleUri;
     public Uri scopeUri;
     public String mediaType;
@@ -180,6 +184,7 @@ class Prefs {
     public void updateMedia(final Context context, final Uri uri, final String type) {
         mediaUri = uri;
         mediaType = type;
+        suppressResume = false;
         updateSubtitle(null);
         updateMeta(null, null, AspectRatioFrameLayout.RESIZE_MODE_FIT, 1.f, 0f, 1.f);
 


### PR DESCRIPTION
A launcher start carries no data, so `initializePlayer` fell back to the URI `Prefs` remembered and resumed the last clip on its own. That is fine for a file the user picked, but a link shared in from another app is remembered the same way and came back on every cold start long after it was watched.

A launch that brings nothing — no VIEW data, no shared link, no videos shortcut — now sets `Prefs.suppressResume`, and `initializePlayer` treats the remembered clip as absent, landing on the branded empty state.

The URI itself is kept: the picker still starts in that folder and the position is still keyed to it, so opening the same video again resumes where it stopped. `updateMedia` clears the flag, so it lifts as soon as any media is actually opened — from the picker, an intent or the next episode.

Checked on a device:

- launcher start → empty state
- VIEW intent → plays
- Home, then tapping the icon (warm start, `onNewIntent`) → playback continues
- force-stop, then the icon → empty state
- empty state → Settings → Back → still the empty state (the flag is not one-shot, otherwise returning from Settings would revive the old clip)