### PR TITLE
Let the volume and brightness swipes be turned off

### DIFF
--- a/app/src/main/java/com/brouken/player/CustomPlayerView.java
+++ b/app/src/main/java/com/brouken/player/CustomPlayerView.java
@@ -207,6 +207,15 @@ public class CustomPlayerView extends PlayerView implements GestureDetector.OnGe
         return false;
     }
 
+    // True when the viewer has turned the volume/brightness swipes off in the settings.
+    private boolean volumeBrightnessGesturesOff() {
+        if (!(getContext() instanceof PlayerActivity)) {
+            return false;
+        }
+        final Prefs prefs = ((PlayerActivity) getContext()).mPrefs;
+        return prefs != null && prefs.disableVolumeBrightnessGestures;
+    }
+
     @Override
     public boolean onScroll(MotionEvent motionEvent, MotionEvent motionEvent1, float distanceX, float distanceY) {
         // No player check here: brightness and volume must stay reachable even when playback has died
@@ -284,7 +293,12 @@ public class CustomPlayerView extends PlayerView implements GestureDetector.OnGe
         }
 
         // LEFT = Brightness  |  RIGHT = Volume
-        if (gestureOrientation == Orientation.VERTICAL || gestureOrientation == Orientation.UNKNOWN) {
+        // Guarding the branch as a whole, rather than the two changeBrightness/setVolumePercent calls inside
+        // it, is what makes the setting a real off switch: gestureOrientation never becomes VERTICAL, so no
+        // level bar, no boost zone and no indicator ever appear either. The horizontal branch above has
+        // already had its turn, so seeking is untouched.
+        if (!volumeBrightnessGesturesOff()
+                && (gestureOrientation == Orientation.VERTICAL || gestureOrientation == Orientation.UNKNOWN)) {
             gestureScrollY += distanceY;
             if (gestureOrientation == Orientation.UNKNOWN) {
                 if (Math.abs(gestureScrollY) <= SCROLL_STEP)

--- a/app/src/main/java/com/brouken/player/Prefs.java
+++ b/app/src/main/java/com/brouken/player/Prefs.java
@@ -44,6 +44,7 @@ class Prefs {
     private static final String PREF_KEY_ASK_SCOPE = "askScope";
     private static final String PREF_KEY_RESTORE_AUTO_ROTATE = "restoreAutoRotate";
     private static final String PREF_KEY_AUTO_PIP = "autoPiP";
+    private static final String PREF_KEY_DISABLE_VOLUME_BRIGHTNESS_GESTURES = "disableVolumeBrightnessGestures";
     private static final String PREF_KEY_TUNNELING = "tunneling";
     private static final String PREF_KEY_SKIP_SILENCE = "skipSilence";
     private static final String PREF_KEY_FRAMERATE_MATCHING = "frameRateMatching";
@@ -114,6 +115,8 @@ class Prefs {
     // with the picker still open cannot leave the whole phone rotating — see PlayerActivity.enableRotation.
     public boolean restoreAutoRotate = false;
     public boolean autoPiP = false;
+    // Off means the vertical swipes work as they always have; on takes them away entirely.
+    public boolean disableVolumeBrightnessGestures = false;
 
     public boolean tunneling = false;
     public boolean skipSilence = false;
@@ -215,6 +218,8 @@ class Prefs {
 
     public void loadUserPreferences() {
         autoPiP = mSharedPreferences.getBoolean(PREF_KEY_AUTO_PIP, autoPiP);
+        disableVolumeBrightnessGestures = mSharedPreferences.getBoolean(
+                PREF_KEY_DISABLE_VOLUME_BRIGHTNESS_GESTURES, disableVolumeBrightnessGestures);
         tunneling = mSharedPreferences.getBoolean(PREF_KEY_TUNNELING, tunneling);
         skipSilence = mSharedPreferences.getBoolean(PREF_KEY_SKIP_SILENCE, skipSilence);
         frameRateMatching = mSharedPreferences.getBoolean(PREF_KEY_FRAMERATE_MATCHING, frameRateMatching);

--- a/app/src/main/java/com/brouken/player/SettingsActivity.java
+++ b/app/src/main/java/com/brouken/player/SettingsActivity.java
@@ -120,6 +120,11 @@ public class SettingsActivity extends AppCompatActivity {
                 // stream responds — an isolated player volume would look broken there.
                 preferenceSystemVolume.setVisible(false);
             }
+            Preference preferenceDisableGestures = findPreference("disableVolumeBrightnessGestures");
+            if (preferenceDisableGestures != null && Utils.isTvBox(getContext())) {
+                // A remote has no swipes to give up, so there is nothing here to turn off.
+                preferenceDisableGestures.setVisible(false);
+            }
             ListPreference listPreferenceFileAccess = findPreference("fileAccess");
             if (listPreferenceFileAccess != null) {
                 List<String> entries = new ArrayList<>(Arrays.asList(getResources().getStringArray(R.array.file_access_entries)));

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -57,6 +57,9 @@
     <string name="pref_title">Настройки</string>
     <string name="pref_repeat_toggle">Переключение повтора</string>
     <string name="pref_repeat_toggle_summary">Дополнительное управление, позволяющее бесконечно зацикливать видео (требуется перезапуск приложения)</string>
+    <string name="pref_disable_volume_brightness_gestures">Отключить жесты громкости и яркости</string>
+    <string name="pref_disable_volume_brightness_gestures_on">Свайпы вверх и вниз ничего не делают; перемотка, масштаб и кнопки громкости работают</string>
+    <string name="pref_disable_volume_brightness_gestures_off">Проведите вверх или вниз, чтобы изменить яркость в левой части экрана и громкость в правой</string>
     <string name="pref_skip_header">Пропуск сегментов</string>
     <string name="pref_skip_enabled">Включено</string>
     <string name="pref_skip_enabled_on">Пропускать заставки и рекламные сегменты от запускающего приложения</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -58,6 +58,9 @@
     <string name="pref_skip_silence_off">Відтворювати контент як є</string>
     <string name="pref_repeat_toggle">Переключення повтору</string>
     <string name="pref_repeat_toggle_summary">Додатковий контроль, що дозволяє необмежений цикл відео (потрібно перезапустити додаток)</string>
+    <string name="pref_disable_volume_brightness_gestures">Вимкнути жести гучності та яскравості</string>
+    <string name="pref_disable_volume_brightness_gestures_on">Проведення вгору та вниз нічого не робить; перемотування, масштаб і кнопки гучності працюють</string>
+    <string name="pref_disable_volume_brightness_gestures_off">Проведіть вгору або вниз, щоб змінити яскравість у лівій частині екрана та гучність у правій</string>
     <string name="pref_skip_header">Пропуск сегментів</string>
     <string name="pref_skip_enabled">Увімкнено</string>
     <string name="pref_skip_enabled_on">Пропускати заставки та рекламні сегменти від застосунку</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -59,6 +59,9 @@
     <string name="pref_skip_silence_off">Play content as is</string>
     <string name="pref_repeat_toggle">Repeat toggle</string>
     <string name="pref_repeat_toggle_summary">Extra control to allow indefinitely loop video (requires app restart)</string>
+    <string name="pref_disable_volume_brightness_gestures">Turn off volume and brightness swipes</string>
+    <string name="pref_disable_volume_brightness_gestures_on">Swiping up and down does nothing; seeking, zoom and the volume buttons still work</string>
+    <string name="pref_disable_volume_brightness_gestures_off">Swipe up and down to change brightness on the left of the screen and volume on the right</string>
     <string name="pref_skip_header">Skip segments</string>
     <string name="pref_skip_enabled">Enabled</string>
     <string name="pref_skip_enabled_on">Skip intros and ad segments provided by the launching app</string>

--- a/app/src/main/res/xml/root_preferences.xml
+++ b/app/src/main/res/xml/root_preferences.xml
@@ -65,6 +65,13 @@
             app:summary="@string/pref_repeat_toggle_summary"
             app:title="@string/pref_repeat_toggle" />
 
+        <SwitchPreferenceCompat
+            app:key="disableVolumeBrightnessGestures"
+            app:defaultValue="false"
+            app:summaryOn="@string/pref_disable_volume_brightness_gestures_on"
+            app:summaryOff="@string/pref_disable_volume_brightness_gestures_off"
+            app:title="@string/pref_disable_volume_brightness_gestures" />
+
     </PreferenceCategory>
 
     <PreferenceCategory app:title="@string/pref_skip_header">


### PR DESCRIPTION
Adds one switch — **Turn off volume and brightness swipes** — at the end of the
General section of the settings screen. Off by default, so nothing changes for
anyone who does not go looking for it.

The motivation is the near miss: a swipe meant as a seek that lands slightly off
vertical costs the viewer the brightness of the whole film, and some people would
rather have nothing but the picture under their thumb.

### How it is switched off

The guard sits on the vertical branch of `CustomPlayerView.onScroll` as a whole,
not on the `changeBrightness` / `setVolumePercent` calls inside it. That is what
makes it a real off switch rather than a muted one: `gestureOrientation` never
reaches `VERTICAL`, so the level bar, the boost zone and the on-screen indicator
never appear either, and the gesture cannot be left half activated. The horizontal
branch has already had its turn by that point, so it is untouched.

Still working when the switch is on: horizontal swipe-to-seek, double-tap seek,
pinch-to-zoom, long-press speed boost, and the hardware volume keys — the setting
is about touch gestures only.

Hidden on TV, right next to the `systemVolume` switch that is hidden there for its
own reason: a remote has no swipes to give up.

`loadUserPreferences()` already runs when the settings screen closes, so the switch
takes effect immediately — no restart caveat needed in the summary.

Ukrainian and Russian strings are included rather than left for Weblate.

### Testing

Built and installed on a phone. No automated tests exist in this project, so the
checks are manual: fresh install shows the switch off with both swipes behaving as
before; switching it on silences the vertical swipes with no leftover indicator,
while seeking, double-tap, pinch-zoom and the volume buttons all still work; and
the preference is absent on TV.
