### PR TITLE
Resolve each language display name only once in settings

### DIFF
--- a/app/src/main/java/com/brouken/player/SettingsActivity.java
+++ b/app/src/main/java/com/brouken/player/SettingsActivity.java
@@ -205,6 +205,12 @@ public class SettingsActivity extends AppCompatActivity {
                 try {
                     // MissingResourceException: Couldn't find 3-letter language code for zz
                     String key = locale.getISO3Language();
+                    if (languages.containsKey(key)) {
+                        // Hundreds of locales collapse onto the same language here, and the display
+                        // name never depends on region or script — resolving it again only burns
+                        // main-thread time while Settings opens.
+                        continue;
+                    }
                     String language = locale.getDisplayLanguage();
                     int length = language.offsetByCodePoints(0, 1);
                     if (!language.isEmpty()) {


### PR DESCRIPTION
Opening the settings screen walked all ~900 entries of `Locale.getAvailableLocales()` and called `getDisplayLanguage()` on every one. The map collecting them is keyed by ISO3 language and only ever holds ~180 entries, so roughly four out of five of those ICU lookups were computed and immediately overwritten — on the main thread, inside `onCreatePreferences`, right after 41 preferences are inflated.

`getLanguages()` now skips the display-name lookup once the language is already in the map.

### Why the list is unchanged

Only the first locale for a language supplies its name instead of the last. `getDisplayLanguage()` ignores region and script, so every locale sharing an ISO3 language yields the same string (`zh-CN`/`zh-TW` → "Chinese", `sr`/`sr-Latn` → "Serbian"). Values embed the key (`English [eng]`), so they stay unique and the stable sort in `Utils.orderByValue` has no new ties to reorder. Entry values are the same ISO3 codes, so a saved preference keeps resolving.

Diffing both variants of the method over the JVM locale list confirms it: 1017 locales, **1017 display-name lookups before vs 213 after**, and identical entries, values and order (212 entries).

### Context

An ANR was recorded on a low-end Android 11 TV box (4 cores @ 1.32 GHz, 977 MB RAM) with the settings screen in the foreground while the player still had an active loader and four HTTP requests in flight. The captured main-thread frame is a platform one — a synchronous `removeImeSurfaceFromWindow` binder call inside a layout traversal, with the deepest frames showing the call had already returned and was only waiting on ART's dump suspend-all — so it marks where the thread dump caught the main thread, not where it had been stuck. The locale enumeration is the one long piece of main-thread work on that screen, and the only part that is ours to remove. Mitigation rather than a proven root cause.

### Testing

`./gradlew assembleLatestUniversalDebug` passes. Settings → preferred audio language should show the same full, alphabetically sorted list, with the previously saved value still selected.
