### PR TITLE
Recover from an unexpected playback error instead of ending the session

### DIFF
--- a/app/src/main/java/com/brouken/player/PlayerActivity.java
+++ b/app/src/main/java/com/brouken/player/PlayerActivity.java
@@ -5804,7 +5804,8 @@ public class PlayerActivity extends Activity {
                     && recoverByRevokingAudioMime(audioTrackInitFailureMime(error))) {
                 return;
             }
-            if (isDecoderFailure(error) && recoverFromDecoderFailure()) {
+            if ((isDecoderFailure(error) || isUnexpectedPlaybackError(error))
+                    && recoverFromDecoderFailure()) {
                 return;
             }
             // The remembered clip can no longer be opened: a foreign app's one-off URI grant has
@@ -6085,6 +6086,19 @@ public class PlayerActivity extends Activity {
             default:
                 return false;
         }
+    }
+
+    // A RuntimeException that escaped on Media3's playback thread, reported as "Unexpected runtime
+    // error". Always an internal player bug rather than anything wrong with the media: the one seen in
+    // the field is the renderer losing the queued entry for its output format when a track reselection
+    // seeks before the first frame has been drained, so the next output buffer finds no format at all
+    // (https://github.com/androidx/media/issues/2965 — the same hole is still open in MediaCodecRenderer).
+    // Nothing about the item, the position or the selection is at fault, so it gets the same bounded
+    // re-prepare as a decoder race instead of ending playback; matched on the exception type, not on
+    // ERROR_CODE_UNSPECIFIED, which is the catch-all code for far more than this.
+    private static boolean isUnexpectedPlaybackError(PlaybackException error) {
+        return error instanceof ExoPlaybackException
+                && ((ExoPlaybackException) error).type == ExoPlaybackException.TYPE_UNEXPECTED;
     }
 
     private boolean recoverFromDecoderFailure() {

--- a/app/src/main/java/com/brouken/player/SubtitleFetcher.java
+++ b/app/src/main/java/com/brouken/player/SubtitleFetcher.java
@@ -121,7 +121,12 @@ class SubtitleFetcher {
                         if (mediaItem != null) {
                             MediaItem.SubtitleConfiguration subtitle = SubtitleUtils.buildSubtitle(activity, convertedSubtitleUri, null, true);
                             mediaItem = mediaItem.buildUpon().setSubtitleConfigurations(Collections.singletonList(subtitle)).build();
-                            PlayerActivity.player.setMediaItem(mediaItem, false);
+                            // Replace only the item the subtitle belongs to. setMediaItem would swap the
+                            // whole playlist for this single item, so an episode list opened from a
+                            // launcher lost the other episodes — and with them the next/prev arrows and
+                            // their remembered positions — the moment a sidecar subtitle turned up.
+                            PlayerActivity.player.replaceMediaItem(
+                                    PlayerActivity.player.getCurrentMediaItemIndex(), mediaItem);
                             if (BuildConfig.DEBUG) {
                                 Toast.makeText(activity, "Subtitle found", Toast.LENGTH_SHORT).show();
                             }


### PR DESCRIPTION
A crash report from the field ([Sentry JUST-PLUS-PLAYER-17](https://justplusplayer.sentry.io/issues/JUST-PLUS-PLAYER-17)): opening a remembered episode, 3.7 s after launch, nothing rendered yet.

```
ExoPlaybackException: Unexpected runtime error
Caused by: NullPointerException
  at com.google.common.base.Preconditions.checkNotNull(Preconditions.java:904)
  at ...mediacodec.MediaCodecRenderer.drainOutputBuffer(MediaCodecRenderer.java:2324)
  at ...video.MediaCodecVideoRenderer.render(MediaCodecVideoRenderer.java:1465)
```

That line is `checkNotNull(outputFormat)` in `drainOutputBuffer`, so the video renderer drained its first output buffer and had no output format for it. The format is written in one place only, from `outputStreamInfo.formatQueue`, and it is queued once per stream; a position reset landing between "first samples handed to the decoder" and "first buffer drained" can clear or swap out the queue the entry was sitting in, and then neither `pollFloor` nor the `pollFirst` fallback can produce anything. This is [androidx/media#2965](https://github.com/androidx/media/issues/2965), reported there for `DecoderVideoRenderer`; the same hole is still open in `MediaCodecRenderer` on `main`, and that class comes from the prebuilt `lib-exoplayer-release.aar`, so there is no version to bump.

**This does not remove the race.** It changes what the race costs: such an error now takes the bounded decoder-failure recovery — up to three delayed `prepare()` calls on the same player, keeping the item, position, surface and track selection — instead of ending playback with a full-screen report. A re-prepare resumes where playback was and the race does not repeat. Anything that still fails after that budget is reported and surfaced exactly as before.

The match is on `ExoPlaybackException.TYPE_UNEXPECTED`, not on `ERROR_CODE_UNSPECIFIED`, which is the catch-all code for much more than this and must keep failing loudly.

Second, unrelated commit found while tracing that report: the HTTP subtitle finder attached its result with `setMediaItem`, which replaces the whole playlist with that one item — an episode list opened from a launcher lost every other episode, and the next/prev arrows with them, as soon as a sidecar subtitle turned up. `replaceMediaItem` touches only the item the subtitle belongs to.

## Testing

- `./gradlew assembleLatestUniversalDebug` passes.
- The playlist fix is checkable by hand: open an episode list with a progressive `http(s)` `.mp4` that has an `.srt` beside it, and the arrows survive the subtitle being picked up.
- The recovery path cannot be reproduced deterministically — the race is timing-dependent and was seen once. It reuses the recovery already exercised by decoder failures, so what is new is only which errors reach it.
- Note for follow-up: recoveries that succeed no longer reach Sentry, so JUST-PLUS-PLAYER-17 going quiet will not by itself prove anything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
