### PR TITLE
Add a "System volume" setting

### DIFF
--- a/app/src/main/java/com/brouken/player/CustomPlayerView.java
+++ b/app/src/main/java/com/brouken/player/CustomPlayerView.java
@@ -13,7 +13,6 @@ import android.view.View;
 import android.widget.FrameLayout;
 import android.widget.ImageButton;
 import android.widget.TextView;
-import android.widget.Toast;
 
 import androidx.core.view.GestureDetectorCompat;
 import androidx.media3.common.C;
@@ -37,7 +36,6 @@ public class CustomPlayerView extends PlayerView implements GestureDetector.OnGe
     private long seekLastPosition;
     public boolean seekProgress;
     private boolean boostAllowed = false;
-    private boolean boostWarned = false;
     private boolean canSetAutoBrightness = false;
     // Volume in percent (0-200, above 100 = boost) tracked as a float so the absolute gesture keeps
     // sub-step precision between events.
@@ -174,7 +172,6 @@ public class CustomPlayerView extends PlayerView implements GestureDetector.OnGe
         gestureScrollX = 0;
         gestureOrientation = Orientation.UNKNOWN;
         isHandledLongPress = false;
-        boostWarned = false;
 
         return false;
     }
@@ -310,11 +307,6 @@ public class CustomPlayerView extends PlayerView implements GestureDetector.OnGe
                 brightnessControl.changeBrightness(this, delta, canSetAutoBrightness);
             } else {
                 gestureVolume = Math.max(0f, Math.min(boostAllowed ? 200f : 100f, gestureVolume + delta));
-                // Warn once per gesture when reaching the loud zone, whether boost engages or is refused
-                if (gestureVolume >= 100f && delta > 0 && !boostWarned) {
-                    boostWarned = true;
-                    Toast.makeText(getContext(), R.string.volume_high_warning, Toast.LENGTH_SHORT).show();
-                }
                 Utils.setVolumePercent(getContext(), mAudioManager, this, gestureVolume);
             }
         }

