### PR TITLE
Tie the screen brightness to the video, not to the activity

### DIFF
--- a/app/src/main/java/com/brouken/player/BrightnessControl.java
+++ b/app/src/main/java/com/brouken/player/BrightnessControl.java
@@ -1,5 +1,8 @@
 package com.brouken.player;
 
+import android.animation.Animator;
+import android.animation.AnimatorListenerAdapter;
+import android.animation.ValueAnimator;
 import android.app.Activity;
 import android.content.res.Resources;
 import android.provider.Settings;
@@ -7,7 +10,10 @@ import android.view.WindowManager;
 
 class BrightnessControl {
 
+    private static final int FADE_DURATION = 300;
+
     private final Activity activity;
+    private ValueAnimator fade;
 
     /** 0-100, or -1 for system/auto brightness. Float so the absolute gesture keeps sub-percent precision. */
     public float percent = -1;
@@ -26,7 +32,63 @@ class BrightnessControl {
         activity.getWindow().setAttributes(lp);
     }
 
+    /**
+     * Hands the window our own brightness while media is on screen, and back to the system whenever it is
+     * not: the empty state is ordinary UI and has no business dimming the device, and the level left over
+     * from the last video is exactly what made it look like the player had a brightness of its own. Faded,
+     * because both switches happen right under the user's eyes.
+     */
+    public void setActive(final boolean active, final boolean animate) {
+        fadeTo(active && percent >= 0
+                ? percentToBrightness(percent)
+                : WindowManager.LayoutParams.BRIGHTNESS_OVERRIDE_NONE, animate);
+    }
+
+    private void fadeTo(final float target, final boolean animate) {
+        cancelFade();
+
+        // BRIGHTNESS_OVERRIDE_NONE is a flag rather than a level, so the fade runs against the brightness
+        // the system would show and the flag itself is only set once the screen is already there.
+        final float from = resolve(getScreenBrightness());
+        final float to = resolve(target);
+
+        if (!animate || Math.abs(to - from) < 0.01f) {
+            setScreenBrightness(target);
+            return;
+        }
+
+        fade = ValueAnimator.ofFloat(from, to);
+        fade.setDuration(FADE_DURATION);
+        fade.addUpdateListener(animation -> setScreenBrightness((float) animation.getAnimatedValue()));
+        fade.addListener(new AnimatorListenerAdapter() {
+            private boolean cancelled;
+
+            @Override
+            public void onAnimationCancel(Animator animation) {
+                cancelled = true;
+            }
+
+            @Override
+            public void onAnimationEnd(Animator animation) {
+                // Whoever cancelled us is setting its own brightness right now; committing ours would fight it.
+                if (!cancelled)
+                    setScreenBrightness(target);
+            }
+        });
+        fade.start();
+    }
+
+    private void cancelFade() {
+        if (fade != null) {
+            fade.cancel();
+            fade = null;
+        }
+    }
+
     public void changeBrightness(final CustomPlayerView playerView, final float delta, final boolean canSetAuto) {
+        // The gesture is direct feedback on a finger: it wins over any fade still running.
+        cancelFade();
+
         final float newPercent = (percent < 0 ? systemPercent() : percent) + delta;
 
         if (canSetAuto && newPercent < 0)
@@ -52,17 +114,30 @@ class BrightnessControl {
         return (float) Math.max(0, Math.min(100, (d - 0.064) / 0.936 * 100));
     }
 
+    private float resolve(final float brightness) {
+        return brightness < 0 ? systemBrightness() : brightness;
+    }
+
+    /**
+     * Device brightness on the window's 0-1 scale. With auto-brightness on this is the slider position
+     * rather than the light the screen actually emits, which is all Android exposes — close enough for a
+     * fade to start from, and the fade itself covers the error.
+     */
+    private float systemBrightness() {
+        final int max = systemBrightnessMax();
+        final int raw = Settings.System.getInt(activity.getContentResolver(), Settings.System.SCREEN_BRIGHTNESS, -1);
+        // Out of range means the ROM stores brightness on a scale we cannot normalize; start from the middle
+        if (raw < 0 || raw > max)
+            return percentToBrightness(50f);
+        return (float) raw / max;
+    }
+
     /**
      * Device brightness on our percent scale, used as the starting point when the player has no brightness
      * of its own yet, so the first gesture continues from what is already on screen instead of from zero.
      */
     private float systemPercent() {
-        final int max = systemBrightnessMax();
-        final int raw = Settings.System.getInt(activity.getContentResolver(), Settings.System.SCREEN_BRIGHTNESS, -1);
-        // Out of range means the ROM stores brightness on a scale we cannot normalize; start from the middle
-        if (raw < 0 || raw > max)
-            return 50f;
-        return brightnessToPercent((float) raw / max);
+        return brightnessToPercent(systemBrightness());
     }
 
     /** The scale system brightness is stored on. OEMs widen it well past the classic 0-255. */

--- a/app/src/main/java/com/brouken/player/PlayerActivity.java
+++ b/app/src/main/java/com/brouken/player/PlayerActivity.java
@@ -1449,10 +1449,11 @@ public class PlayerActivity extends Activity {
         playerListener = new PlayerListener();
 
         mBrightnessControl = new BrightnessControl(this);
-        if (mPrefs.brightness >= 0) {
-            mBrightnessControl.percent = mPrefs.brightness;
-            mBrightnessControl.setScreenBrightness(mBrightnessControl.percentToBrightness(mBrightnessControl.percent));
-        }
+        // Only the level is restored here. Putting it on the window as well tied the brightness to the
+        // activity instead of the video: the empty state kept the last clip's dimming, and every trip to
+        // the settings screen — a window of its own — flipped back to the device brightness and back again.
+        // show/hideEmptyState own the window now.
+        mBrightnessControl.percent = mPrefs.brightness;
         playerView.setBrightnessControl(mBrightnessControl);
 
         final LinearLayout exoBasicControls = playerView.findViewById(R.id.exo_basic_controls);
@@ -5416,9 +5417,11 @@ public class PlayerActivity extends Activity {
         final View link = findViewById(R.id.empty_state_link);
         final View settings = findViewById(R.id.empty_state_settings);
 
-        // No video to match, so the orientation preference has nothing to say here: hand the page back to
-        // the system, whichever way the device is held. Reapplied by hideEmptyState once media takes over.
+        // No video to match, so neither the orientation nor the brightness preference has anything to say
+        // here: hand the page back to the system, whichever way the device is held and however bright it
+        // keeps its screen. Both are reapplied by hideEmptyState once media takes over.
         setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED);
+        mBrightnessControl.setActive(false, !isReducedMotion());
 
         open.setOnClickListener(v -> openFile(mPrefs.mediaUri));
         link.setOnClickListener(v -> askForLink());
@@ -5606,9 +5609,10 @@ public class PlayerActivity extends Activity {
     }
 
     private void hideEmptyState() {
-        // Media is taking the screen, so the preference applies again — including after an empty state
-        // relaxed it. No video format yet, so VIDEO lands on landscape and STATE_READY corrects it.
+        // Media is taking the screen, so the preferences apply again — including after an empty state
+        // relaxed them. No video format yet, so VIDEO lands on landscape and STATE_READY corrects it.
         Utils.setOrientation(this, mPrefs.orientation);
+        mBrightnessControl.setActive(true, !isReducedMotion());
         stopEmptyStatePulse();
         final View overlay = findViewById(R.id.empty_state);
         if (overlay != null && overlay.getVisibility() != View.GONE) {


### PR DESCRIPTION
The saved brightness was pushed onto the window once in `onCreate`, so it outlived whatever it was set for. The empty state kept the last clip's dimming, and every trip to the settings screen — a window of its own — flipped back to the device brightness and back again on return. On a device sitting at minimum or maximum brightness that reads as the player having a brightness of its own, for no reason the user can see.

Brightness is a property of playback, so it now follows the media:

- `hideEmptyState()` applies the saved level, `showEmptyState()` hands the window back to the system — right next to the lines that already do exactly that for the orientation. Every path that gains or loses media (`initializePlayer`, end of playlist, PiP, background release, settings round-trip) goes through that pair, so there is no route that leaves the window overridden without a video behind it.
- Both switches happen under the user's eyes, so `BrightnessControl.setActive()` fades them over 300ms. The swipe gesture cancels any running fade and stays instant — it is direct feedback on a finger.
- `BRIGHTNESS_OVERRIDE_NONE` is a flag rather than a level, so the fade runs against the brightness the system would show and only sets the flag once the screen is already there.

Known limitation: with system auto-brightness on, `Settings.System.SCREEN_BRIGHTNESS` is the slider position rather than the light the screen actually emits — all Android exposes. The first animation frame can therefore be slightly off; a 300ms fade covers it.

Side effect, accepted: opening the app from the launcher at night now lights the empty state at the system brightness until a video is picked. That is what every other app does, and it is the point of the change.

## Testing

Manual, on a device with the system brightness at minimum and at maximum (no test infrastructure in this project):

- Play a video, change the brightness by gesture, reach the empty state: the screen fades back to the system brightness.
- Empty state → settings → back: no jump in either direction.
- Empty state → open a video: fades to the saved brightness.
- Relaunch from the launcher: the empty state shows the system brightness, the picked video fades to the saved one.
- Pause, controls shown/hidden, track menus: brightness does not move.
- Swipe during playback: instant, and swiping down to auto releases the screen to the system.
- Repeated with Animator duration scale off: transitions are instant, still no jumps.
