### PR TITLE
Let the user out of the update download

### DIFF
--- a/app/src/main/java/com/brouken/player/update/UpdateUi.java
+++ b/app/src/main/java/com/brouken/player/update/UpdateUi.java
@@ -76,16 +76,31 @@ public final class UpdateUi {
         layout.setPadding(pad, pad, pad, pad);
         layout.addView(bar);
 
+        // The worker does not exist yet — the dialog has to be built first so the callbacks below can
+        // dismiss it — so the cancel action reaches it through this holder. Nothing can read it before it
+        // is assigned: show() only posts, and the assignment happens before this returns to the looper.
+        final Thread[] download = new Thread[1];
         final AlertDialog dialog = new AlertDialog.Builder(activity)
                 .setTitle(R.string.update_downloading)
                 .setView(layout)
-                .setCancelable(false)
+                // Without this the dialog had no way out at all: a download that stalls without failing
+                // (a connection that trickles bytes never reaches OkHttp's read timeout) left the user
+                // with a modal that BACK could not dismiss, which on a TV means Home is the only escape.
+                .setNegativeButton(android.R.string.cancel, (d, which) -> cancelDownload(download[0]))
+                // BACK does the same as the button rather than nothing: it is what people reach for, and
+                // merely dismissing would leave the download running to fire the installer later, out of
+                // any context. Cancelling is not dismissing, so a normal finish does not come through here.
+                .setOnCancelListener(d -> cancelDownload(download[0]))
                 .create();
         dialog.show();
 
-        Updater.downloadApkAsync(activity, info,
+        download[0] = Updater.downloadApkAsync(activity, info,
                 percent -> activity.runOnUiThread(() -> {
-                    bar.setIndeterminate(false);
+                    // Only the first tick has anything to switch: setting this per percent swapped the
+                    // drawable and invalidated a hundred times over a download.
+                    if (bar.isIndeterminate()) {
+                        bar.setIndeterminate(false);
+                    }
                     bar.setProgress(percent);
                 }),
                 file -> activity.runOnUiThread(() -> {
@@ -98,6 +113,19 @@ public final class UpdateUi {
                         Toast.makeText(activity, R.string.update_download_failed, Toast.LENGTH_LONG).show();
                     }
                 }));
+    }
+
+    /**
+     * Stops a download the user called off. Interrupting is the whole cancel: the read loop checks the flag
+     * every chunk, and {@code downloadApkAsync} suppresses its own callback once interrupted, so no
+     * installer is launched and no failure toast is shown for something nobody is waiting for any more.
+     * A socket read already in flight is not interruptible, so the worker can sit in one until OkHttp's
+     * read timeout — harmless: it is a daemon thread, and the partial file is deleted by the next download.
+     */
+    private static void cancelDownload(final Thread download) {
+        if (download != null) {
+            download.interrupt();
+        }
     }
 
     private static int dp(final Activity activity, final int value) {


### PR DESCRIPTION
The self-updater's progress dialog had **no way out**: `setCancelable(false)` and no buttons at all. A download that stalls without failing — a connection that trickles bytes never reaches OkHttp's read timeout — left the user with a modal that BACK could not dismiss. On a TV that means Home is the only escape, and "the app is frozen" is a fair description of it.

### The cancel was already written, just not wired up

`Updater.downloadApkAsync` returns an interruptible worker, its read loop checks the flag every chunk, and it suppresses its own callback once interrupted — so no installer is launched and no failure toast is shown for a download nobody is waiting for any more. `startDownload` was discarding that thread.

### BACK does the same as the button

Merely dismissing would have left the download running to fire the system installer later, out of any context. `setOnCancelListener` is the right hook rather than `setOnDismissListener`: cancelling is not dismissing, so a normal finish does not come through there.

### Known ceiling, documented in the code

A socket read already in flight is not interruptible, so the worker can sit in one until the read timeout. Harmless: it is a daemon thread, the loop checks the flag *before* writing the next chunk (so it cannot touch the file a retry has just recreated), and the partial `update.apk` is deleted at the start of the next download.

### Also

`bar.setIndeterminate(false)` was called on every percent tick. Only the first has anything to switch; the rest swapped the drawable and invalidated a hundred times over a download, on exactly the low-end boxes where that is noticeable.

### Where this came from

Found while analysing an ANR from a Xiaomi Mi Box S (2 GB, `device.class: low`) that happened in Settings with three live GitHub connections, one of them to `release-assets.githubusercontent.com` — i.e. during a self-update download. **The ANR itself is not attributed to this and is not claimed to be fixed here:** its main thread was parked in `nativePollOnce`, so nothing in our code was blocking, and the likely cause is process starvation while writing ~54 MB on that device. What the trace did surface is this dialog, which is a real defect on its own terms.

### Testing

Built (`assembleLatestUniversalRelease`). The cancel path is reasoned from `Updater`'s existing interrupt checks rather than exercised — the flow needs a published release newer than the installed build to reach.