### PR TITLE
Tell a mid-film stall apart from a load that never started

### DIFF
--- a/app/src/main/java/com/brouken/player/PlayerActivity.java
+++ b/app/src/main/java/com/brouken/player/PlayerActivity.java
@@ -314,8 +314,8 @@ public class PlayerActivity extends Activity {
     // renderers are built — that is where the library is loaded anyway — so a report never pays for a
     // dlopen on the main thread, and stays null until then rather than lying.
     private static Boolean ffmpegAvailable;
-    // Position where playback actually began (first STATE_READY, then every seek), so progress is measured
-    // against it rather than against zero: a film resumed at the fortieth minute, or a live stream
+    // Position where playback actually began (first STATE_READY, then every item change), so progress is
+    // measured against it rather than against zero: a film resumed at the fortieth minute, or a live stream
     // positioned inside its window, still has a large position when it wedges on its first frame, and
     // judging by the position alone would call that a mid-stream stall. C.TIME_UNSET until known.
     private long playerStartPositionMs = C.TIME_UNSET;
@@ -1808,6 +1808,12 @@ public class PlayerActivity extends Activity {
         } else {
             resumeFrameRendered = false;
             playerView.postDelayed(resumeWatchdogRunnable, RESUME_WATCHDOG_MS);
+            // Put back what onStop cancelled, and only that: a load that was still buffering when the user
+            // left gets a full timeout from the moment they are looking at it again.
+            if (player.getPlaybackState() == Player.STATE_BUFFERING) {
+                cancelLoadWatchdog();
+                playerView.postDelayed(loadTimeoutRunnable, VIDEO_LOAD_TIMEOUT_MS);
+            }
         }
         updateButtonRotation();
     }
@@ -1856,6 +1862,12 @@ public class PlayerActivity extends Activity {
             displayManager.unregisterDisplayListener(displayListener);
         }
         player.pause();
+        // The load watchdog only ever ran while the activity was on screen by accident: nothing cancelled it
+        // on this path, so an item still buffering when the user left would time out in the background —
+        // stopping a session they may come straight back to, and posting a snackbar nobody can see. onStart
+        // re-arms it, which it has to do by hand: pausing does not leave STATE_BUFFERING, so the state does
+        // not change across the trip and onPlaybackStateChanged never re-fires.
+        cancelLoadWatchdog();
         playerView.removeCallbacks(resumeWatchdogRunnable);
         playerView.postDelayed(backgroundReleaseRunnable, BACKGROUND_RELEASE_MS);
     }
