### PR TITLE
Stop the download when a load never starts playing

### DIFF
--- a/app/src/main/java/com/brouken/player/PlayerActivity.java
+++ b/app/src/main/java/com/brouken/player/PlayerActivity.java
@@ -4781,8 +4781,12 @@ public class PlayerActivity extends Activity {
         // call and suppress the next file the user opens.
         final boolean keepPaused = sourceSwitchKeepPaused;
         sourceSwitchKeepPaused = false;
-        // A watchdog armed for the player being replaced must not judge the fresh one.
+        // A watchdog armed for the player being replaced must not judge the fresh one. The load watchdog
+        // needs saying too: the teardown below is inline rather than releasePlayer(), which is where it
+        // would otherwise be cancelled, and callers that replace a still-buffering player (onNewIntent,
+        // a playlist pick) would leave it armed to stop the new session 30 s in.
         resumeFrameRendered = true;
+        cancelLoadWatchdog();
 
         // Unless this is the stuck-playback recovery rebuild (which must keep forceHevcForDolbyVision),
         // clear the one-shot Dolby Vision recovery state so a normal open plays DV through its regular
@@ -5402,9 +5406,19 @@ public class PlayerActivity extends Activity {
         if (player == null) {
             return;
         }
-        // A silent stall (buffering never reached READY). Not sent to Sentry — it is usually an
-        // upstream/network condition, not an app bug — just surface a friendly message with its code.
+        // A silent stall (buffering never reached READY). Stop the loaders: they keep pulling bytes for as
+        // long as the player sits in BUFFERING, and hiding the spinner below hides the rate readout with
+        // it, so the wait turns into an invisible download that shows nothing. Stopped, not released or
+        // rebuilt — that is what strands a codec on a wedged playback thread; stop() is only a message to
+        // it. STATE_IDLE keeps the timeline and the position, so the play button (dispatchPlayPause ->
+        // handlePlayButtonAction) re-prepares this very item, which is what the message asks for.
+        player.stop();
+        // Not sent to Sentry — it is usually an upstream/network condition, not an app bug.
         updateLoading(false);
+        // Entering the wait disabled the episode arrows (showLoadingRunnable) and only STATE_READY and the
+        // error paths ever re-enabled them, so a timeout left the one escape from a stuck episode dead.
+        // They work from here: stepEpisodeWhileIdle reloads out of an idle player.
+        setEpisodeNavLoading(false);
         showSnack(getString(R.string.error_playback_timeout), null);
     }
 


### PR DESCRIPTION
A user reported that a 4K stream "never finishes buffering, and then the internet gets eaten somewhere, but there is no content" — and pointed out that the timeout was in the player, not in the server's response: bytes kept arriving the whole time.

A screen recording confirms it. The stream opens, the spinner and the transfer rate readout cycle between 0.9 and 2.8 MB/s for 30 s with the position at `00:00`, the timeout message appears — and then the spinner and the rate readout disappear, the centre button shows **pause**, the position is still `00:00`, and the duration silently drifts from `13:53` to `13:27` because the container is still being read. Traffic keeps flowing until the user leaves the screen.

## Cause

`reportVideoLoadTimeout` reported and stepped aside; it never touched the player. ExoPlayer stayed in `STATE_BUFFERING` and its loaders kept pulling bytes forever. The same `updateLoading(false)` that hid the spinner also killed the transfer rate readout — it only re-arms on a fresh `STATE_BUFFERING`, which never comes — and restored the play/pause button, which Media3 draws as *pause* since `playWhenReady` was still set. So the message asked the user to try again while the only affordance on screen poked a still-buffering player.

## Fix

`player.stop()` before the message. Stopped, not released or rebuilt: releasing is what strands a hardware codec on a wedged playback thread, while `stop()` is only a message to that thread. `STATE_IDLE` keeps the timeline and the position, so the centre button becomes *play* on its own and the existing `dispatchPlayPause` path re-prepares the same item — "Please try again" is now a working action, with no new UI and no new string.

Two things found alongside it:

- The episode arrows were disabled on entering the wait and only re-enabled at `STATE_READY` or by the error paths, so a timeout left the one escape from a stuck episode permanently dead. Cleared here too.
- `initializePlayer` tears the previous player down inline instead of going through `releasePlayer`, where the watchdog is cancelled. Replacing a still-buffering player — sharing a video into the running player, picking from a playlist — therefore left a stale watchdog armed. Harmless before this change; with it, it would stop a healthy new session 30 s in. Cancelled next to the sibling reset that already exists for exactly this reason.

## Deliberately out of scope

No auto-retry or rebuild from this watchdog: a previous attempt at that regressed badly by stranding a codec, and one tap on play is the price of not repeating it. No `LoadControl` or HTTP timeout tuning either — data was arriving at 2.8 MB/s, so this was never a network profile problem.

Known limit: if the playback thread is genuinely wedged, `stop()`'s message is never processed and loading would not stop. Only `release()` reaches that case, which is the regression above. The reported case had a live playback thread.

## Verification

Manual (no test infrastructure in this project). After the timeout message: the centre button reads *play* rather than *pause*, and the app's traffic counter stays flat where it previously grew by ~2 MB/s. Tapping play re-prepares from the kept position. Episode arrows move to another episode. Normal HTTP, local and HLS playback reach ready well inside the window and are unaffected; sharing a new video into a still-buffering player keeps playing past the 30 s mark.
