### PR TITLE
Offer the Skip button briefly, and name the modes by how long it stays

### DIFF
--- a/app/src/main/java/com/brouken/player/PlayerActivity.java
+++ b/app/src/main/java/com/brouken/player/PlayerActivity.java
@@ -669,7 +669,9 @@ public class PlayerActivity extends Activity {
     // when the intro's first frames arrive. Only the button is pre-shown; auto-skip waits for the
     // segment itself, or it would silently cut the seconds of real content that still precede it.
     static final double SKIP_LEAD_SEC = 3;
-    // How long the "undo" pill stays up after an automatic jump.
+    // How long a timed pill stays up: the "undo" offer after a jump, and brief mode's Skip offer. The
+    // pref_skip_mode_brief option names these seconds out loud ("Skip button for 3 seconds"), so changing
+    // this means changing that string in every locale too.
     static final long SKIP_NOTICE_MS = 3000;
     // Faint groove the pill's countdown underline drains along; transparent when there is no underline.
     static final int SKIP_PILL_GROOVE_COLOR = 0x33FFFFFF;
@@ -730,6 +732,13 @@ public class PlayerActivity extends Activity {
     private int skipPillSecs;
     // When the post-skip notice is due to disappear, so its underline can drain like the other states'.
     private long skipNoticeHideAtMs;
+    // Brief mode: when the timed Skip offer is due to go. Ownership of the pill is derived from it rather
+    // than latched (see skipFlashActive), so anything that takes the pill over ends the flash by itself.
+    private long skipFlashEndMs;
+    // Brief mode: end of the segment whose one automatic offer has already been made. Keyed on the position
+    // and not the segment object for the reason spelled out at autoSkipUndone — a segment can come back
+    // re-derived, with its once-only flags cleared.
+    private long skipBriefFlashedUntilMs = C.TIME_UNSET;
     // Confirm key whose ACTION_UP must be swallowed after triggering a Skip on its ACTION_DOWN (TV).
     private int skipKeyUpToConsume = 0;
     final Runnable skipRunnable = new Runnable() {
@@ -1673,6 +1682,8 @@ public class PlayerActivity extends Activity {
                 }
                 updateOverlayClock();
                 scheduleHideControllerOnPause();
+                // Brief skip mode: the Skip button comes and goes with the controls — see rideSkipWithController.
+                updateBriefSkipWithController();
 
                 if (PlayerActivity.restoreControllerTimeout) {
                     restoreControllerTimeout = false;
@@ -2880,7 +2891,9 @@ public class PlayerActivity extends Activity {
         }
         final double posSec = player.getCurrentPosition() / 1000.0;
         if (skipPill == SkipPill.UNDO) {
-            updateUndoCountdown();
+            updatePillCountdown(skipNoticeHideAtMs, R.string.notification_skipped_undo);
+        } else if (skipFlashActive()) {
+            updatePillCountdown(skipFlashEndMs, R.string.button_skip_countdown);
         }
         final SkipSegment segment = skipManager.activeSegment(posSec);
         if (segment == null) {
@@ -2894,6 +2907,13 @@ public class PlayerActivity extends Activity {
             } else if (isAutoSkip(upcoming)) {
                 hideSkipButton();
                 showSkipHeadsUp(upcoming);
+            } else if (isBriefSkip(upcoming)) {
+                // No head start in brief mode: the offer belongs to the segment, and three seconds spent
+                // before it even begins would be three the viewer never gets over the intro itself.
+                hideSkipHeadsUp();
+                if (!skipFlashActive()) {
+                    hideSkipButton(); // clear anything the segment just behind us left up
+                }
             } else {
                 hideSkipHeadsUp();
                 updateSkipButtonProgress(upcoming);
@@ -2906,6 +2926,8 @@ public class PlayerActivity extends Activity {
             hideSkipButton();
             skipSeekTo(segment);
             showSkipNotification(true);
+        } else if (isBriefSkip(segment)) {
+            briefSkipTick(segment);
         } else {
             updateSkipButtonProgress(segment);
             showSkipButton(segment);
@@ -3005,7 +3027,7 @@ public class PlayerActivity extends Activity {
         }
         if (fresh || secsLeft != skipPillSecs) {
             skipPillSecs = secsLeft;
-            showSkipPill(SkipPill.CANCEL, countdownLabel(R.string.notification_skipping_cancel, secsLeft), true);
+            showSkipPill(SkipPill.CANCEL, countdownLabel(R.string.notification_skipping_cancel, secsLeft), true, true);
         }
     }
 
@@ -3024,9 +3046,11 @@ public class PlayerActivity extends Activity {
 
     /**
      * Paints and shows the one floating pill. {@code actionable} also drives focusability: a pill that
-     * does nothing must not take D-pad focus away from the player.
+     * does nothing must not take D-pad focus away from the player. {@code claimFocus} says whether this
+     * pill may take the focus at all — a pill the viewer summoned themselves must not, or it snatches the
+     * focus out from under the controls they are navigating.
      */
-    private void showSkipPill(SkipPill mode, CharSequence label, boolean actionable) {
+    private void showSkipPill(SkipPill mode, CharSequence label, boolean actionable, boolean claimFocus) {
         if (buttonSkip == null) {
             return;
         }
@@ -3034,17 +3058,28 @@ public class PlayerActivity extends Activity {
             hideSkipPill(); // unusable in the PiP window; automatic skips still happen, just silently
             return;
         }
+        // Whatever timer the outgoing pill had is not the incoming one's. Without this a pill replaced
+        // mid-countdown — back-to-back segments land the next offer inside the previous notice's three
+        // seconds — inherited a hider that took the new pill away early. Callers that want a timer arm
+        // it after calling this.
+        if (playerView != null) {
+            playerView.removeCallbacks(skipPillHider);
+        }
+        // Read before the assignment below: a change of state is what earns a focus request, so a countdown
+        // repainting itself every second cannot keep yanking the focus back.
+        final boolean stateChanged = skipPill != mode;
         skipPill = mode;
         buttonSkip.setText(label);
         buttonSkip.setCompoundDrawablesRelative(
                 pillIcon(mode), null, null, null);
         buttonSkip.setClickable(actionable);
         buttonSkip.setFocusable(actionable);
-        if (buttonSkip.getVisibility() != View.VISIBLE) {
+        final boolean appearing = buttonSkip.getVisibility() != View.VISIBLE;
+        if (appearing) {
             buttonSkip.setVisibility(View.VISIBLE);
-            if (isTvBox && actionable) {
-                buttonSkip.requestFocus();
-            }
+        }
+        if (isTvBox && actionable && claimFocus && (appearing || stateChanged)) {
+            buttonSkip.requestFocus();
         }
     }
 
@@ -3092,16 +3127,16 @@ public class PlayerActivity extends Activity {
         }
     }
 
-    /** Ticks the seconds left on the undo pill while it is up. */
-    private void updateUndoCountdown() {
+    /** Ticks the seconds left on whichever timed pill is up — the undo offer or brief mode's Skip offer. */
+    private void updatePillCountdown(long deadlineMs, int labelRes) {
         if (buttonSkip == null || !buttonSkip.isClickable()) {
             return; // a plain "skipped" notice has nothing to count down to
         }
         final int secsLeft = (int) Math.max(1,
-                Math.ceil((skipNoticeHideAtMs - SystemClock.uptimeMillis()) / 1000.0));
+                Math.ceil((deadlineMs - SystemClock.uptimeMillis()) / 1000.0));
         if (secsLeft != skipPillSecs) {
             skipPillSecs = secsLeft;
-            buttonSkip.setText(countdownLabel(R.string.notification_skipped_undo, secsLeft));
+            buttonSkip.setText(countdownLabel(labelRes, secsLeft));
         }
     }
 
@@ -3143,6 +3178,10 @@ public class PlayerActivity extends Activity {
         skipUndoneUntilMs = C.TIME_UNSET;
         skipHeadsUpEndMs = C.TIME_UNSET;
         skipPillSecs = 0;
+        // Called on every media item change, which is exactly when brief mode's "already offered" mark has
+        // to go: two episodes of the same length can carry intros that end on the very same millisecond, and
+        // the mark is keyed on that position, so keeping it would swallow the next episode's offer.
+        skipBriefFlashedUntilMs = C.TIME_UNSET;
     }
 
     // OK/Enter-style keys that activate the focused Skip button on a TV remote / gamepad.
@@ -3216,7 +3255,103 @@ public class PlayerActivity extends Activity {
             return;
         }
         pendingSkip = segment;
-        showSkipPill(SkipPill.SKIP, getString(R.string.button_skip), true);
+        showSkipPill(SkipPill.SKIP, getString(R.string.button_skip), true, true);
+    }
+
+    /** Whether this segment's position is set to offer the Skip button briefly rather than throughout. */
+    private boolean isBriefSkip(SkipSegment segment) {
+        return Prefs.SKIP_MODE_BRIEF.equals(segment.credits ? mPrefs.skipModeCredits : mPrefs.skipMode);
+    }
+
+    /** True while brief mode's timed offer is on screen and owns the pill. */
+    private boolean skipFlashActive() {
+        return skipPill == SkipPill.SKIP && SystemClock.uptimeMillis() < skipFlashEndMs;
+    }
+
+    /**
+     * Brief mode, once playback is inside a segment the viewer is asked about. The offer comes twice over:
+     * once by itself when the segment starts, and thereafter only while the controller is up. Between the
+     * two the picture is left alone, which is the whole point of the mode — the Skip button in the corner
+     * for the length of an intro is exactly what it exists to avoid.
+     */
+    private void briefSkipTick(SkipSegment segment) {
+        pendingSkip = segment;
+        if (skipFlashActive()) {
+            if (!controllerVisible) {
+                return; // still counting down; leave it its three seconds
+            }
+            // Controls came up mid-countdown. End the flash here and hand the pill over rather than letting
+            // its timer run out under an open controller, which would blink the button out and back in.
+            skipFlashEndMs = 0;
+        }
+        // Controls already up when the segment arrived: ride along with them and keep the segment's own
+        // offer in hand. Counting down over an open controller would say nothing — the button is not about
+        // to go while the controls are there — and would then blink out and straight back in as this rides.
+        if (controllerVisible) {
+            rideSkipWithController();
+            return;
+        }
+        if (segment.endMs() != skipBriefFlashedUntilMs) {
+            flashSkipOffer(segment);
+            return;
+        }
+        rideSkipWithController();
+    }
+
+    /**
+     * The one unprompted offer: three seconds of Skip, counted down in the label, then gone. Same timer and
+     * same countdown as the undo pill, because it is the same promise in the other direction.
+     */
+    private void flashSkipOffer(SkipSegment segment) {
+        if (buttonSkip == null || playerView == null) {
+            return;
+        }
+        // Do not spend the segment's one offer where it cannot be seen — it would be spent invisibly and
+        // never come back on its own. The controller can still summon it, and PiP/unlock re-arms nothing.
+        if (inPip || (locked && mPrefs.skipHideWhenLocked)) {
+            return;
+        }
+        skipBriefFlashedUntilMs = segment.endMs();
+        skipFlashEndMs = SystemClock.uptimeMillis() + SKIP_NOTICE_MS;
+        skipPillSecs = (int) (SKIP_NOTICE_MS / 1000);
+        hideSkipPillUnderline(); // the number is the countdown here; no bar to say it twice
+        showSkipPill(SkipPill.SKIP, countdownLabel(R.string.button_skip_countdown, skipPillSecs), true, true);
+        playerView.postDelayed(skipPillHider, SKIP_NOTICE_MS);
+    }
+
+    /**
+     * After the flash, the button is the controller's companion: shown whenever the controls are, gone with
+     * them. No countdown and no timer — the screen is already given over to controls, so there is nothing
+     * left to keep clean, and a button vanishing from under the viewer's finger would read as a fault. It
+     * takes no focus either: they are steering, and the pill must not grab the D-pad out of their hands.
+     */
+    private void rideSkipWithController() {
+        if (locked && mPrefs.skipHideWhenLocked) {
+            return;
+        }
+        if (controllerVisible) {
+            hideSkipPillUnderline();
+            showSkipPill(SkipPill.SKIP, getString(R.string.button_skip), true, false);
+        } else if (skipPill == SkipPill.SKIP) {
+            hideSkipButton();
+        }
+    }
+
+    /**
+     * Brief mode's second trigger, driven by the controller rather than the clock. Called from the
+     * controller's visibility listener because the 250 ms poll is both too slow to feel like a response to
+     * a tap and stopped altogether while playback is paused.
+     */
+    private void updateBriefSkipWithController() {
+        if (player == null || skipManager == null || mPrefs == null || !mPrefs.skipEnabled) {
+            return;
+        }
+        final double posSec = player.getCurrentPosition() / 1000.0;
+        final SkipSegment segment = skipManager.activeSegment(posSec);
+        if (segment == null || isAutoSkip(segment) || !isBriefSkip(segment)) {
+            return;
+        }
+        briefSkipTick(segment);
     }
 
     /**
@@ -3262,8 +3397,7 @@ public class PlayerActivity extends Activity {
         showSkipPill(SkipPill.UNDO, undoable
                         ? countdownLabel(R.string.notification_skipped_undo, skipPillSecs)
                         : getString(R.string.notification_skipped),
-                undoable);
-        playerView.removeCallbacks(skipPillHider);
+                undoable, true);
         playerView.postDelayed(skipPillHider, SKIP_NOTICE_MS);
     }
 

--- a/app/src/main/java/com/brouken/player/Prefs.java
+++ b/app/src/main/java/com/brouken/player/Prefs.java
@@ -72,6 +72,10 @@ class Prefs {
     private static final String PREF_KEY_REVOKED_AUDIO_MIMES = "revokedAudioMimes";
     private static final String PREF_KEY_REVOKED_AUDIO_MIMES_RELEARNED = "revokedAudioMimesRelearned";
 
+    // How a skippable segment is offered. BRIEF shows the Skip button for PlayerActivity.SKIP_NOTICE_MS and
+    // then leaves the picture alone; the option's name says "3 seconds", so that constant and the
+    // pref_skip_mode_brief strings have to move together.
+    public static final String SKIP_MODE_BRIEF = "brief";
     public static final String SKIP_MODE_BUTTON = "button";
     public static final String SKIP_MODE_AUTO = "auto";
 
@@ -130,8 +134,8 @@ class Prefs {
     public boolean subtitleStyleEmbedded = true;
     public boolean subtitleStyleBold = false;
     public boolean skipEnabled = true;
-    public String skipMode = SKIP_MODE_BUTTON;
-    public String skipModeCredits = SKIP_MODE_BUTTON;
+    public String skipMode = SKIP_MODE_BRIEF;
+    public String skipModeCredits = SKIP_MODE_BRIEF;
     public boolean skipHideWhenLocked = false;
     public boolean skipFetchOnline = true;
     public String skipUndo = SKIP_UNDO_ALL;

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -65,7 +65,8 @@
     <string name="pref_skip_enabled_on">Пропускать заставки и рекламные сегменты от запускающего приложения</string>
     <string name="pref_skip_enabled_off">Воспроизводить как есть</string>
     <string name="pref_skip_mode">Заставка</string>
-    <string name="pref_skip_mode_button">Показывать кнопку «Пропустить»</string>
+    <string name="pref_skip_mode_brief">Кнопка «Пропустить» на 3 секунды</string>
+    <string name="pref_skip_mode_button">Кнопка «Пропустить» на весь сегмент</string>
     <string name="pref_skip_mode_auto">Пропускать автоматически</string>
     <string name="pref_skip_mode_credits">Финальные титры</string>
     <string name="pref_skip_fetch">Искать сегменты онлайн</string>
@@ -83,6 +84,7 @@
     <string name="skip_offset_reset">Сбросить</string>
     <string name="button_skip_offset">Смещение пропуска</string>
     <string name="button_skip">Пропустить</string>
+    <string name="button_skip_countdown">Пропустить %1$d</string>
     <string name="notification_skipped">Пропущено</string>
     <string name="notification_skipped_undo">Вернуться %1$d</string>
     <string name="notification_skipping_cancel">Не пропускать %1$d</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -66,7 +66,8 @@
     <string name="pref_skip_enabled_on">Пропускати заставки та рекламні сегменти від застосунку</string>
     <string name="pref_skip_enabled_off">Відтворювати контент як є</string>
     <string name="pref_skip_mode">Заставка</string>
-    <string name="pref_skip_mode_button">Показувати кнопку «Пропустити»</string>
+    <string name="pref_skip_mode_brief">Кнопка «Пропустити» на 3 секунди</string>
+    <string name="pref_skip_mode_button">Кнопка «Пропустити» на весь сегмент</string>
     <string name="pref_skip_mode_auto">Пропускати автоматично</string>
     <string name="pref_skip_mode_credits">Кінцеві титри</string>
     <string name="pref_skip_fetch">Шукати сегменти онлайн</string>
@@ -84,6 +85,7 @@
     <string name="skip_offset_reset">Скинути</string>
     <string name="button_skip_offset">Зміщення пропуску</string>
     <string name="button_skip">Пропустити</string>
+    <string name="button_skip_countdown">Пропустити %1$d</string>
     <string name="notification_skipped">Пропущено</string>
     <string name="notification_skipped_undo">Повернутися %1$d</string>
     <string name="notification_skipping_cancel">Не пропускати %1$d</string>

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -27,11 +27,13 @@
   </string-array>
 
   <string-array name="skip_mode_entries">
+    <item>@string/pref_skip_mode_brief</item>
     <item>@string/pref_skip_mode_button</item>
     <item>@string/pref_skip_mode_auto</item>
   </string-array>
 
   <string-array name="skip_mode_values">
+    <item>brief</item>
     <item>button</item>
     <item>auto</item>
   </string-array>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -67,7 +67,8 @@
     <string name="pref_skip_enabled_on">Skip intros and ad segments provided by the launching app</string>
     <string name="pref_skip_enabled_off">Play content as is</string>
     <string name="pref_skip_mode">Intro</string>
-    <string name="pref_skip_mode_button">Show Skip button</string>
+    <string name="pref_skip_mode_brief">Skip button for 3 seconds</string>
+    <string name="pref_skip_mode_button">Skip button for the whole segment</string>
     <string name="pref_skip_mode_auto">Skip automatically</string>
     <string name="pref_skip_mode_credits">End credits</string>
     <string name="pref_skip_fetch">Find segments online</string>
@@ -85,6 +86,7 @@
     <string name="skip_offset_reset">Reset</string>
     <string name="button_skip_offset">Skip offset</string>
     <string name="button_skip">Skip</string>
+    <string name="button_skip_countdown">Skip %1$d</string>
     <string name="notification_skipped">Skipped</string>
     <string name="notification_skipped_undo">Go back %1$d</string>
     <string name="notification_skipping_cancel">Don\'t skip %1$d</string>

--- a/app/src/main/res/xml/root_preferences.xml
+++ b/app/src/main/res/xml/root_preferences.xml
@@ -84,7 +84,7 @@
             app:title="@string/pref_skip_enabled" />
 
         <ListPreference
-            app:defaultValue="button"
+            app:defaultValue="brief"
             app:dependency="skipEnabled"
             app:entries="@array/skip_mode_entries"
             app:entryValues="@array/skip_mode_values"
@@ -93,7 +93,7 @@
             app:useSimpleSummaryProvider="true" />
 
         <ListPreference
-            app:defaultValue="button"
+            app:defaultValue="brief"
             app:dependency="skipEnabled"
             app:entries="@array/skip_mode_entries"
             app:entryValues="@array/skip_mode_values"


### PR DESCRIPTION
Adds a third way to handle a skippable segment, and makes it the default for both
Intro and End credits.

**Why.** In `button` mode the Skip button sits in the corner for the whole segment,
and an intro runs well over a minute — a piece of interface parked over the picture
for all of it. The new mode offers the button for three seconds when the segment
starts, counts them down in the label exactly as the "Go back" pill does (same
`countdownLabel` helper, so the same accent digit), no underline, and then gets out
of the way.

**Two triggers, because three seconds cannot be the only chance.** A viewer who
looked away would otherwise have no route back to the skip at all. So:

- **Unprompted**, once per segment, at its start: the timed countdown.
- **Summoned**, thereafter: the button rides with the controller — shown whenever
  the controls are, gone with them, no countdown. The screen is already given over
  to controls at that point, so there is nothing left to keep clean, and a button
  vanishing from under a finger reads as a fault.

The mark that the unprompted offer has been spent is keyed on the segment's **end
position**, not on the segment object — `autoSkipUndone` documents why: a segment
can come back re-derived with its once-only flags cleared. `clearSkipUndo` drops the
mark, because two episodes of the same length can carry intros that end on the very
same millisecond.

Handover is glitch-free in both directions: controls already up when the segment
arrives means no countdown at all (it would be claiming the button is about to go
when it is not), and controls raised mid-countdown end the flash on the spot rather
than letting its timer burn down and blink the button out and back in.

**Focus follows who asked.** The unprompted offer claims it, so OK works immediately
on a remote. The summoned one never does — it would snatch the D-pad from someone
steering the controls, and the existing remote routing only fires with the controller
hidden anyway. Claiming is now tied to a change of pill state rather than to becoming
visible, which also stops a countdown repainting every second from yanking focus back.

**Naming.** A third option makes "Show Skip button" meaningless, so all three are
renamed after what actually separates them:

| | |
|---|---|
| Skip button for 3 seconds | new, default |
| Skip button for the whole segment | was "Show Skip button" |
| Skip automatically | unchanged |

The seconds are spoken aloud in the option's name, so `SKIP_NOTICE_MS` carries a note
that the strings move with it. Ukrainian and Russian are included rather than left to
Weblate.

**No migration needed.** `PreferenceManager.setDefaultValues` is never called and a
`ListPreference` persists only on an explicit change, so opening the settings screen
has not been writing `"button"` into prefs. Everyone who never touched the setting
picks the new default up; anyone who chose a mode keeps it.

### Also fixes an existing bug

The pill's *show* path never cancelled the outgoing pill's hide timer — only its hide
path did. Back-to-back segments (a recap straight after an intro, an ad chain) land
the next offer inside the previous notice's three seconds, and the stale timer then
took the new pill away early. Now cancelled in `showSkipPill`, where every state
change passes. The new mode would have walked straight into this.

### Testing

No automated tests exist in this project, so this was checked by hand. Verified on a
phone: the new mode is the default on a fresh install, the button appears at segment
start and counts down with the digit coloured like "Go back" and no underline before
going, raising the controls brings it back and dropping them takes it away, pressing
it skips exactly as the old button did, and the other two modes behave as before.

Not yet exercised on a TV: the focus handover between the unprompted and summoned
offers is the part a remote would show up.
