### PR TITLE
Stay paused after a trip to the background

### DIFF
--- a/app/src/main/java/com/brouken/player/PlayerActivity.java
+++ b/app/src/main/java/com/brouken/player/PlayerActivity.java
@@ -283,11 +283,15 @@ public class PlayerActivity extends Activity {
         }
     };
     // Backgrounding keeps the player (see onStop) instead of tearing it down, so a quick round-trip —
-    // settings, notification shade, app switch — returns to the same session instead of re-buffering the
-    // stream. The decoder is held for it, so give up on the session once the user is plainly gone: after
+    // settings, notification shade, app switch — returns to the same session, paused, instead of
+    // re-buffering the stream. The decoder is held for it, so give up once the user is plainly gone: after
     // this the teardown is the same as before. Tune if holding a decoder that long proves a problem.
-    private static final long BACKGROUND_RELEASE_MS = TimeUnit.MINUTES.toMillis(2);
-    private final Runnable backgroundReleaseRunnable = () -> releasePlayer(false);
+    private static final long BACKGROUND_RELEASE_MS = TimeUnit.MINUTES.toMillis(5);
+    private final Runnable backgroundReleaseRunnable = () -> {
+        // The return finds no player and rebuilds it; that rebuild must not start playing on its own.
+        sourceSwitchKeepPaused = true;
+        releasePlayer(false);
+    };
     // How long a resumed session gets to put a frame back on screen. The retained player is attached to a
     // SurfaceView that was destroyed while we were away, and on a slow box the decoder does not always
     // hand the surface back (Media3 reports that as ERROR_CODE_TIMEOUT — but not always at all).
