### PR TITLE
Seek in the time bar by tapping it

### DIFF
--- a/app/src/main/java/com/brouken/player/CustomDefaultTimeBar.java
+++ b/app/src/main/java/com/brouken/player/CustomDefaultTimeBar.java
@@ -11,8 +11,6 @@ import androidx.annotation.Nullable;
 import androidx.media3.ui.DefaultTimeBar;
 
 import java.lang.reflect.Field;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
 
 class CustomDefaultTimeBar extends DefaultTimeBar {
 
@@ -133,21 +131,34 @@ class CustomDefaultTimeBar extends DefaultTimeBar {
             else
                 scrubbing = true;
         }
-        if (!scrubbing && event.getAction() == MotionEvent.ACTION_MOVE && scrubberBar != null) {
+        // The DOWN was swallowed above, so the base class is not scrubbing. Start it now, either
+        // because the finger has moved far enough to be a deliberate drag, or because the finger
+        // was lifted without moving at all — a tap, which seeks to the touched point.
+        if (!scrubbing && scrubberBar != null
+                && (event.getAction() == MotionEvent.ACTION_MOVE || event.getAction() == MotionEvent.ACTION_UP)) {
             final int distanceFromStart = Math.abs(((int)event.getX()) - scrubbingStartX);
-            if (distanceFromStart > Utils.dpToPx(6)) {
-                scrubbing = true;
-                try {
-                    final Method method = DefaultTimeBar.class.getDeclaredMethod("startScrubbing", long.class);
-                    method.setAccessible(true);
-                    method.invoke(this, (long) 0);
-                } catch (NoSuchMethodException | SecurityException | IllegalAccessException | IllegalArgumentException | InvocationTargetException e) {
-                    e.printStackTrace();
-                }
-            } else {
+            if (event.getAction() == MotionEvent.ACTION_MOVE && distanceFromStart <= Utils.dpToPx(6)) {
                 return true;
             }
+            scrubbing = true;
+            startScrubbingAt(event);
         }
         return super.onTouchEvent(event);
+    }
+
+    /**
+     * Hands the base class the ACTION_DOWN it never received, so it positions the scrubber itself.
+     * The press is clamped onto the bar because the finger may already have left it — dragging off
+     * the bar is how fine scrubbing is started — and a press outside the bar would be ignored.
+     */
+    private void startScrubbingAt(MotionEvent event) {
+        final MotionEvent down = MotionEvent.obtainNoHistory(event);
+        down.setAction(MotionEvent.ACTION_DOWN);
+        if (progressBar != null) {
+            final float x = Math.min(Math.max(event.getX(), progressBar.left), progressBar.right - 1);
+            down.setLocation(x, progressBar.centerY());
+        }
+        super.onTouchEvent(down);
+        down.recycle();
     }
 }


### PR DESCRIPTION
On touch devices the playback position could only be changed by dragging. `CustomDefaultTimeBar.onTouchEvent` swallowed an `ACTION_DOWN` landing farther than 24dp from the scrubber head, so `DefaultTimeBar` never started scrubbing and a plain tap on the bar did nothing.

The swallowed press is now replayed to the base class at the moment the gesture is resolved:

* on `ACTION_UP` with no drag — a tap, which seeks to the touched point;
* on `ACTION_MOVE` past the existing 6dp threshold — a drag started away from the head.

Pressing the bar still does nothing visible while the finger is down; the seek happens on release. Dragging behaves as before.

The drag path previously reached the private `DefaultTimeBar.startScrubbing(long)` by reflection and passed a literal `0`, so `onScrubStart` reported position zero and the player briefly seeked to the start of the file before the first `onScrubMove` corrected it. The replayed press carries the real position, so that reflection and the glitch are gone.

The synthesized press is clamped onto the bar: by the time a drag is recognised the finger may already have left the 48dp touch band (dragging off the bar is how fine scrubbing is started), and the base class ignores a press outside it.

Worth checking on a device: tap far from the head while playing and while paused, taps at both ends of the bar, drag from the head, drag starting away from the head, fine scrubbing (drag off the bar, then sideways), and that the bottom bar buttons are still clickable — the bar's touch band overlaps their top ~9dp.