### PR TITLE
Bring the sound back after a seek on a bitstream output

### DIFF
--- a/app/src/main/java/com/brouken/player/PlayerActivity.java
+++ b/app/src/main/java/com/brouken/player/PlayerActivity.java
@@ -524,6 +524,15 @@ public class PlayerActivity extends Activity {
     // from the listener, which is dispatched inside player.pause() — there isScrubbing is not set yet.
     private boolean audioRestartInFlight;
     private final Runnable passthroughRestartRunnable = this::restartPassthroughAudio;
+    // A seek releases the audio output too (MediaCodecAudioRenderer.onPositionReset -> audioSink.flush()), and
+    // the field reported it coming back silent on a receiver just like a pause does. Latched rather than acted
+    // on at once, because restartPassthroughAudio needs STATE_READY and a seek out of the buffered range
+    // spends a while in BUFFERING first; spent on the next STATE_READY. Only for a seek within the same item —
+    // an item change brings its own fresh output, and tearing that one down is how a just-started stream ends
+    // up silent.
+    private boolean audioRestartAfterSeek;
+    // Retry budget for one request: restartPassthroughAudio drops nothing on a transient blocker, it waits.
+    private int audioRestartRetries;
     public boolean frameRendered;
     private boolean alive;
     public static boolean focusPlay = false;
@@ -5148,6 +5157,7 @@ public class PlayerActivity extends Activity {
         audioDecoderName = null;
         // A restart that never got its onTracksChanged belongs to the player being replaced here.
         audioRestartInFlight = false;
+        audioRestartAfterSeek = false;
 
         // Fresh media — drop any container track names so the tap re-parses for this item.
         containerTracks.clear();
@@ -5837,6 +5847,7 @@ public class PlayerActivity extends Activity {
             playerView.removeCallbacks(backgroundReleaseRunnable);
             playerView.removeCallbacks(resumeWatchdogRunnable);
             playerView.removeCallbacks(passthroughRestartRunnable);
+            audioRestartAfterSeek = false;
             playerView.removeCallbacks(showLoadingRunnable);
             // A pending key-seek target belongs to the session being torn down; left armed it would land
             // on whatever plays next.
@@ -5961,6 +5972,12 @@ public class PlayerActivity extends Activity {
             if (oldPosition.mediaItemIndex != newPosition.mediaItemIndex) {
                 playerStartPositionMs = currentPeriodPositionMs();
             }
+            // The seek flushed the audio output, so the bitstream may need re-locking (see
+            // audioRestartAfterSeek). Latched, not run here. Within one item only.
+            if (reason == Player.DISCONTINUITY_REASON_SEEK
+                    && oldPosition.mediaItemIndex == newPosition.mediaItemIndex) {
+                audioRestartAfterSeek = true;
+            }
             if (apiPlaylistPositions == null || player == null) {
                 return;
             }
@@ -5998,6 +6015,8 @@ public class PlayerActivity extends Activity {
                     }
                 }
             }
+            // The new item opens its own audio output; a seek latched on the old one must not tear it down.
+            audioRestartAfterSeek = false;
             updateTopInfo();
             hideSkipButton();
             cancelSegmentFinder();
@@ -6078,7 +6097,7 @@ public class PlayerActivity extends Activity {
                         && reason != Player.PLAY_WHEN_READY_CHANGE_REASON_REMOTE)) {
                 return;
             }
-            playerView.post(passthroughRestartRunnable);
+            requestPassthroughRestart();
         }
 
         @Override
