### PR TITLE
Stop trusting a skip segment that spans the episode

### DIFF
--- a/app/src/main/java/com/brouken/player/skip/SkipManager.java
+++ b/app/src/main/java/com/brouken/player/skip/SkipManager.java
@@ -30,6 +30,14 @@ public class SkipManager {
      */
     private static final double CREDITS_END_TOLERANCE_SEC = 1.5;
 
+    /**
+     * A segment spanning more than this fraction of the file is not an intro, recap or credits — no
+     * such segment covers a third of an episode. Sources do return one: a credits entry whose start
+     * was recorded wrong and whose end is open-ended arrives as "skip from minute six to the end".
+     * Acting on it would skip the episode, so it is dropped once the duration is known.
+     */
+    private static final double MAX_SEGMENT_FRACTION = 1.0 / 3;
+
     private SkipSource source;
     private List<SkipSegment> segments = Collections.emptyList();
 
@@ -56,8 +64,37 @@ public class SkipManager {
     public void rebuild(double durationSec) {
         final List<SkipSegment> base = source != null
                 ? source.getSegments(durationSec) : Collections.<SkipSegment>emptyList();
-        segments = offsetSec != 0 ? applyOffset(base, durationSec) : base;
+        segments = sanitize(offsetSec != 0 ? applyOffset(base, durationSec) : base, durationSec);
         classifyCredits(durationSec);
+    }
+
+    /**
+     * Clamps segment ends to the file end — an open-ended credits segment arrives with a sentinel end
+     * far past it — and drops whatever is left spanning more than {@link #MAX_SEGMENT_FRACTION} of the
+     * file. A no-op while the duration is unknown: there is nothing to judge a segment against then,
+     * and the next rebuild runs this once it is.
+     */
+    private static List<SkipSegment> sanitize(List<SkipSegment> in, double durationSec) {
+        if (!(durationSec > 0)) {
+            return in; // also covers NaN
+        }
+        final double maxSpan = durationSec * MAX_SEGMENT_FRACTION;
+        final List<SkipSegment> out = new ArrayList<>(in.size());
+        for (SkipSegment s : in) {
+            final double end = Math.min(s.endSec, durationSec);
+            if (end <= s.startSec || end - s.startSec > maxSpan) {
+                continue;
+            }
+            if (end == s.endSec) {
+                out.add(s);
+                continue;
+            }
+            final SkipSegment clamped = new SkipSegment(s.startSec, end, s.type, s.category,
+                    s.coordBase, s.timeTrust);
+            clamped.confirmed = s.confirmed;
+            out.add(clamped);
+        }
+        return out;
     }
 
     /** Shift every segment by {@link #offsetSec}, clamped to the media bounds; drop any pushed out. */


### PR DESCRIPTION
## Problem

For 9-1-1 (`tt7235466`) S3E11 the player offered a "skip credits" segment covering almost the whole episode.

Every source is empty for that episode except TheIntroDB, which answers:

```
GET https://api.theintrodb.org/v3/media?tmdb_id=75219&season=3&episode=11
{"credits":[{"start_ms":357000,"end_ms":null}]}
```

357000 ms is 5:57 — nowhere near the end of a ~43 minute episode. Neighbouring episodes in the same database are sane (S3E9 `2536000`, S3E10 `2534000`), so E11-E13 are simply bad rows.

A null `end_ms` means open-ended, which `SegmentFinder` turns into the sentinel `OPEN_ENDED_SEC = 99999`. Nothing clamped that against the file length, so the segment stayed `[357, 99999]`, was classified as credits reaching the end, and skipping it jumped to the next episode. Cross-source voting could not help: it was the only vote in its category, and single-source categories are deliberately still offered.

## Fix

One guard in `SkipManager.rebuild`, the single point every source flows through:

- clamp segment ends to the file duration, which removes the sentinel;
- drop what is left spanning more than a third of the file;
- no-op while the duration is unknown — the next rebuild applies it.

## Verified

Against the real API values, with a standalone run of `SkipManager`:

- `[357, 99999]` at 2580 s (86% of the file) is dropped;
- `[2534, 99999]` is clamped to 2580 and stays `credits` + `reachesEnd`;
- a normal intro and 10-minute credits on a 100-minute film survive;
- an unknown duration filters nothing.

## Known limit

The filter runs after voting. If one source has broken credits and another has good ones, the broken segment can still win its cluster and then be dropped, leaving nothing instead of the good segment. Not the case here (only TheIntroDB has credits at all); passing the duration into `voteSegments` is the fix if it ever shows up.