### PR TITLE
Hide the closed-caption track HLS playlists never declared

### DIFF
--- a/app/src/main/java/com/brouken/player/PlayerActivity.java
+++ b/app/src/main/java/com/brouken/player/PlayerActivity.java
@@ -4396,7 +4396,8 @@ public class PlayerActivity extends Activity {
         boolean textSelected = false;
         if (player != null) {
             for (Tracks.Group group : player.getCurrentTracks().getGroups()) {
-                if (group.getType() == C.TRACK_TYPE_TEXT) {
+                if (group.getType() == C.TRACK_TYPE_TEXT
+                        && !isPhantomClosedCaption(group.getMediaTrackGroup().getFormat(0))) {
                     hasSubtitles = true;
                     if (group.isSelected()) {
                         textSelected = true;
@@ -4433,6 +4434,20 @@ public class PlayerActivity extends Activity {
                     () -> applyAudio(choice)));
         }
         showSideMenu(getString(R.string.audio_title), items);
+    }
+
+    // ExoPlayer invents an empty CEA-608 track for every HLS stream whose playlist declares no closed
+    // captions at all (DefaultHlsExtractorFactory.exposeCea608WhenMissingDeclarations, on by default
+    // and not reachable through the final DefaultMediaSourceFactory). Almost no such stream actually
+    // carries captions, so the picker offered a subtitle that showed nothing once selected, on streams
+    // where every other player correctly reports no subtitles. A CC track a playlist really declares
+    // always carries INSTREAM-ID (CC1..CC4) — an accessibility channel — which the invented one lacks.
+    // ponytail: this also hides an undeclared but real CEA-608 track, the same trade-off ExoPlayer's
+    // own flag makes. Flipping the flag instead needs a custom HlsMediaSource.Factory, which means
+    // re-doing the sideloaded-subtitle merging DefaultMediaSourceFactory does for us.
+    private static boolean isPhantomClosedCaption(Format format) {
+        return MimeTypes.APPLICATION_CEA608.equals(format.sampleMimeType)
+                && format.accessibilityChannel == Format.NO_VALUE;
     }
 
     private String buildSubtitleInfo(Format text) {
@@ -4472,6 +4487,9 @@ public class PlayerActivity extends Activity {
                     continue;
                 }
                 final Format format = trackGroup.getFormat(i);
+                if (isPhantomClosedCaption(format)) {
+                    continue;
+                }
                 number++;
                 String label = buildSubtitleInfo(format);
                 if (label == null || label.isEmpty()) {


### PR DESCRIPTION
## Problem

Playing an HLS stream whose multivariant playlist declares no closed captions at all offered a subtitle track in the picker that did nothing when selected. Most other players correctly report no subtitles for such a stream.

Reported for a stream whose playlist is just three `#EXT-X-STREAM-INF` variants — no `CLOSED-CAPTIONS` attribute, no closed-caption `#EXT-X-MEDIA` tag, MPEG-TS segments.

## Cause

`DefaultHlsExtractorFactory` has `exposeCea608WhenMissingDeclarations` enabled by default: when a playlist declares nothing about closed captions, Media3 assumes a CEA-608 track exists and exposes it. Almost no such stream actually carries captions, so the track stays empty.

Sidecar discovery (`SubtitleFinder`) was ruled out — every probed `.srt`/`.ass`/`.vtt` URL for this stream returns 404.

## Fix

Skip these tracks in the two places subtitles reach the user — `showSubtitleDialog()` and `updateSubtitleButton()`, so the CC button is hidden too.

A closed-caption track a playlist really declares always carries an `INSTREAM-ID` (`CC1`..`CC4`), and so an accessibility channel, which the assumed one lacks. The label cannot be used to tell them apart: `SeiReader` rebuilds the track format and drops it.

Turning the Media3 flag off at the source is not reachable from here — `DefaultMediaSourceFactory` is `final` and exposes no HLS extractor factory, and passing our own `HlsMediaSource.Factory` would mean re-doing the sideloaded-subtitle merging it performs for us. Same trade-off the Media3 flag itself makes: an undeclared but genuinely present CEA-608 track is hidden as well.

## Testing

Built and installed the debug APK on a phone.

- The reported stream: no CC button, no phantom entry in the subtitle picker.
- A stream with subtitles declared in the playlist: picker and button unchanged.
