### PR TITLE
Fix long labels and a drifting clock in the picker panels

### DIFF
--- a/app/src/main/java/com/brouken/player/PlayerActivity.java
+++ b/app/src/main/java/com/brouken/player/PlayerActivity.java
@@ -2409,6 +2409,41 @@ public class PlayerActivity extends Activity {
         dialog.show();
     }
 
+    // A long label does not fit the width of a picker panel, and the two device classes want opposite
+    // answers. On TV the row that has D-pad focus scrolls its text: focus makes the movement mean
+    // something ("this row"), it is the 10-foot idiom, and only one row is ever moving. In touch mode
+    // nothing is ever focused, so scrolling could only mean scrolling — six rows crawling in a list the
+    // user is trying to scan is motion without a message, so there the label wraps to a second line and
+    // ellipsizes instead, which shows more of it than a marquee does at any one moment. Scrolling also
+    // needs the view focused or selected, and the focusable view is the row, not its texts, hence the
+    // relay below; only the TextViews move, the poster/number box of a playlist row is a sibling.
+    private void fitLongText(final View row, final TextView... texts) {
+        final boolean scroll = ui.deviceClass == UiMetrics.DeviceClass.TV && !isReducedMotion();
+        for (final TextView text : texts) {
+            if (text == null) {
+                continue;
+            }
+            if (scroll) {
+                text.setSingleLine(true);
+                text.setEllipsize(TextUtils.TruncateAt.MARQUEE);
+                text.setMarqueeRepeatLimit(-1);
+                text.setHorizontalFadingEdgeEnabled(true);
+            } else {
+                text.setMaxLines(2);
+                text.setEllipsize(TextUtils.TruncateAt.END);
+            }
+        }
+        if (scroll) {
+            row.setOnFocusChangeListener((v, hasFocus) -> {
+                for (final TextView text : texts) {
+                    if (text != null) {
+                        text.setSelected(hasFocus);
+                    }
+                }
+            });
+        }
+    }
+
     // Bar state while a picker panel is open: navigation/gesture bar shown (avoids OxygenOS's fullscreen
     // back-gesture guard, which keys on hidden nav gestures), status bar hidden (clean top edge).
     private void applyPickerBars() {
@@ -3360,8 +3395,6 @@ public class PlayerActivity extends Activity {
             titleText.setText(title);
             titleText.setTextColor(isCurrent ? 0xFFFFFFFF : 0xFFDDDDDD);
             titleText.setTextSize(TypedValue.COMPLEX_UNIT_SP, ui.textList());
-            titleText.setMaxLines(2);
-            titleText.setEllipsize(TextUtils.TruncateAt.END);
             if (isCurrent) {
                 titleText.setTypeface(Typeface.DEFAULT_BOLD);
             }
@@ -3370,6 +3403,7 @@ public class PlayerActivity extends Activity {
             titleLp.gravity = Gravity.CENTER_VERTICAL;
             titleText.setLayoutParams(titleLp);
             row.addView(titleText);
+            fitLongText(row, titleText);
 
             row.setOnClickListener(v -> {
                 if (player != null) {
@@ -3610,22 +3644,22 @@ public class PlayerActivity extends Activity {
             title.setText(qualityChoiceTitle(choice));
             title.setTextColor(isCurrent ? 0xFFFFFFFF : 0xFFDDDDDD);
             title.setTextSize(TypedValue.COMPLEX_UNIT_SP, ui.textBody());
-            title.setSingleLine(true);
             if (isCurrent) {
                 title.setTypeface(Typeface.DEFAULT_BOLD);
             }
             textBlock.addView(title);
 
             final String subtitle = qualityChoiceSubtitle(choice);
+            TextView details = null;
             if (subtitle != null && !subtitle.isEmpty()) {
-                final TextView details = new TextView(this);
+                details = new TextView(this);
                 details.setText(subtitle);
                 details.setTextColor(0x99FFFFFF);
                 details.setTextSize(TypedValue.COMPLEX_UNIT_SP, ui.textCaption());
-                details.setSingleLine(true);
                 textBlock.addView(details);
             }
             row.addView(textBlock);
+            fitLongText(row, title, details);
 
             if (choice.bitrateText != null && !choice.bitrateText.isEmpty()) {
                 final TextView bitrate = new TextView(this);
@@ -3821,21 +3855,21 @@ public class PlayerActivity extends Activity {
             title.setText(item.title);
             title.setTextColor(isCurrent ? 0xFFFFFFFF : 0xFFDDDDDD);
             title.setTextSize(TypedValue.COMPLEX_UNIT_SP, ui.textBody());
-            title.setSingleLine(true);
             if (isCurrent) {
                 title.setTypeface(Typeface.DEFAULT_BOLD);
             }
             textBlock.addView(title);
 
+            TextView details = null;
             if (item.subtitle != null && item.subtitle.length() > 0) {
-                final TextView details = new TextView(this);
+                details = new TextView(this);
                 details.setText(item.subtitle);
                 details.setTextColor(0x99FFFFFF);
                 details.setTextSize(TypedValue.COMPLEX_UNIT_SP, ui.textCaption());
-                details.setSingleLine(true);
                 textBlock.addView(details);
             }
             row.addView(textBlock);
+            fitLongText(row, title, details);
 
             row.setOnClickListener(v -> {
                 if (menuDialog != null) {

--- a/app/src/main/java/com/brouken/player/PlayerActivity.java
+++ b/app/src/main/java/com/brouken/player/PlayerActivity.java
@@ -1176,7 +1176,16 @@ public class PlayerActivity extends Activity {
                 // Extend the header's background up over the status-bar area (top margin -> 0, top inset moved into
                 // the top padding). The content position is unchanged (padding pushes it down by the same amount the
                 // margin used to), but the panel now paints the status-bar strip, in perfect sync with the header.
-                Utils.setViewParams(topInfoPanel, paddingLeft + titleViewPaddingHorizontal, windowInsets.getSystemWindowInsetTop() + overscanV + Utils.dpToPx(4), paddingRight + titleViewPaddingHorizontal, titleViewPaddingVertical,
+                // Reserve that strip whether or not the status bar happens to be showing: the controls hide together
+                // with the system bars, so a top padding that tracked the live inset moved the header's clock every
+                // time they toggled, and the floating clock mirrors that position while remaining visible — which is
+                // how it crept upwards when a picker panel hid the controls. Landscape is where it showed, the top
+                // inset there really does fall to 0; in portrait a display cutout keeps it non-zero.
+                final int insetTop = Build.VERSION.SDK_INT >= 30
+                        ? Math.max(windowInsets.getSystemWindowInsetTop(),
+                                windowInsets.getInsetsIgnoringVisibility(WindowInsets.Type.statusBars()).top)
+                        : windowInsets.getSystemWindowInsetTop();
+                Utils.setViewParams(topInfoPanel, paddingLeft + titleViewPaddingHorizontal, insetTop + overscanV + Utils.dpToPx(4), paddingRight + titleViewPaddingHorizontal, titleViewPaddingVertical,
                         marginLeft, 0, marginRight, 0);
 
 


### PR DESCRIPTION
Two fixes to the side panels (playlist, quality, audio, subtitles).

**Long labels had nowhere to go.** The quality, audio and subtitle rows put their text on a single line with no `ellipsize` at all, so a long track name was cut off at the edge of the panel without even an ellipsis to show for it. Those labels now wrap to a second line and ellipsize there, which is enough for a track name that carries a dubbing studio and a codec.

On TV the row holding D-pad focus scrolls its text instead: focus is what makes the movement mean something, only one row is ever moving, and a second dense line reads poorly across a room. Scrolling is dropped when the system has animations turned off (`isReducedMotion()`). One helper, `fitLongText()`, covers all three panels; only the text moves, the poster and episode number of a playlist row stay put.

**The floating clock crept upwards.** The header reserved room for the status bar out of the inset as it stood at that moment, and the controls hide together with the system bars, so hiding them pulled the header up by the bar's height. The floating clock mirrors the position of the clock inside the header and stays on screen when the header does not, so it was the one seen drifting — most obviously on opening a picker panel, which hides the controls and leaves them hidden, so the clock stayed up until they were called back. The strip is now reserved from the inset the status bar would occupy whether or not it is on screen, never less than the current inset so a display cutout taller than the bar still counts.

Landscape is where this showed, being where the top inset really does fall to zero; in portrait a cutout keeps it non-zero.

## Testing

Builds clean. Installed on a phone; the panels and the clock were not yet exercised on a TV.