### PR TITLE
Offer .avi files where the other containers are offered

### DIFF
--- a/app/src/main/java/com/brouken/player/Utils.java
+++ b/app/src/main/java/com/brouken/player/Utils.java
@@ -74,7 +74,7 @@ class Utils {
 
     public static final String FEATURE_FIRE_TV = "amazon.hardware.fire_tv";
 
-    public static final String[] supportedExtensionsVideo = new String[] { "3gp", "m4v", "mkv", "mov", "mp4", "ts", "webm" };
+    public static final String[] supportedExtensionsVideo = new String[] { "3gp", "avi", "m4v", "mkv", "mov", "mp4", "ts", "webm" };
     public static final String[] supportedExtensionsSubtitle = new String[] { "srt", "ssa", "ass", "vtt", "ttml", "dfxp", "xml" };
 
     public static final String[] supportedMimeTypesVideo = new String[] {
@@ -85,6 +85,8 @@ class Utils {
             "video/quicktime", // .mov
             "video/mp2ts", // .ts, but also incompatible .m2ts
             MimeTypes.VIDEO_H263, // .3gp
+            "video/avi", // .avi
+            "video/x-msvideo", // .avi, older mime table
             // For remote storages:
             "video/x-m4v", // .m4v
     };


### PR DESCRIPTION
`.avi` was the one common container the app would not let you reach. Playback itself was never the problem — Media3's extractor module carries `AviExtractor` and `DefaultExtractorsFactory` uses it, and the bundled ffmpeg extension covers the codecs those files usually hold. What blocked it was the file lists:

- `Utils.supportedExtensionsVideo` drives the vendored file chooser's suffix filter and `findNext` (the next-episode scan), so `.avi` was invisible in both;
- `Utils.supportedMimeTypesVideo` becomes `EXTRA_MIME_TYPES` for the SAF picker, so the system picker greyed those files out.

Adds `avi` to the extension list and both spellings to the mime list — Android's newer mime table reports `video/avi`, older ones `video/x-msvideo`, and which one a provider hands back depends on the device.

Deliberately not in scope: the `pathPattern` intent filters in the manifest, which catch bare `http(s)` links by extension when the sender supplies no mime type. `.avi` is not among them, so such a link still will not offer the app. Every other extension there costs ~60 lines of generated XML (upper and lower case, nested 30 deep), and links that do carry a `video/*` type are already covered by the mime filter — worth its own change if it turns out to matter.