@@ -6147,6 +6166,12 @@ public class PlayerActivity extends Activity {
                 // starts at its saved timecode — neither is progress.
                 if (playerStartPositionMs == C.TIME_UNSET) {
                     playerStartPositionMs = currentPeriodPositionMs();
+                }
+
+                // The seek is over: give the bitstream a fresh AudioTrack (see audioRestartAfterSeek). The
+                // flag is cleared by the restart itself, so a transient blocker keeps the request alive.
+                if (audioRestartAfterSeek) {
+                    requestPassthroughRestart();
                 }
 
                 // Ready — hide the spinner and re-enable the episode arrows. Done unconditionally (not only on
@@ -6725,22 +6750,44 @@ public class PlayerActivity extends Activity {
         return true;
     }
 
-    // Recreates the AudioTrack behind a paused bitstream (see audioRestartInFlight). Runs one message after
-    // the pause was dispatched, so the guards are real: the player may already be gone, and the user may
-    // have gone on to scrub, in which case their own seek recreates the track anyway. STATE_READY keeps us
-    // out of a rebuffer that is already under way; alive drops the onStop pause, where savePlayer() has run
-    // and the work would be spent on a session that is going away. Nothing here seeks, so seekability and
-    // liveness do not matter — and with no audio track selected there is nothing to recreate.
+    // Recreates the AudioTrack behind a bitstream that was torn down (see audioRestartInFlight). Runs one
+    // message after the pause, or after the STATE_READY that ends a seek, so the guards are real: the player
+    // may already be gone, and the user may have gone on to scrub, in which case their own seek recreates the
+    // track anyway. alive drops the onStop pause, where savePlayer() has run and the work would be spent on a
+    // session that is going away. Nothing here seeks, so seekability and liveness do not matter — and with no
+    // audio track selected there is nothing to recreate.
     private void restartPassthroughAudio() {
-        if (!alive || player == null || isScrubbing || audioRestartInFlight
+        if (!alive || player == null || isScrubbing
                 || audioSink == null || !audioSink.isPassthrough() || mPrefs.tunneling
-                || player.getPlaybackState() != Player.STATE_READY
                 || !player.getCurrentTracks().isTypeSelected(C.TRACK_TYPE_AUDIO)) {
             return;
         }
+        // Transient blockers, so wait rather than drop: a previous reselect has not reported back through
+        // onTracksChanged yet, or a rebuffer moved us out of STATE_READY between the trigger and this
+        // message. Dropping the request is how the sound is lost with no cure — the trigger is spent and
+        // nothing retries, so only the *next* pause or seek fixes it, which is exactly the reported "first
+        // seek loses it, second brings it back". The budget is per request (reset by
+        // requestPassthroughRestart), so an abandoned one cannot starve the next.
+        if (audioRestartInFlight || player.getPlaybackState() != Player.STATE_READY) {
+            if (audioRestartRetries < 5) {
+                audioRestartRetries++;
+                playerView.postDelayed(passthroughRestartRunnable, 100);
+            }
+            return;
+        }
+        // Cleared here rather than at the trigger: until the reselect is actually issued the request still
+        // has to survive, or every guard above becomes a silent no-cure path.
+        audioRestartAfterSeek = false;
         audioRestartInFlight = true;
         player.setTrackSelectionParameters(player.getTrackSelectionParameters().buildUpon()
                 .setTrackTypeDisabled(C.TRACK_TYPE_AUDIO, true).build());
+    }
+
+    /** One restart request, with a fresh retry budget. */
+    private void requestPassthroughRestart() {
+        audioRestartRetries = 0;
+        playerView.removeCallbacks(passthroughRestartRunnable);
+        playerView.post(passthroughRestartRunnable);
     }
 
     // AudioSink.InitializationException.format is a public field in this build — no reflection needed.


### PR DESCRIPTION
A seek releases the audio output as surely as a pause does — `MediaCodecAudioRenderer.onPositionReset` calls `AudioSink.flush()`, which in this build is the operation that releases the output rather than merely flushing it. On a device handing a compressed bitstream to a receiver, the new track is not always picked up again: video keeps playing, the position keeps advancing, and there is no sound and no error to report.

A second seek then finds the audio renderer unable to report ready, so playback never reaches `STATE_READY` again. That is what produced the "playback took too long to start" message a tester saw after pressing the seek key twice: the silence was the cause, not a neighbouring symptom.

## What this changes

**Recreate the audio track after a seek**, reusing the restart a user pause already performs (`restartPassthroughAudio`). Latched rather than run inline, because the reselect needs a ready player and a seek out of the buffered range spends a while in `STATE_BUFFERING` first; spent on the `STATE_READY` that ends the seek. Within one media item only — an item change opens its own output, and tearing that one down leaves a just-started stream silent.

**Stop discarding a restart request that cannot run yet.** It used to be dropped when a previous reselect had not reported back through `onTracksChanged`, or when a rebuffer had moved the player out of `STATE_READY` — with nothing to retry it, so the sound only returned on the next pause or seek. That is exactly the reported "the first seek loses it, the second brings it back". It now waits for the blocker to clear, with a retry budget scoped to the request instead of a counter that an abandoned request could leave exhausted for the next one.

Costs one audio-track recreate per seek, and only where the output actually bitstreams: every other configuration returns from the first guard, `!audioSink.isPassthrough()`.

## Verified

- Confirmed by a tester on an Android TV box feeding an external receiver, on a Matroska stream with AC-3 / E-AC-3 tracks: seeking no longer drops the sound, and repeated seeking no longer freezes playback.
- The seek path reaching the spend point was checked against the bundled ExoPlayer bytecode: `ExoPlayerImpl.seekTo` masks `STATE_READY` to `STATE_BUFFERING` and reports `DISCONTINUITY_REASON_SEEK`, so the latch is always spent. The reselect itself reports `DISCONTINUITY_REASON_INTERNAL`, so it cannot re-arm the latch and loop.
- Unaffected paths: decoded (PCM) output, gapless episode advance, and live streams.

## Not addressed

Silence after a **long** pause remains open. The shipped restart fires when the user pauses, which rebuilds the output at the start of the pause and leaves it for however long the user is away. Whether that window is the variable — a lost format lock — or whether the receiver merely takes its documented 0.5–2.5 s to lock again on resume cannot be told apart from the data available, and the two point at opposite fixes. Moving the trigger to the resume edge was tried and reverted: it puts the recreate at the moment playback begins, which made a fresh open come up silent every few attempts.
