### PR TITLE
Open the empty state upright instead of flipping through landscape

### DIFF
--- a/app/src/main/java/com/brouken/player/PlayerActivity.java
+++ b/app/src/main/java/com/brouken/player/PlayerActivity.java
@@ -5194,8 +5194,15 @@ public class PlayerActivity extends Activity {
 
         playerView.setControllerShowTimeoutMs(-1);
 
-        locked = false;
-        clearLockUi();
+        // Only when a lock is actually there to undo — the flag is static, so it can outlive the session
+        // that set it. Undoing one that was never on also restored the video orientation, which turned a
+        // launcher start into landscape until showEmptyState relaxed it again a few lines below: a visible
+        // flip to landscape and back on a phone held upright. Both branches below set the orientation the
+        // page really needs, so nothing is lost by leaving it alone here.
+        if (locked) {
+            locked = false;
+            clearLockUi();
+        }
 
         if (haveMedia) {
             hideEmptyState();


### PR DESCRIPTION
Starting the app from the launcher on a phone held upright showed the empty page in landscape for a moment, then rotated it to portrait.

## Cause

`onCreate` already picks the right orientation -- with no media in the launch intent it hands the page to the system, and the window comes up portrait. Then `initializePlayer` reset the screen lock unconditionally:

```java
locked = false;
clearLockUi();
```

Undoing a lock restores the video orientation preference, and with no video format to look at that means `SCREEN_ORIENTATION_SENSOR_LANDSCAPE`. `showEmptyState()` relaxes it back to unspecified a few lines further down, so the page ends up upright after all -- but the two requests reach the window manager separately, so the flip is visible.

## Fix

Undo the lock only when there is one. The flag is static, so it can outlive the session that set it, which is why it is touched here at all -- but nothing needs restoring when it was never on, and the sibling call site in `onPlaybackStateChanged` already guards it the same way. Both branches immediately below set whatever orientation the page actually needs, so leaving it alone here loses nothing.

## Testing

Measured on a phone (auto-rotate off, display upright), sampling the display size every 350 ms from launch:

| | frames after launch |
|---|---|
| before | portrait, **landscape**, portrait |
| after | portrait in every frame, twice in a row |

Opening a video still applies the preference as before.

Unrelated and left alone: a **portrait** video still opens with one landscape frame and rotates at `STATE_READY`. Same kind of jolt, different cause -- the video orientation is unknown until the format arrives, and the preference defaults to landscape until then.