@@ -297,11 +301,19 @@ public class PlayerActivity extends Activity {
         if (player == null || resumeFrameRendered) {
             return;
         }
-        // Ready and playing, yet nothing has been drawn — or stopped outright: treat the retained session
-        // as dead and rebuild it. Position and meta were saved in onPause. Buffering is deliberately left
-        // alone: coming back to a slow stream is not a broken surface.
+        // Nothing has been drawn since we came back — or the player stopped outright: treat the retained
+        // session as dead and rebuild it. Position and meta were saved in onPause. Playback is paused on
+        // return, which is no excuse for a black frame: a paused player still re-renders when the surface
+        // comes back (setOutput drops firstFrameState to FIRST_FRAME_NOT_RENDERED, which releases a frame
+        // whether started or not). It does not "join" while paused though, so until that frame lands the
+        // renderer reports not-ready and the player sits in BUFFERING rather than READY — which is why
+        // buffering counts here. What separates it from an honestly slow stream is the buffer: the retained
+        // session still holds the one it had. Audio-only media never renders a frame, so it is exempt.
         final int state = player.getPlaybackState();
-        if (state == Player.STATE_IDLE || (state == Player.STATE_READY && player.getPlayWhenReady())) {
+        final boolean stalledWithData = (state == Player.STATE_READY || state == Player.STATE_BUFFERING)
+                && player.getVideoFormat() != null && player.getTotalBufferedDuration() > 0;
+        if (state == Player.STATE_IDLE || stalledWithData) {
+            sourceSwitchKeepPaused = true;
             releasePlayer(false);
             initializePlayer();
         }
@@ -411,7 +423,9 @@ public class PlayerActivity extends Activity {
     private boolean restoreOrientationLock;
     private boolean restorePlayState;
     private boolean restorePlayStateAllowed;
-    private boolean play;
+    // "Start playing once the player is ready". Read live by Utils.playIfCan, whose frame-rate probe runs on
+    // a background thread: a snapshot taken before it started would still play after onStop cleared this.
+    boolean play;
     private float subtitlesScale;
     private boolean isScrubbing;
     private boolean scrubbingNoticeable;
@@ -534,8 +548,9 @@ public class PlayerActivity extends Activity {
     private boolean skipSeenThisSession;
     private static final double SKIP_OFFSET_MAX_SEC = 30;   // ± range of the offset slider
     private static final double SKIP_OFFSET_STEP_SEC = 0.25; // fine step (touch / ± buttons)
-    // Set before a SOURCE-switch reinitialisation so the player keeps a paused state (initializePlayer
-    // otherwise force-plays under apiAccess). Consumed once inside initializePlayer.
+    // Set before a reinitialisation that must not auto-play — a SOURCE switch, or any rebuild caused by
+    // returning to the foreground (initializePlayer otherwise force-plays under apiAccess or at position
+    // zero). Consumed once inside initializePlayer.
     boolean sourceSwitchKeepPaused;
     List<MediaItem.SubtitleConfiguration> apiSubs = new ArrayList<>();
     boolean intentReturnResult;
@@ -1615,20 +1630,21 @@ public class PlayerActivity extends Activity {
             Utils.toggleSystemUi(this, playerView, true);
         }
         playerView.removeCallbacks(backgroundReleaseRunnable);
+        // Coming back never resumes playback — that is the user's call. Clear the latch before anything
+        // below can read it: whatever the trip to the background interrupted (a scrub drag) may have left
+        // it armed, and a rebuild here or in onActivityResult would consume it as "play". Show the
+        // controls with it, so the return lands on an obviously paused player and not a frozen frame.
+        restorePlayState = false;
+        playerView.showController();
         if (player == null) {
             initializePlayer();
         } else if (player.getPlayerError() != null) {
             // The session survived being backgrounded but the player did not: Media3 stops it when the
             // surface detach times out (see onPlayerError), so resuming would show a dead picture.
+            sourceSwitchKeepPaused = true;
             releasePlayer(false);
             initializePlayer();
         } else {
-            if (restorePlayState) {
-                restorePlayState = false;
-                playerView.showController();
-                playerView.setControllerShowTimeoutMs(PlayerActivity.CONTROLLER_TIMEOUT);
-                player.setPlayWhenReady(true);
-            }
             resumeFrameRendered = false;
             playerView.postDelayed(resumeWatchdogRunnable, RESUME_WATCHDOG_MS);
         }
@@ -1669,12 +1685,17 @@ public class PlayerActivity extends Activity {
         }
         // Otherwise keep the player and only stop the sound: a rebuild would re-buffer the stream and
         // drop everything that lives on the instance (quality override, selected tracks, lock).
-        if (player.isPlaying()) {
-            if (restorePlayStateAllowed) {
-                restorePlayState = true;
-            }
-            player.pause();
+        // Unconditional, and the pending auto-play with it: while buffering isPlaying() is false but
+        // playWhenReady is set, and the STATE_READY handler would call play() the moment the buffer fills,
+        // leaving video playing with sound in the background. Nothing is latched for a resume.
+        play = false;
+        // The frame-rate switch registers this listener while waiting to auto-play; with play cleared behind
+        // its back it would never unregister itself.
+        if (displayManager != null && displayListener != null) {
+            displayManager.unregisterDisplayListener(displayListener);
         }
+        player.pause();
+        playerView.removeCallbacks(resumeWatchdogRunnable);
         playerView.postDelayed(backgroundReleaseRunnable, BACKGROUND_RELEASE_MS);
     }
 
@@ -1817,6 +1838,9 @@ public class PlayerActivity extends Activity {
             final String action = intent.getAction();
             final String type = intent.getType();
             final Uri uri = intent.getData();
+            // New media, not a return: it must play even if a background teardown armed the keep-paused
+            // one-shot while we were away (this can be delivered before onStart consumes it).
+            sourceSwitchKeepPaused = false;
 
             if (Intent.ACTION_VIEW.equals(action) && uri != null) {
                 // Keep getIntent() pointing at what is actually playing (used by the intent report).
@@ -4653,6 +4677,7 @@ public class PlayerActivity extends Activity {
             // but options like the decoder priority or tunneling are baked into it at build time. So
             // rebuild when the screen actually changed something — going in for a look costs nothing.
             if (player != null && !settingsBefore.equals(mPrefs.snapshot())) {
+                sourceSwitchKeepPaused = true;
                 releasePlayer();
                 initializePlayer();
             }
@@ -4749,6 +4774,15 @@ public class PlayerActivity extends Activity {
             skipMediaAfterFatalError = false;
             haveMedia = false;
         }
+
+        // A reinitialisation that must not auto-play — a SOURCE quality switch, or a rebuild triggered by
+        // returning to the foreground; otherwise apiAccess or a zero position would force it. Consumed here
+        // rather than next to its use below, which the empty state skips: the flag must never outlive this
+        // call and suppress the next file the user opens.
+        final boolean keepPaused = sourceSwitchKeepPaused;
+        sourceSwitchKeepPaused = false;
+        // A watchdog armed for the player being replaced must not judge the fresh one.
+        resumeFrameRendered = true;
 
         // Unless this is the stuck-playback recovery rebuild (which must keep forceHevcForDolbyVision),
         // clear the one-shot Dolby Vision recovery state so a normal open plays DV through its regular
@@ -5040,10 +5074,6 @@ public class PlayerActivity extends Activity {
 
             updateLoading(true);
 
-            // A SOURCE quality-switch that was paused must stay paused after reinitialisation; otherwise
-            // apiAccess would force auto-play. Consume the one-shot flag here.
-            final boolean keepPaused = sourceSwitchKeepPaused;
-            sourceSwitchKeepPaused = false;
             if ((mPrefs.getPosition() == 0L || apiAccess || apiAccessPartial) && !keepPaused) {
                 play = true;
             }
@@ -5080,7 +5110,9 @@ public class PlayerActivity extends Activity {
         player.addListener(playerListener);
         player.prepare();
 
-        if (restorePlayState) {
+        // Only while the activity is up: a recovery rebuild posted from onPlayerError can land after the user
+        // has already left, and resuming there would play in the background.
+        if (restorePlayState && alive) {
             restorePlayState = false;
             playerView.showController();
             playerView.setControllerShowTimeoutMs(PlayerActivity.CONTROLLER_TIMEOUT);
@@ -5763,7 +5795,7 @@ public class PlayerActivity extends Activity {
                             }
                             displayManager.registerDisplayListener(displayListener, null);
                         }
-                        switched = Utils.switchFrameRate(PlayerActivity.this, mPrefs.mediaUri, play);
+                        switched = Utils.switchFrameRate(PlayerActivity.this, mPrefs.mediaUri);
                     }
                     if (!switched) {
                         if (displayManager != null) {
@@ -6011,7 +6043,9 @@ public class PlayerActivity extends Activity {
         }
         player.setMediaItems(items, index, position);
         player.prepare();
-        player.play();
+        if (alive) {
+            player.play();
+        }
         return true;
     }
 

--- a/app/src/main/java/com/brouken/player/Utils.java
+++ b/app/src/main/java/com/brouken/player/Utils.java
@@ -593,7 +593,7 @@ class Utils {
     }
 
     @RequiresApi(api = Build.VERSION_CODES.M)
-    static void handleFrameRate(final PlayerActivity activity, float frameRate, boolean play) {
+    static void handleFrameRate(final PlayerActivity activity, float frameRate) {
         activity.runOnUiThread(() -> {
             boolean switchingModes = false;
 
@@ -653,13 +653,15 @@ class Utils {
             }
 
             if (!switchingModes) {
-                playIfCan(activity, play);
+                playIfCan(activity);
             }
         });
     }
 
-    static void playIfCan(final PlayerActivity activity, boolean play) {
-        if (play) {
+    // Reads activity.play now rather than a value captured before the frame-rate probe ran: that probe takes
+    // seconds on a network file, and the user may have left in the meantime (onStop clears it).
+    static void playIfCan(final PlayerActivity activity) {
+        if (activity.play) {
             if (PlayerActivity.player != null)
                 PlayerActivity.player.play();
             if (activity.playerView != null)
@@ -922,7 +924,7 @@ class Utils {
         return frameRate;
     }
 
-    public static boolean switchFrameRate(final PlayerActivity activity, final Uri uri, final boolean play) {
+    public static boolean switchFrameRate(final PlayerActivity activity, final Uri uri) {
         // preferredDisplayModeId only available on SDK 23+
         // ExoPlayer already uses Surface.setFrameRate() on Android 11+
         if (Build.VERSION.SDK_INT >= 23) {
@@ -931,7 +933,7 @@ class Utils {
             }
             activity.frameRateSwitchThread = new Thread(() -> {
                 float frameRate = getFrameRate(activity, uri);
-                Utils.handleFrameRate(activity, frameRate, play);
+                Utils.handleFrameRate(activity, frameRate);
             });
             activity.frameRateSwitchThread.start();
             return true;


### PR DESCRIPTION
`onStop` keeps the player alive across a background trip instead of tearing it down, so a quick round-trip returns to the same session. It also armed `restorePlayState`, which made `onStart` call `setPlayWhenReady(true)` — coming back started playing on its own. Now leaving pauses for good and returning leaves it paused; the user decides when playback continues. The retained session gets **five minutes** instead of two before the delayed teardown frees the decoder.

**Pausing is unconditional.** `isPlaying()` is false while buffering, so the old `if (player.isPlaying())` skipped the pause, and the auto-play staged in the `play` field was still consumed by the `STATE_READY` handler once the buffer filled — video playing with sound behind other apps. `onStop` now clears `play` as well. Three more paths could start playback while the activity was down and are gated on `alive`:

* `Utils.playIfCan` took `play` by value before the frame-rate probe (a `MediaExtractor` read that takes seconds on a network file) ran on its background thread; it now reads the live field, and the parameter is gone from `switchFrameRate`/`handleFrameRate`.
* `recoverFromContainerError` called `player.play()` unconditionally from `onPlayerError`.
* The tail of `initializePlayer` resumed on `restorePlayState`, which the stuck-playback and audio-mime recoveries set before posting a rebuild.

**Rebuilds on the way back must not auto-play.** `initializePlayer` forces playback when the position is zero or under `apiAccess`, so the teardown timer, the dead-retained-player branch of `onStart`, the resume watchdog and a settings change that rebuilds all arm the existing keep-paused one-shot. Its consume moved to the top of `initializePlayer` — it used to sit inside the `haveMedia` branch, so a rebuild that landed in the empty state left the flag armed and silently suppressed the next file the user opened. `onNewIntent` clears it: opening media is not a return.

**The resume watchdog had to follow.** It rebuilds a retained player that cannot put a frame back on a SurfaceView destroyed while away. A paused renderer does not join, so until the recreated surface takes a frame the player reports `BUFFERING`, not `READY` — the old condition would have stopped covering exactly the case it exists for, leaving a spinner and a load timeout instead of a 3s rebuild. Buffering now counts, with the buffer the retained session still holds as the discriminator against an honestly slow stream, and audio-only media (which never renders a frame) is exempt instead of being rebuilt in a loop.

Also fixed: the `DisplayListener` registered by the frame-rate switch unregisters itself only while `play` is set, so clearing it in `onStop` would have leaked the listener; and the return now shows the controls, since the auto-hide scheduled by pausing runs while the activity is stopped and used to leave the user on a frozen frame with no buttons.

PiP is untouched — `onStop` does not run while the PiP window is up. Scrubbing, quality switching and the error-recovery rebuilds keep their own resume behaviour.

Worth checking on a device: Home and return; the settings screen with and without changing anything; backgrounding while buffering (no audio from the background); more than five minutes away; an audio-only file; opening a new file from a chooser and from another app (must start playing); PiP.