### PR TITLE
Stop the first subtitle track selecting itself on HLS

### DIFF
--- a/app/src/main/java/com/brouken/player/PlayerActivity.java
+++ b/app/src/main/java/com/brouken/player/PlayerActivity.java
@@ -6118,7 +6118,10 @@ public class PlayerActivity extends Activity {
     }
 
     private TrackGroup getTrackGroupFromFormatId(int trackType, String id) {
-        if ((id == null && trackType == C.TRACK_TYPE_AUDIO ) || player == null) {
+        // No id means nothing was recorded for that track type, so there is nothing to match. Not just a
+        // shortcut: HLS leaves Format.id null on every rendition, so a null id would match the first
+        // group of the type and force-select it — the first subtitle track switching itself on at start.
+        if (id == null || player == null) {
             return null;
         }
         for (Tracks.Group group : player.getCurrentTracks().getGroups()) {
@@ -6144,25 +6147,20 @@ public class PlayerActivity extends Activity {
         TrackGroup subtitleGroup = getTrackGroupFromFormatId(C.TRACK_TYPE_TEXT, subtitleId);
         TrackGroup audioGroup = getTrackGroupFromFormatId(C.TRACK_TYPE_AUDIO, audioId);
 
-        TrackSelectionParameters.Builder overridesBuilder = new TrackSelectionParameters.Builder(this);
-        TrackSelectionOverride trackSelectionOverride = null;
-        final List<Integer> tracks = new ArrayList<>(); tracks.add(0);
+        if (player == null) {
+            return;
+        }
+        // setOverrideForType replaces only the overrides of that track type, so applying both keeps both —
+        // a single shared override variable used to let the audio one drop the subtitle one on the floor.
+        final List<Integer> tracks = Collections.singletonList(0);
+        TrackSelectionParameters.Builder builder = player.getTrackSelectionParameters().buildUpon();
         if (subtitleGroup != null) {
-            trackSelectionOverride = new TrackSelectionOverride(subtitleGroup, tracks);
-            overridesBuilder.addOverride(trackSelectionOverride);
+            builder.setOverrideForType(new TrackSelectionOverride(subtitleGroup, tracks));
         }
         if (audioGroup != null) {
-            trackSelectionOverride = new TrackSelectionOverride(audioGroup, tracks);
-            overridesBuilder.addOverride(trackSelectionOverride);
+            builder.setOverrideForType(new TrackSelectionOverride(audioGroup, tracks));
         }
-
-        if (player != null) {
-            TrackSelectionParameters.Builder trackSelectionParametersBuilder = player.getTrackSelectionParameters().buildUpon();
-            if (trackSelectionOverride != null) {
-                trackSelectionParametersBuilder.setOverrideForType(trackSelectionOverride);
-            }
-            player.setTrackSelectionParameters(trackSelectionParametersBuilder.build());
-        }
+        player.setTrackSelectionParameters(builder.build());
     }
 
     private boolean hasOverrideType(final int trackType) {


### PR DESCRIPTION
## Problem

Opening an m3u8 came up with subtitles on — always the first text track in the playlist, whatever language it happened to be (`VIE #01` in the reported case), even with subtitles previously turned off.

## Cause

`setSelectedTracks()` restores the remembered tracks by matching a track group's `Format.id`. A null id means nothing was remembered, but `getTrackGroupFromFormatId()` only treated it that way for audio. HLS leaves `Format.id` null on **every** rendition, so the null subtitle id matched the first text group and an explicit override switched it on.

Captured with a temporary `EventLogger` on the reported stream:

```
21:11:17.172  tracks [...]                                   <- no text track selected
21:11:19.669  setSelectedTracks sub=null audio=null
21:11:19.725  [X] Track:0, id=null, ... labels=[VIE #01]     <- first subtitle forced on
```

## Fix

- Treat a missing id as "nothing to match" for every track type, not only audio. Where ids exist (containers, external subtitle files) the restore is unchanged; where they do not, tracks are left as the selector chose them.
- Apply both overrides instead of only the last one built. `setOverrideForType` replaces the overrides of a single track type, so the shared variable meant a restored audio track discarded the restored subtitle.

## Testing

Reproduced and verified on the reported HLS stream launched through the API path (as Lampa does): the first subtitle track no longer turns itself on, audio selection and the picker panels behave as before. No automated tests exist in this project.