--- a/app/src/main/java/com/brouken/player/PlayerActivity.java
+++ b/app/src/main/java/com/brouken/player/PlayerActivity.java
@@ -323,9 +323,19 @@ public class PlayerActivity extends Activity {
     public static Snackbar snackbar;
     private ExoPlaybackException errorToShow;
     public static int boostLevel = 0;
+    // Whether the hearing warning has already been shown this session, see Utils.warnAboutBoost
+    public static boolean boostWarned = false;
+    // Off = volume gestures and keys drive the player alone and never touch the device's stream. Mirrors
+    // Prefs.systemVolume, except on TV boxes where volume has to go through the system (CEC).
+    public static boolean systemVolume = true;
+    // The player's own level, 0-100, only meaningful while systemVolume is off. Anything above 100 lives
+    // in boostLevel, exactly as in the synced mode.
+    public static float playerVolume = 100f;
     private boolean isScaling = false;
     private boolean isScaleStarting = false;
     private float scaleFactor = 1.0f;
+    // Preference state as it was when the settings screen opened, see openSettings()
+    private Map<String, ?> settingsBefore;
 
     private static final int REQUEST_CHOOSER_VIDEO = 1;
     private static final int REQUEST_CHOOSER_SUBTITLE = 2;
@@ -617,6 +627,11 @@ public class PlayerActivity extends Activity {
     protected void onCreate(Bundle savedInstanceState) {
         // Rotate ASAP, before super/inflating to avoid glitches with activity launch animation
         mPrefs = new Prefs(this);
+        systemVolume = mPrefs.systemVolume;
+        playerVolume = mPrefs.volume;
+        // Boost is session state kept in statics, so a launch must not inherit it from the last one
+        boostLevel = 0;
+        boostWarned = false;
         Utils.setOrientation(this, mPrefs.orientation);
 
         super.onCreate(savedInstanceState);
@@ -809,8 +824,7 @@ public class PlayerActivity extends Activity {
         buttonMore.setContentDescription(getString(R.string.button_more));
         buttonMore.setOnClickListener(view -> showMoreMenu());
         buttonMore.setOnLongClickListener(view -> {
-            Intent intent = new Intent(this, SettingsActivity.class);
-            startActivityForResult(intent, REQUEST_SETTINGS);
+            openSettings();
             return true;
         });
 
@@ -4410,8 +4424,7 @@ public class PlayerActivity extends Activity {
         items.add(new MenuItem(R.drawable.ic_folder_open_24dp, getString(R.string.empty_state_open), null, false, () -> openFile(mPrefs.mediaUri)));
         items.add(new MenuItem(R.drawable.ic_link_24dp, getString(R.string.empty_state_link), null, false, this::askForLink));
         // "More" → the full app settings screen (long-pressing the gear opens it directly, too).
-        items.add(new MenuItem(R.drawable.ic_settings_24dp, getString(R.string.button_more), null, false, () ->
-                startActivityForResult(new Intent(this, SettingsActivity.class), REQUEST_SETTINGS)));
+        items.add(new MenuItem(R.drawable.ic_settings_24dp, getString(R.string.button_more), null, false, this::openSettings));
         showSideMenu(getString(R.string.pref_title), items);
     }
 
@@ -4669,14 +4682,19 @@ public class PlayerActivity extends Activity {
                 }
             }
         } else if (requestCode == REQUEST_SETTINGS) {
-            final Map<String, ?> settingsBefore = mPrefs.snapshot();
+            final Map<String, ?> before = settingsBefore;
+            settingsBefore = null;
             mPrefs.loadUserPreferences();
+            systemVolume = mPrefs.systemVolume;
+            // Also switch the volume path over here, so it is right even when nothing below rebuilds
+            applyVolumeMode();
             updateSubtitleStyle(this);
             updateOverlayClock();
             // Coming back from the settings screen no longer rebuilds the player by itself (see onStop),
             // but options like the decoder priority or tunneling are baked into it at build time. So
             // rebuild when the screen actually changed something — going in for a look costs nothing.
-            if (player != null && !settingsBefore.equals(mPrefs.snapshot())) {
+            // A missing snapshot means the activity was recreated meanwhile, so rebuild to be safe.
+            if (player != null && (before == null || !before.equals(mPrefs.snapshot()))) {
                 sourceSwitchKeepPaused = true;
                 releasePlayer();
                 initializePlayer();
@@ -4987,6 +5005,7 @@ public class PlayerActivity extends Activity {
                 .setContentType(C.AUDIO_CONTENT_TYPE_MOVIE)
                 .build();
         player.setAudioAttributes(audioAttributes, true);
+        applyVolumeMode();
 
         if (mPrefs.skipSilence) {
             player.setSkipSilenceEnabled(true);
@@ -5068,6 +5087,7 @@ public class PlayerActivity extends Activity {
                     loudnessEnhancer.release();
                 }
                 loudnessEnhancer = new LoudnessEnhancer(player.getAudioSessionId());
+                Utils.applyBoost();
             } catch (Exception e) {
                 e.printStackTrace();
             }
@@ -5124,7 +5144,30 @@ public class PlayerActivity extends Activity {
         }
     }
 
+    /**
+     * Opens the settings screen, recording the preference state first. The screen writes into the same
+     * SharedPreferences instance this activity reads, so the "did anything actually change" comparison
+     * has to be against a snapshot taken before it opens — taking one on the way back always compares
+     * the new state with itself.
+     */
+    private void openSettings() {
+        settingsBefore = mPrefs.snapshot();
+        startActivityForResult(new Intent(this, SettingsActivity.class), REQUEST_SETTINGS);
+    }
+
+    /**
+     * Restores the isolated level on a fresh player, and clears the attenuation whenever the system
+     * volume is in charge, so switching the setting back can never leave the player quietened.
+     */
+    private void applyVolumeMode() {
+        if (player != null) {
+            player.setVolume(systemVolume ? 1f : Math.min(playerVolume, 100f) / 100f);
+        }
+    }
+
     private void savePlayer() {
+        // Outside the player guard: the error screen keeps the volume gestures alive without a player.
+        mPrefs.updateVolume(Math.round(playerVolume));
         if (player != null) {
             mPrefs.updateBrightness(Math.round(mBrightnessControl.percent));
             mPrefs.updateOrientation();
@@ -5178,8 +5221,7 @@ public class PlayerActivity extends Activity {
 
         open.setOnClickListener(v -> openFile(mPrefs.mediaUri));
         link.setOnClickListener(v -> askForLink());
-        settings.setOnClickListener(v ->
-                startActivityForResult(new Intent(this, SettingsActivity.class), REQUEST_SETTINGS));
+        settings.setOnClickListener(v -> openSettings());
         stopEmptyStatePulse();
 
         // TV is viewed from across the room; scale the phone-tuned sizes up, matching the
@@ -5541,6 +5583,7 @@ public class PlayerActivity extends Activity {
                     loudnessEnhancer.release();
                 }
                 loudnessEnhancer = new LoudnessEnhancer(audioSessionId);
+                Utils.applyBoost();
             } catch (Exception e) {
                 e.printStackTrace();
             }

--- a/app/src/main/java/com/brouken/player/Prefs.java
+++ b/app/src/main/java/com/brouken/player/Prefs.java
@@ -30,6 +30,7 @@ class Prefs {
     private static final String PREF_KEY_MEDIA_TYPE = "mediaType";
     private static final String PREF_KEY_BRIGHTNESS = "brightness"; // legacy 0-30 levels, migrated on load
     private static final String PREF_KEY_BRIGHTNESS_PERCENT = "brightnessPercent";
+    private static final String PREF_KEY_VOLUME_PERCENT = "volumePercent";
     private static final String PREF_KEY_FIRST_RUN = "firstRun";
     private static final String PREF_KEY_SUBTITLE_URI = "subtitleUri";
 
@@ -60,6 +61,7 @@ class Prefs {
     private static final String PREF_KEY_SKIP_FETCH = "skipFetchOnline";
     private static final String PREF_KEY_SKIP_HIDE_LOCKED = "skipHideWhenLocked";
     private static final String PREF_KEY_SHOW_CLOCK = "showClock";
+    private static final String PREF_KEY_SYSTEM_VOLUME = "systemVolume";
     private static final String PREF_KEY_CRASH_REPORTING = "crashReporting";
     private static final String PREF_KEY_AUTO_UPDATE = "autoUpdate";
     private static final String PREF_KEY_UPDATE_LAST_CHECK = "updateLastCheck";
@@ -93,6 +95,8 @@ class Prefs {
     public String audioTrackId;
 
     public int brightness = -1;
+    // The player's own volume, only used while systemVolume is off (see Utils.applyPlayerVolume)
+    public int volume = 100;
     public boolean firstRun = true;
     public boolean askScope = true;
     public boolean autoPiP = false;
@@ -114,6 +118,7 @@ class Prefs {
     public boolean skipHideWhenLocked = false;
     public boolean skipFetchOnline = true;
     public boolean showClock = false;
+    public boolean systemVolume = true;
     public boolean crashReporting = true;
     public boolean autoUpdate = true;
     public long updateLastCheck = 0L;
@@ -146,6 +151,7 @@ class Prefs {
             final int level = mSharedPreferences.getInt(PREF_KEY_BRIGHTNESS, -1);
             brightness = level < 0 ? -1 : level * 100 / 30;
         }
+        volume = mSharedPreferences.getInt(PREF_KEY_VOLUME_PERCENT, volume);
         firstRun = mSharedPreferences.getBoolean(PREF_KEY_FIRST_RUN, firstRun);
         if (mSharedPreferences.contains(PREF_KEY_SUBTITLE_URI))
             subtitleUri = Uri.parse(mSharedPreferences.getString(PREF_KEY_SUBTITLE_URI, null));
@@ -186,6 +192,9 @@ class Prefs {
         skipFetchOnline = mSharedPreferences.getBoolean(PREF_KEY_SKIP_FETCH, skipFetchOnline);
         skipHideWhenLocked = mSharedPreferences.getBoolean(PREF_KEY_SKIP_HIDE_LOCKED, skipHideWhenLocked);
         showClock = mSharedPreferences.getBoolean(PREF_KEY_SHOW_CLOCK, showClock);
+        // Forced on for TV boxes, where the remote routes volume to the panel or receiver over CEC and
+        // only the system stream responds — the setting is hidden there too.
+        systemVolume = Utils.isTvBox(mContext) || mSharedPreferences.getBoolean(PREF_KEY_SYSTEM_VOLUME, systemVolume);
         crashReporting = mSharedPreferences.getBoolean(PREF_KEY_CRASH_REPORTING, crashReporting);
         autoUpdate = mSharedPreferences.getBoolean(PREF_KEY_AUTO_UPDATE, autoUpdate);
         revokedAudioMimes = mSharedPreferences.getStringSet(PREF_KEY_REVOKED_AUDIO_MIMES, revokedAudioMimes);
@@ -259,6 +268,13 @@ class Prefs {
             sharedPreferencesEditor.putInt(PREF_KEY_BRIGHTNESS_PERCENT, brightness);
             sharedPreferencesEditor.apply();
         }
+    }
+
+    public void updateVolume(final int volume) {
+        this.volume = volume;
+        final SharedPreferences.Editor sharedPreferencesEditor = mSharedPreferences.edit();
+        sharedPreferencesEditor.putInt(PREF_KEY_VOLUME_PERCENT, volume);
+        sharedPreferencesEditor.apply();
     }
 
     public void markFirstRun() {

--- a/app/src/main/java/com/brouken/player/SettingsActivity.java
+++ b/app/src/main/java/com/brouken/player/SettingsActivity.java
@@ -114,6 +114,12 @@ public class SettingsActivity extends AppCompatActivity {
                     preferenceAllowSystemFrameRate.setChecked(!Utils.isTvBox(getContext()));
                 }
             }
+            Preference preferenceSystemVolume = findPreference("systemVolume");
+            if (preferenceSystemVolume != null && Utils.isTvBox(getContext())) {
+                // TV remotes route volume to the panel or receiver over CEC, where only the system
+                // stream responds — an isolated player volume would look broken there.
+                preferenceSystemVolume.setVisible(false);
+            }
             ListPreference listPreferenceFileAccess = findPreference("fileAccess");
             if (listPreferenceFileAccess != null) {
                 List<String> entries = new ArrayList<>(Arrays.asList(getResources().getStringArray(R.array.file_access_entries)));

--- a/app/src/main/java/com/brouken/player/Utils.java
+++ b/app/src/main/java/com/brouken/player/Utils.java
@@ -40,6 +40,7 @@ import android.view.WindowInsetsController;
 import android.view.WindowManager;
 import android.widget.FrameLayout;
 import android.widget.ImageButton;
+import android.widget.Toast;
 
 import androidx.annotation.RequiresApi;
 import androidx.core.text.HtmlCompat;
@@ -202,6 +203,8 @@ class Utils {
     public static int getVolumePercent(final Context context, final AudioManager audioManager) {
         if (PlayerActivity.boostLevel > 0)
             return 100 + PlayerActivity.boostLevel * 10;
+        if (!PlayerActivity.systemVolume)
+            return Math.round(PlayerActivity.playerVolume);
         final int max = getVolume(context, true, audioManager);
         if (max <= 0)
             return 0;
@@ -217,7 +220,12 @@ class Utils {
         }
     }
 
-    private static void applyBoost() {
+    /**
+     * Pushes boostLevel into the effect. Also called right after a LoudnessEnhancer is created, because
+     * boostLevel outlives both the effect and the activity, so a fresh effect starts at zero gain while
+     * the level still says otherwise.
+     */
+    static void applyBoost() {
         if (PlayerActivity.loudnessEnhancer == null)
             return;
         try {
@@ -229,26 +237,52 @@ class Utils {
     }
 
     /**
-     * Absolute volume set from the vertical gesture: 0-100% maps onto the system range, 101-200% keeps
-     * the system volume maxed out and adds boost. Displayed value is read back, so it never overstates
-     * what was actually applied.
+     * Hearing warning for the boost zone, shown once per session however the volume was raised — gesture,
+     * hardware keys, mouse wheel or joystick all end up here.
+     */
+    private static void warnAboutBoost(final Context context) {
+        if (PlayerActivity.boostWarned || PlayerActivity.boostLevel <= 0)
+            return;
+        PlayerActivity.boostWarned = true;
+        Toast.makeText(context, R.string.volume_high_warning, Toast.LENGTH_SHORT).show();
+    }
+
+    /**
+     * The player's own attenuation, used instead of the system stream when systemVolume is off. It is a
+     * multiplier on top of the system volume, so 100% means "as loud as the device currently is".
+     */
+    static void applyPlayerVolume() {
+        if (PlayerActivity.player != null)
+            PlayerActivity.player.setVolume(PlayerActivity.playerVolume / 100f);
+    }
+
+    /**
+     * Absolute volume set from the vertical gesture: 0-100% maps onto the system range (or onto the
+     * player's own attenuation while systemVolume is off), 101-200% leaves that maxed out and adds boost.
+     * Displayed value is read back, so it never overstates what was actually applied.
      */
     public static void setVolumePercent(final Context context, final AudioManager audioManager, final CustomPlayerView playerView, final float percent) {
         playerView.removeCallbacks(playerView.textClearRunnable);
 
-        final int max = audioManager.getStreamMaxVolume(AudioManager.STREAM_MUSIC);
-        final int index = Math.round(Math.min(percent, 100f) / 100f * max);
-        if (index != audioManager.getStreamVolume(AudioManager.STREAM_MUSIC)) {
-            try {
-                audioManager.setStreamVolume(AudioManager.STREAM_MUSIC, index, 0);
-            } catch (RuntimeException e) {
-                // Setting the volume can be denied (Do Not Disturb, device policy)
-                e.printStackTrace();
+        if (PlayerActivity.systemVolume) {
+            final int max = audioManager.getStreamMaxVolume(AudioManager.STREAM_MUSIC);
+            final int index = Math.round(Math.min(percent, 100f) / 100f * max);
+            if (index != audioManager.getStreamVolume(AudioManager.STREAM_MUSIC)) {
+                try {
+                    audioManager.setStreamVolume(AudioManager.STREAM_MUSIC, index, 0);
+                } catch (RuntimeException e) {
+                    // Setting the volume can be denied (Do Not Disturb, device policy)
+                    e.printStackTrace();
+                }
             }
+        } else {
+            PlayerActivity.playerVolume = Math.min(percent, 100f);
+            applyPlayerVolume();
         }
 
         PlayerActivity.boostLevel = percent > 100f ? Math.min(10, Math.round((percent - 100f) / 10f)) : 0;
         applyBoost();
+        warnAboutBoost(context);
 
         playerView.showVolume(getVolumePercent(context, audioManager));
     }
@@ -256,30 +290,46 @@ class Utils {
     public static void adjustVolume(final Context context, final AudioManager audioManager, final CustomPlayerView playerView, final boolean raise, boolean canBoost, boolean clear) {
         playerView.removeCallbacks(playerView.textClearRunnable);
 
-        final int volume = getVolume(context,false, audioManager);
-        final int volumeMax = getVolume(context,true, audioManager);
-
-        // Handle volume changes outside the app (lose boost if volume is not maxed out)
-        if (volume != volumeMax) {
-            PlayerActivity.boostLevel = 0;
-        }
-
         if (!canBoostVolume()) {
             canBoost = false;
         }
 
-        if (volume != volumeMax || (PlayerActivity.boostLevel == 0 && !raise)) {
+        int volume = 0;
+        final boolean maxedOut;
+        if (PlayerActivity.systemVolume) {
+            volume = getVolume(context, false, audioManager);
+            maxedOut = volume == getVolume(context, true, audioManager);
+        } else {
+            // Slightly below 100 to absorb float slop from repeated steps, which would otherwise leave
+            // the level a hair under maximum and never let boost engage.
+            maxedOut = PlayerActivity.playerVolume >= 99.5f;
+        }
+
+        // Boost only exists on top of a maxed-out level, so drop it whenever the level is below that:
+        // a volume change outside the app, or a level carried over from the other volume mode.
+        if (!maxedOut) {
+            PlayerActivity.boostLevel = 0;
+        }
+
+        if (!maxedOut || (PlayerActivity.boostLevel == 0 && !raise)) {
             applyBoost();
-            audioManager.adjustStreamVolume(AudioManager.STREAM_MUSIC, raise ? AudioManager.ADJUST_RAISE : AudioManager.ADJUST_LOWER, AudioManager.FLAG_REMOVE_SOUND_AND_VIBRATE);
-            final int volumeNew = getVolume(context, false, audioManager);
-            // Custom volume step on Samsung devices (Sound Assistant)
-            if (raise && volume == volumeNew) {
-                playerView.volumeUpsInRow++;
+            if (PlayerActivity.systemVolume) {
+                audioManager.adjustStreamVolume(AudioManager.STREAM_MUSIC, raise ? AudioManager.ADJUST_RAISE : AudioManager.ADJUST_LOWER, AudioManager.FLAG_REMOVE_SOUND_AND_VIBRATE);
+                final int volumeNew = getVolume(context, false, audioManager);
+                // Custom volume step on Samsung devices (Sound Assistant)
+                if (raise && volume == volumeNew) {
+                    playerView.volumeUpsInRow++;
+                } else {
+                    playerView.volumeUpsInRow = 0;
+                }
+                if (playerView.volumeUpsInRow > 4 && !isVolumeMin(audioManager)) {
+                    audioManager.adjustStreamVolume(AudioManager.STREAM_MUSIC, AudioManager.ADJUST_RAISE, AudioManager.FLAG_REMOVE_SOUND_AND_VIBRATE | AudioManager.FLAG_SHOW_UI);
+                }
             } else {
-                playerView.volumeUpsInRow = 0;
-            }
-            if (playerView.volumeUpsInRow > 4 && !isVolumeMin(audioManager)) {
-                audioManager.adjustStreamVolume(AudioManager.STREAM_MUSIC, AudioManager.ADJUST_RAISE, AudioManager.FLAG_REMOVE_SOUND_AND_VIBRATE | AudioManager.FLAG_SHOW_UI);
+                // Same step as the system's, so the button feels the same whichever mode is on
+                final float step = 100f / Math.max(1, audioManager.getStreamMaxVolume(AudioManager.STREAM_MUSIC));
+                PlayerActivity.playerVolume = Math.max(0f, Math.min(100f, PlayerActivity.playerVolume + (raise ? step : -step)));
+                applyPlayerVolume();
             }
         } else {
             if (canBoost && raise && PlayerActivity.boostLevel < 10)
@@ -290,6 +340,7 @@ class Utils {
             applyBoost();
         }
 
+        warnAboutBoost(context);
         playerView.showVolume(getVolumePercent(context, audioManager));
 
         if (clear) {

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -77,6 +77,9 @@
     <string name="pref_show_clock">Показывать часы</string>
     <string name="pref_show_clock_on">Часы всегда в правом верхнем углу поверх видео</string>
     <string name="pref_show_clock_off">Часы показываются только с элементами управления</string>
+    <string name="pref_system_volume">Системная громкость</string>
+    <string name="pref_system_volume_on">Жесты и кнопки громкости меняют громкость медиа на устройстве</string>
+    <string name="pref_system_volume_off">Жесты и кнопки громкости меняют только этот плеер и не затрагивают громкость устройства</string>
     <string name="pref_privacy_header">Конфиденциальность</string>
     <string name="pref_crash_reporting">Отправлять отчёты о сбоях</string>
     <string name="pref_crash_reporting_on">Автоматически отправлять отчёты о сбоях и ошибках воспроизведения, чтобы помочь их исправить</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -78,6 +78,9 @@
     <string name="pref_show_clock">Показувати годинник</string>
     <string name="pref_show_clock_on">Годинник завжди у верхньому правому куті поверх відео</string>
     <string name="pref_show_clock_off">Годинник показується лише з елементами керування</string>
+    <string name="pref_system_volume">Системна гучність</string>
+    <string name="pref_system_volume_on">Жести та кнопки гучності змінюють гучність медіа на пристрої</string>
+    <string name="pref_system_volume_off">Жести та кнопки гучності змінюють лише цей плеєр і не торкаються гучності пристрою</string>
     <string name="pref_privacy_header">Приватність</string>
     <string name="pref_crash_reporting">Надсилати звіти про збої</string>
     <string name="pref_crash_reporting_on">Автоматично надсилати звіти про збої та помилки відтворення, щоб допомогти їх виправити</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -79,6 +79,9 @@
     <string name="pref_show_clock">Show clock</string>
     <string name="pref_show_clock_on">Clock stays in the top-right corner over the video</string>
     <string name="pref_show_clock_off">Clock shows only with the player controls</string>
+    <string name="pref_system_volume">System volume</string>
+    <string name="pref_system_volume_on">Volume gestures and buttons change the device media volume</string>
+    <string name="pref_system_volume_off">Volume gestures and buttons change only this player and leave the device volume alone</string>
     <string name="pref_privacy_header">Privacy</string>
     <string name="pref_crash_reporting">Send crash reports</string>
     <string name="pref_crash_reporting_on">Automatically report crashes and playback errors to help fix them</string>

--- a/app/src/main/res/xml/root_preferences.xml
+++ b/app/src/main/res/xml/root_preferences.xml
@@ -46,6 +46,13 @@
             app:title="@string/pref_show_clock" />
 
         <SwitchPreferenceCompat
+            app:key="systemVolume"
+            app:defaultValue="true"
+            app:summaryOn="@string/pref_system_volume_on"
+            app:summaryOff="@string/pref_system_volume_off"
+            app:title="@string/pref_system_volume" />
+
+        <SwitchPreferenceCompat
             app:key="skipSilence"
             app:defaultValue="false"
             app:summaryOn="@string/pref_skip_silence_on"


### PR DESCRIPTION
Volume gestures and keys have always written the device's media stream (`AudioManager.STREAM_MUSIC`), so watching something quietly leaves the whole device quiet afterwards — the next call or alarm included.

**System volume** (General, on by default) keeps that behaviour. Turned off, both gestures and hardware keys go through the player's own volume (`player.setVolume`) and the device stream is never written.

- The isolated level persists between sessions, like brightness does.
- A key press moves it by the same step the system uses, so the button feels the same in either mode.
- Isolated 100% means "as loud as the device currently is"; the existing boost band (110–200%) is how to go louder, and it is independent of the stream.
- Hidden on TV boxes, where the remote routes volume over CEC and only the system stream responds.
- In PiP the system handles the volume keys, so they move the system slider there. Known limitation.

The branch on the pref is contained in `Utils.getVolumePercent` / `setVolumePercent` / `adjustVolume`, so none of the four call sites (gesture, volume keys, mouse wheel, joystick) changed, and the OSD, level bar and boost gate work unmodified.

### Fixes in the same volume path

- **Boost gain was not applied to freshly created effects.** `boostLevel` lived in a static outliving both the `LoudnessEnhancer` and the activity, so a new effect sat at zero gain while the OSD claimed a boost. The gain is now applied right after the effect is created, and the level is cleared on launch.
- **The hearing warning fired once per swipe and never for the keys.** It now covers every path into the boost zone and shows once per session. Note the trigger changed from "reached 100%" to "boost actually engaged", which is what makes it consistent between gestures and keys.
- **A settings change never rebuilt the player.** The "did anything change" snapshot was taken in `onActivityResult`, after the settings screen had already written to the same `SharedPreferences`, so it always compared the new state with itself. It is now taken before the screen opens. Consequence worth knowing: the rebuild is alive again and reacts to any changed preference, so returning from settings after a change pauses and re-buffers playback.

### Testing

Manual, on a phone (no test suite in this repo).

With the setting on, volume must be indistinguishable from before: gestures and keys move the system slider, boost still engages past 100%. Turned off: the player quietens while `media volume --stream 3 --get` stays put, the key step matches the synced one, the level survives a restart, and switching back on restores full volume rather than leaving the player attenuated. Boost warning: no toast on reaching 100% with the keys, one toast on the press that enters boost, none afterwards until the app is relaunched.