### PR TITLE
Dismiss the controls with the remote's up key

### DIFF
--- a/app/src/main/java/com/brouken/player/PlayerActivity.java
+++ b/app/src/main/java/com/brouken/player/PlayerActivity.java
@@ -1894,6 +1894,21 @@ public class PlayerActivity extends Activity {
                         return true;
                 }
                 break;
+            case KeyEvent.KEYCODE_DPAD_UP:
+                if (controllerVisibleFully) {
+                    // Up from the topmost row dismisses the controls instead of waiting out the timeout.
+                    // Anywhere else it stays plain focus navigation: consuming the key here would suppress
+                    // the focus search this mirrors, because onKeyDown runs before it.
+                    final View focusedUp = getCurrentFocus();
+                    if (!haveMedia || (focusedUp != null && focusedUp.focusSearch(View.FOCUS_UP) != null))
+                        break;
+                    // Repeats are swallowed below: a held key would re-show what the first press dismissed.
+                    if (event.getRepeatCount() == 0)
+                        playerView.hideController();
+                } else if (event.getRepeatCount() == 0) {
+                    playerView.showController();
+                }
+                return true;
             case KeyEvent.KEYCODE_BACK:
                 if (isTvBox) {
                     if (controllerVisible && player != null && player.isPlaying()) {


### PR DESCRIPTION
Requested by a user: pressing up on the remote should clear the playback controls, instead of having to wait for them to disappear.

Until now the controls only went away on the 3.5s timeout (or `BACK` on TV), and pressing up actively kept them on screen — Media3's `PlayerView.dispatchKeyEvent` re-arms the timeout for any unconsumed D-pad key.

### Behaviour

Up hides the controls **only from the topmost row**. Anywhere else it remains plain focus navigation: `Activity.onKeyDown` runs before `ViewRootImpl.performFocusNavigation()`, so consuming the key unconditionally would break the existing bottom-pill → seek bar → transport row chain. The guard is `focusSearch(View.FOCUS_UP) == null`, i.e. the same search the framework would have run.

Since every controller show force-focuses `exo_play_pause` — the topmost focusable row on TV, where the header holds no focusable views — one press dismisses in the common case. After navigating down, up first walks the focus back up, and the next press dismisses.

Repeats are consumed only where the branch acts, so holding the key cannot flip the controls on and off; holding still moves the focus up one row per repeat and stops at the top.

### Notes

- With no media loaded the key falls through to normal navigation, mirroring the `haveMedia` guard in `CustomPlayerView.tap()`.
- Not gated on TV: the focus guard is correct on touch devices too, where the header does hold focusable buttons.
- The floating Skip pill sits below the transport row, so it never absorbs the upward search. After the controls are dismissed the focus lands on the pill and `OK` still triggers the skip, since that interceptor requires the controller to be hidden.
- Zoom mode (up/down adjust scale) and the locked screen intercept keys earlier in `dispatchKeyEvent` and are unaffected.

### Test plan

On a TV box / emulator, during playback:

- controls hidden → up shows them (unchanged)
- controls shown, focus on play/pause → up hides them
- down to the seek bar or bottom pill → up moves the focus up, does not hide; another up from the top row hides
- hold up → focus walks to the top row and stops, no flicker
- left/right accelerated seek, `DPAD_CENTER` play/pause, `BACK`, Skip pill + `OK`, and long-press aspect → zoom all behave as before
