### PR TITLE
Keep playing when the audio output dies under the player

### DIFF
--- a/app/src/main/java/com/brouken/player/PlayerActivity.java
+++ b/app/src/main/java/com/brouken/player/PlayerActivity.java
@@ -6349,7 +6349,16 @@ public class PlayerActivity extends Activity {
                     && recoverByRevokingAudioMime(audioTrackInitFailureMime(error))) {
                 return;
             }
-            if ((isDecoderFailure(error) || isUnexpectedPlaybackError(error))
+            // A bitstream's AudioTrack can also die under a player that was happily feeding it for an hour
+            // (AudioTrack.write returns ERROR_DEAD_OBJECT: the audio server restarted, or the HDMI route to
+            // the receiver dropped). Media3 calls that recoverable but spends its single attempt at the front
+            // of the message queue — milliseconds after the output died, so it fails again and ends playback.
+            // The same delayed re-read is what this needs: by then the route is usually back, and prepare()
+            // keeps the item, position, surface and track selection. Not a reason to revoke the mime as the
+            // branch above does — this device had been bitstreaming it fine until the output went away, and
+            // if it comes back without passthrough the reselect falls to ffmpeg on its own.
+            if ((isDecoderFailure(error) || isUnexpectedPlaybackError(error)
+                    || error.errorCode == PlaybackException.ERROR_CODE_AUDIO_TRACK_WRITE_FAILED)
                     && recoverFromDecoderFailure()) {
                 return;
             }


### PR DESCRIPTION
## The failure

Sentry `JUST-PLUS-PLAYER-2H`. An NVIDIA SHIELD TV Pro (Android 11) playing a Jellyfin direct stream — mp4, Dolby Vision video, E-AC3 5.1 bitstreamed over HDMI — lost its audio output **53 minutes into a 101-minute film**: `AudioTrack.write` returned `-6`, `ERROR_DEAD_OBJECT`. The audio server restarting or the HDMI link to the receiver renegotiating does that to a track that has been fed without trouble for an hour.

The viewer got a full-screen error and lost the session, for two reasons:

1. Media3 classifies the error as recoverable but retries it **once**, posted with `sendMessageAtFrontOfQueue` — milliseconds after the output went away, so the second write failed too and the error became fatal. (`ExoPlayerImplInternal` exempts only the two `AUDIO_TRACK_OFFLOAD_*` codes from the one-attempt limit; this is `ERROR_CODE_AUDIO_TRACK_WRITE_FAILED`.) The reported exception carries its own predecessor as `Suppressed`, which is the signature of exactly that sequence.
2. `onPlayerError` had no branch for `ERROR_CODE_AUDIO_TRACK_WRITE_FAILED` at all, so it fell straight through to the error screen.

## The change

One condition: route that error code into the existing `recoverFromDecoderFailure()` — `player.prepare()` after `1200 ms × attempt`, three attempts per player build, budget reset once a frame renders. A *delayed* re-read is the whole point, since the immediate one has already been tried and failed. `prepare()` keeps the media item, the position, the surface and the track selection, so the viewer sees a moment of spinner rather than a dead session.

The mime is deliberately **not** revoked, unlike the neighbouring `ERROR_CODE_AUDIO_TRACK_INIT_FAILED` branch: that penalty is permanent, persisted and device-wide, and this box had been bitstreaming E-AC3 fine until the output disappeared. `format_supported=NO_UNSUPPORTED_SUBTYPE` in the Sentry title is a consequence of the dead output making the player re-query the HDMI route, not a verdict on the device. If the route does come back without passthrough, track selection falls to the software decoder on its own.

## How it was checked

There are no tests in the repo and the failure cannot be produced by hand, so it was injected: a temporary override in the audio sink wrapper throwing `AudioSink.WriteException(-6, format, true)`, run on the `tv_720p` emulator against a clip served over HTTP. The override is not part of this PR.

| Injected | Result |
|---|---|
| Two failures inside one recovery window (the field shape) | `Playback error` with a `Suppressed` duplicate — the reported chain reproduced. Then cured: `ERROR` at 12 036 ms, `PLAYING` again at **12 051 ms**, roughly 1.2 s, no error screen. Held over three separate bursts. |
| Thirty in a row (the route stays dead) | Bounded — three re-prepares, then the existing error screen. No loop. |

Worth noting for anyone repeating this: a **single** injected failure is always cured by Media3 itself and never reaches the app, because the cure reaches `STATE_READY` and clears the pending-error latch. Two inside one window are needed.