@@ -5596,7 +5608,14 @@ public class PlayerActivity extends Activity {
         // error paths ever re-enabled them, so a timeout left the one escape from a stuck episode dead.
         // They work from here: stepEpisodeWhileIdle reloads out of an idle player.
         setEpisodeNavLoading(false);
-        showSnack(getString(R.string.error_playback_timeout), null);
+        // A film that has been playing for an hour and then stopped is not a film that "took too long to
+        // start", and that was the message it got. Deliberately not stalledAtStart(): that answers a
+        // different question — whether *this* playback attempt produced anything — and its baseline is not
+        // rebased on a seek (see playerStartPositionMs), so a rewind reads as "at start" in mid-film. All
+        // this message needs is whether the item ever became ready, which is exactly what a set baseline
+        // means. Both messages ask for the same thing, and the play button re-prepares either way.
+        showSnack(getString(playerStartPositionMs == C.TIME_UNSET
+                ? R.string.error_playback_timeout : R.string.error_playback_stalled), null);
     }
 
     public void releasePlayer() {

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -4,7 +4,7 @@
     <string name="error_stream_not_ready">Не удалось получить ссылку на видео. Попробуйте перезапустить воспроизведение.</string>
     <string name="error_playback_general">Не удалось воспроизвести это видео.</string>
     <string name="error_playback_timeout">Воспроизведение слишком долго не начинается. Попробуйте ещё раз.</string>
-    <string name="error_playback_stalled">Воспроизведение остановилось — это устройство, возможно, не может декодировать этот файл.</string>
+    <string name="error_playback_stalled">Воспроизведение остановилось и не продолжилось. Попробуйте ещё раз.</string>
     <string name="error_stream_interrupted">Эфир постоянно прерывается, продолжить не удалось. Попробуйте позже.</string>
     <string name="error_stream_broken">Поток видео повреждён или недоступен. Попробуйте ещё раз.</string>
     <string name="error_stream_http_status">Ошибка сервера %1$d на %2$s</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -17,7 +17,7 @@
     <string name="error_stream_not_ready">Не вдалося отримати посилання на відео. Спробуйте перезапустити відтворення.</string>
     <string name="error_playback_general">Не вдалося відтворити це відео.</string>
     <string name="error_playback_timeout">Відтворення надто довго не починається. Спробуйте ще раз.</string>
-    <string name="error_playback_stalled">Відтворення зупинилося — цей пристрій, можливо, не може декодувати цей файл.</string>
+    <string name="error_playback_stalled">Відтворення зупинилося і не продовжилося. Спробуйте ще раз.</string>
     <string name="error_stream_interrupted">Ефір постійно переривається, продовжити не вдалося. Спробуйте пізніше.</string>
     <string name="error_stream_broken">Потік відео пошкоджено або недоступний. Спробуйте ще раз.</string>
     <string name="error_stream_http_status">Помилка сервера %1$d на %2$s</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -18,7 +18,7 @@
     <string name="error_stream_not_ready">Couldn\'t get the video link. Please try restarting playback.</string>
     <string name="error_playback_general">Couldn\'t play this video.</string>
     <string name="error_playback_timeout">Playback took too long to start. Please try again.</string>
-    <string name="error_playback_stalled">Playback stalled — this device may not be able to decode this file.</string>
+    <string name="error_playback_stalled">Playback stopped and did not resume. Please try again.</string>
     <string name="error_stream_interrupted">The live stream keeps stopping and could not be resumed. Please try again later.</string>
     <string name="error_stream_broken">The video stream is damaged or unavailable. Please try again.</string>
     <string name="error_stream_http_status">Server error %1$d at %2$s</string>


### PR DESCRIPTION
The 30 s load watchdog showed **"Playback took too long to start"** for a film that had been playing for an hour and a half. Field telemetry caught it with 52 seconds of buffer already downloaded, `playWhenReady` set and no suppression — so the message named the one thing that had demonstrably not gone wrong, and the user was told to retry a start that had happened long ago.

### The message now matches the situation

Picked by whether the item ever became ready, which is exactly what a set `playerStartPositionMs` means.

Deliberately **not** `stalledAtStart()`: that answers a different question — whether *this* playback attempt produced anything — and its baseline is not rebased on a seek, so a rewind reads as "at start" in mid-film. Leaving it alone also keeps the tunneling recovery working, since that fires only on a stall at the very start and is aimed at an item that wedges on its first frame, before the baseline is set.

Accepted limitation: a failed auto-advance to the next episode now reports "stopped and did not resume" rather than "did not start". Literally true, just less specific, and both messages ask for the same thing.

### `error_playback_stalled` reused rather than duplicated

It was already defined in en/uk/ru and referenced nowhere — its Java use was removed at some point — and its name fits this case exactly. Reworded in all three locales instead of adding a fourth near-synonym to the error strings, so no locale is left holding the old (decoder-flavoured) meaning.

### The watchdog no longer survives a trip to the background

`onStop` keeps the player rather than releasing it, so nothing ever cancelled the timer on that path: an item still buffering when the user left timed out while the activity was stopped, ending a session they may come straight back to and posting a snackbar nobody can see. It is cancelled there and re-armed in `onStart`, which has to be done by hand — pausing does not leave `STATE_BUFFERING`, so the state does not change across the trip and `onPlaybackStateChanged` never re-fires.

### What deliberately did not change

`player.stop()` inside the watchdog stays. `ExoPlayerImpl.prepare()` returns immediately unless the player is `STATE_IDLE`, so stopping is what makes the play button able to re-prepare the item at all — the lost buffer is the price of a working retry, not a defect.

### Testing

Built (`assembleLatestUniversalRelease`). The failure itself comes from a TV box bitstreaming AC-3 to a receiver and is not reproducible on a phone or emulator; the wrong message and the background timeout were both read off field telemetry rather than guessed at.