### PR TITLE
Keep the empty state and the first launch from disagreeing on orientation

### DIFF
--- a/app/src/main/java/com/brouken/player/PlayerActivity.java
+++ b/app/src/main/java/com/brouken/player/PlayerActivity.java
@@ -680,7 +680,14 @@ public class PlayerActivity extends Activity {
         // Boost is session state kept in statics, so a launch must not inherit it from the last one
         boostLevel = 0;
         boostWarned = false;
-        Utils.setOrientation(this, mPrefs.orientation);
+        // Only when something is actually going to play: a launcher start opens on the empty state, and the
+        // orientation preference is about the video, so there is nothing to rotate for there. Doing it here
+        // rather than leaving it to showEmptyState below avoids launching landscape and flipping back.
+        if (getIntent().getData() != null || Intent.ACTION_SEND.equals(getIntent().getAction())) {
+            Utils.setOrientation(this, mPrefs.orientation);
+        } else {
+            setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED);
+        }
 
         super.onCreate(savedInstanceState);
         if (Build.VERSION.SDK_INT == 28 && Build.MANUFACTURER.equalsIgnoreCase("xiaomi") &&
@@ -5380,6 +5387,10 @@ public class PlayerActivity extends Activity {
         final View link = findViewById(R.id.empty_state_link);
         final View settings = findViewById(R.id.empty_state_settings);
 
+        // No video to match, so the orientation preference has nothing to say here: hand the page back to
+        // the system, whichever way the device is held. Reapplied by hideEmptyState once media takes over.
+        setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED);
+
         open.setOnClickListener(v -> openFile(mPrefs.mediaUri));
         link.setOnClickListener(v -> askForLink());
         settings.setOnClickListener(v -> openSettings());
@@ -5566,6 +5577,9 @@ public class PlayerActivity extends Activity {
     }
 
     private void hideEmptyState() {
+        // Media is taking the screen, so the preference applies again — including after an empty state
+        // relaxed it. No video format yet, so VIDEO lands on landscape and STATE_READY corrects it.
+        Utils.setOrientation(this, mPrefs.orientation);
         stopEmptyStatePulse();
         final View overlay = findViewById(R.id.empty_state);
         if (overlay != null && overlay.getVisibility() != View.GONE) {

--- a/app/src/main/java/com/brouken/player/Prefs.java
+++ b/app/src/main/java/com/brouken/player/Prefs.java
@@ -87,7 +87,9 @@ class Prefs {
     public Uri scopeUri;
     public String mediaType;
     public int resizeMode = AspectRatioFrameLayout.RESIZE_MODE_FIT;
-    public Utils.Orientation orientation = Utils.Orientation.UNSPECIFIED;
+    // VIDEO from the start: UNSPECIFIED is a no-op in Utils.setOrientation, so defaulting to it left the
+    // first-ever launch following the device until the first STATE_READY upgraded it to VIDEO anyway.
+    public Utils.Orientation orientation = Utils.Orientation.VIDEO;
     public float scale = 1.f;
     public float aspectRatio = 0f; // 0 = natural video AR; >0 = forced display AR (16:9, 4:3, …)
     public float speed = 1.f;


### PR DESCRIPTION
The empty page opened in portrait on the very first launch and in landscape on every launch after that. The player itself was affected too: on a fresh install it could open portrait and only snap to landscape once the clip was ready.

Both come from one place — the orientation preference means "match the video", but it was applied while there is no video.

- A fresh install stores `UNSPECIFIED`, which `Utils.setOrientation` silently ignores, so the empty page and the player both followed the device.
- The first `STATE_READY` upgrades the preference to `VIDEO` and persists it, so every later `onCreate` ran `setOrientation(VIDEO)` with no player yet and fell through to `SENSOR_LANDSCAPE`, pinning the empty page sideways.

Fix:

- `onCreate` applies the preference only when the launch intent actually carries media; a launcher start relaxes to `SCREEN_ORIENTATION_UNSPECIFIED` (needed explicitly — the activity is `singleTask`, so an earlier request sticks).
- `showEmptyState` relaxes to the system orientation. Single choke point, so the empty state reached at runtime (file deleted, source unreachable) no longer stays locked landscape either.
- `hideEmptyState` reapplies the preference, so opening a clip from the empty page rotates immediately instead of waiting for `STATE_READY`.
- The preference now defaults to `VIDEO`, which removes the first-launch special case altogether — and with it the rotation button showing the "system" icon while the screen was in fact locked.

Existing installs are unaffected: they stored `VIDEO` at their first playback, and the `UNSPECIFIED -> VIDEO` upgrade stays in place for anyone still holding the old value.

Checked on a phone (debug build):

- launcher start held upright -> empty page in portrait, on the first and on later launches;
- opening a video from the empty page -> landscape before the spinner clears;
- opening a video straight from a `VIEW` intent -> landscape from the first frame, no flip while buffering.
