### PR TITLE
Offer a sleep timer, by duration or to the end of the file

### DIFF
--- a/app/src/main/java/com/brouken/player/DurationPanel.java
+++ b/app/src/main/java/com/brouken/player/DurationPanel.java
@@ -1,0 +1,364 @@
+package com.brouken.player;
+
+import android.app.Activity;
+import android.app.Dialog;
+import android.content.res.ColorStateList;
+import android.content.res.Configuration;
+import android.graphics.Color;
+import android.graphics.Typeface;
+import android.graphics.drawable.ColorDrawable;
+import android.graphics.drawable.GradientDrawable;
+import android.graphics.drawable.RippleDrawable;
+import android.text.SpannableStringBuilder;
+import android.text.format.DateFormat;
+import android.text.style.RelativeSizeSpan;
+import android.util.TypedValue;
+import android.view.Gravity;
+import android.view.KeyEvent;
+import android.view.View;
+import android.view.ViewGroup;
+import android.view.Window;
+import android.widget.ImageButton;
+import android.widget.LinearLayout;
+import android.widget.ScrollView;
+import android.widget.TextView;
+
+import java.util.Date;
+import java.util.Locale;
+
+/**
+ * An end-docked panel for typing a duration on a numeric keypad, modelled on VLC's time picker
+ * (dialog_time_picker.xml): digits shift in from the right like an alarm clock, so 1-3-0 reads as 1ʰ30ᵐ
+ * and a bare 90 means an hour and a half.
+ *
+ * Taken from that picker: keys with no background, bold and 18sp, carrying a layout weight instead of a
+ * width so three of them divide whatever the column measures; a backspace beside the readout, which is the
+ * way back from a mistyped digit; the ":00"/":30" keys that fill the minutes in one tap; and two equal
+ * actions across the foot. Typed rather than dragged because the values wanted here span minutes to hours,
+ * and the ± / SeekBar idiom of {@link OffsetPanel} needs one step size that would serve neither end.
+ *
+ * Sizing is derived rather than fixed. Key rows take what is left of the panel's height after the parts
+ * whose size is set by their text, so the whole thing fits by construction: a docked panel is roughly
+ * 304 × 804 dp in portrait but only 360 × 363 dp in landscape, and four finger-sized rows plus a readout
+ * plus actions do not fit the latter stacked — hence landscape sets the keypad beside the readout instead
+ * of below it, which is the one thing here that VLC's bottom sheet never has to solve.
+ */
+final class DurationPanel {
+
+    interface Listener {
+        /** @param minutes the picked duration, or 0 to turn the timer off */
+        void onDurationPicked(int minutes);
+    }
+
+    private static final int MAX_MINUTES = 12 * 60;
+
+    private DurationPanel() {
+    }
+
+    /**
+     * @param insetSource view used to read the window insets for the panel padding (any attached view)
+     * @param accent      brand accent for the readout and the Start action
+     */
+    static Dialog create(final Activity activity, final UiMetrics ui, final View insetSource,
+                         final int accent, final String title, final Listener listener) {
+        final int[] typed = {0}; // up to 4 digits, read as HHMM
+
+        final Configuration cfg = activity.getResources().getConfiguration();
+        final boolean landscape = cfg.orientation == Configuration.ORIENTATION_LANDSCAPE;
+        final int hPad = Utils.dpToPx(24) + ui.overscanH();
+        final int usableW = ui.pickerWidthPx(cfg) - 2 * hPad;
+
+        // Portrait has height to spare, so the rows simply take VLC's own size. Landscape has to divide what
+        // is left after the title and the window insets — and only those: with the keypad beside the readout
+        // rather than under it, the readout and the actions cost the rows nothing. Counting them anyway is
+        // what squeezed these rows to 33dp.
+        final int rowHeight = ui.dp(landscape
+                ? Math.max(36, Math.min(52, (cfg.screenHeightDp - 110) / 4 - 8))
+                : 52);
+
+        final LinearLayout root = new LinearLayout(activity);
+        root.setOrientation(LinearLayout.VERTICAL);
+
+        // Left-aligned 18sp medium, as VLC's BottomSheetTitle is — and as every other picker header in
+        // this app already is.
+        final TextView header = new TextView(activity);
+        header.setText(title);
+        header.setTextColor(Color.WHITE);
+        header.setTextSize(TypedValue.COMPLEX_UNIT_SP, ui.textTitle());
+        header.setTypeface(Typeface.create("sans-serif-medium", Typeface.NORMAL));
+        header.setMinHeight(ui.dp(48));
+        header.setGravity(Gravity.CENTER_VERTICAL);
+        root.addView(header);
+
+        // Laid out top down with plain margins, exactly as VLC's sheet is — no weight, no vertical centring.
+        // Those two put a void above the readout and another below the keypad, and gave the scroll view room
+        // to carry the title off the top edge. Nothing here needs to stretch.
+        final LinearLayout body = new LinearLayout(activity);
+        body.setOrientation(landscape ? LinearLayout.HORIZONTAL : LinearLayout.VERTICAL);
+        body.setLayoutParams(new LinearLayout.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT));
+        root.addView(body);
+
+        // Side by side the width splits 45/55 in the keypad's favour: it has three columns to seat, the
+        // readout only its own digits and the two actions.
+        final LinearLayout readoutColumn = new LinearLayout(activity);
+        readoutColumn.setOrientation(LinearLayout.VERTICAL);
+        readoutColumn.setLayoutParams(new LinearLayout.LayoutParams(
+                landscape ? Math.round(usableW * 0.45f) : ViewGroup.LayoutParams.MATCH_PARENT,
+                ViewGroup.LayoutParams.WRAP_CONTENT));
+        body.addView(readoutColumn);
+
+        final LinearLayout valueRow = new LinearLayout(activity);
+        valueRow.setOrientation(LinearLayout.HORIZONTAL);
+        valueRow.setGravity(Gravity.CENTER_VERTICAL);
+        readoutColumn.addView(valueRow);
+
+        final TextView value = new TextView(activity);
+        // 24sp bold, VLC's size for this readout — not the big light numeral of the skip-offset panel. That
+        // one owns its whole panel; this one shares a line with a backspace and a narrow landscape column.
+        value.setTextSize(TypedValue.COMPLEX_UNIT_SP, ui.sp(24));
+        value.setTypeface(Typeface.DEFAULT_BOLD);
+        value.setFontFeatureSettings("tnum"); // fixed-width digits: the readout stops twitching as it fills
+        value.setGravity(Gravity.CENTER_VERTICAL);
+        value.setLayoutParams(new LinearLayout.LayoutParams(
+                0, ViewGroup.LayoutParams.WRAP_CONTENT, 1f));
+        valueRow.addView(value);
+
+        final ImageButton backspace = new ImageButton(activity, null, 0,
+                R.style.ExoStyledControls_Button_Bottom);
+        backspace.setImageResource(R.drawable.ic_backspace_24dp);
+        backspace.setContentDescription(activity.getString(R.string.sleep_timer_backspace));
+        valueRow.addView(backspace);
+
+        // Where the duration lands in wall-clock terms — the same phrasing the header uses for the end of
+        // the video, since it answers the same question.
+        final TextView endsAt = new TextView(activity);
+        endsAt.setTextColor(0xB3FFFFFF);
+        endsAt.setTextSize(TypedValue.COMPLEX_UNIT_SP, ui.textEndsAt());
+        endsAt.setPadding(0, 0, 0, Utils.dpToPx(6));
+        readoutColumn.addView(endsAt);
+
+        // Under the readout, not under the title: here the rule is the underline of a field being typed into.
+        final View divider = new View(activity);
+        divider.setLayoutParams(new LinearLayout.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT, Utils.dpToPx(1)));
+        divider.setBackgroundColor(0x1AFFFFFF);
+        readoutColumn.addView(divider);
+
+        final Runnable render = () -> {
+            final SpannableStringBuilder text = new SpannableStringBuilder();
+            appendUnit(text, String.format(Locale.US, "%d", typed[0] / 100), "h");
+            text.append("  ");
+            appendUnit(text, String.format(Locale.US, "%02d", typed[0] % 100), "m");
+            value.setText(text);
+            value.setTextColor(typed[0] == 0 ? Color.WHITE : accent);
+            backspace.setEnabled(typed[0] != 0);
+            backspace.setAlpha(typed[0] != 0 ? 1f : 0.35f);
+
+            final int total = totalMinutes(typed[0]);
+            if (total > 0) {
+                final Date end = new Date(System.currentTimeMillis() + total * 60_000L);
+                endsAt.setText(activity.getString(R.string.time_ends_at_inline,
+                        DateFormat.getTimeFormat(activity).format(end)));
+                endsAt.setVisibility(View.VISIBLE);
+            } else {
+                // INVISIBLE, not GONE: nothing below may shift as the line comes and goes.
+                endsAt.setVisibility(View.INVISIBLE);
+            }
+        };
+
+        final View[] firstKey = new View[1];
+        final View[] digitKeys = new View[10];
+        final LinearLayout keypad = new LinearLayout(activity);
+        keypad.setOrientation(LinearLayout.VERTICAL);
+        final LinearLayout.LayoutParams keypadLp = new LinearLayout.LayoutParams(
+                landscape ? Math.round(usableW * 0.55f) : ViewGroup.LayoutParams.MATCH_PARENT,
+                ViewGroup.LayoutParams.WRAP_CONTENT);
+        if (!landscape) {
+            keypadLp.topMargin = Utils.dpToPx(8);
+        }
+        keypad.setLayoutParams(keypadLp);
+        for (int row = 0; row < 3; row++) {
+            final LinearLayout line = keyRow(activity, rowHeight);
+            for (int col = 0; col < 3; col++) {
+                final int digit = row * 3 + col + 1;
+                final View key = keyButton(activity, ui, String.valueOf(digit),
+                        () -> appendDigit(typed, digit, render));
+                digitKeys[digit] = key;
+                if (firstKey[0] == null) {
+                    firstKey[0] = key;
+                }
+                line.addView(key);
+            }
+            keypad.addView(line);
+        }
+        // Last row as VLC has it: the two minute values worth a shortcut, either side of the zero.
+        final LinearLayout lastRow = keyRow(activity, rowHeight);
+        lastRow.addView(keyButton(activity, ui, ":00", () -> appendMinutes(typed, 0, render)));
+        digitKeys[0] = keyButton(activity, ui, "0", () -> appendDigit(typed, 0, render));
+        lastRow.addView(digitKeys[0]);
+        lastRow.addView(keyButton(activity, ui, ":30", () -> appendMinutes(typed, 30, render)));
+        keypad.addView(lastRow);
+        body.addView(keypad);
+
+        // Right-aligned at the foot, the way VLC ends its picker with "remove current" and "ok".
+        final LinearLayout actions = new LinearLayout(activity);
+        actions.setOrientation(LinearLayout.HORIZONTAL);
+        actions.setGravity(Gravity.END);
+        final LinearLayout.LayoutParams actionsLp = new LinearLayout.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT);
+        actionsLp.topMargin = Utils.dpToPx(12);
+        actions.setLayoutParams(actionsLp);
+
+        final Dialog dialog = new Dialog(activity, android.R.style.Theme_Translucent_NoTitleBar);
+
+        final TextView stop = actionButton(activity, ui,
+                activity.getString(R.string.sleep_timer_stop), Color.WHITE);
+        stop.setOnClickListener(v -> {
+            listener.onDurationPicked(0);
+            dialog.dismiss();
+        });
+        final TextView start = actionButton(activity, ui,
+                activity.getString(R.string.sleep_timer_start), accent);
+        start.setOnClickListener(v -> {
+            final int total = totalMinutes(typed[0]);
+            if (total <= 0) {
+                return;
+            }
+            listener.onDurationPicked(total);
+            dialog.dismiss();
+        });
+        actions.addView(stop);
+        actions.addView(start);
+        // The foot of its own column either way: under the readout when the keypad is beside it, under
+        // everything when the keypad is below it.
+        if (landscape) {
+            readoutColumn.addView(actions);
+        } else {
+            root.addView(actions);
+        }
+
+        backspace.setOnClickListener(v -> {
+            typed[0] /= 10;
+            render.run();
+        });
+        render.run();
+
+        // Backstop only. The sizing above is meant to make the panel fit outright; this catches what it
+        // cannot foresee — a large font scale, split screen, a window shape not thought of — so that no
+        // action can ever end up somewhere unreachable. No fillViewport: nothing in here wants to stretch.
+        final ScrollView scrollView = new ScrollView(activity);
+        scrollView.addView(root, new ViewGroup.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT));
+        Utils.padForPickerInsets(activity, ui, insetSource, scrollView, hPad,
+                Utils.dpToPx(16), Utils.dpToPx(20));
+
+        dialog.setContentView(scrollView);
+        dialog.setCanceledOnTouchOutside(true);
+        // On TV the remote's number keys are the natural way in — arrowing across ten buttons is not.
+        dialog.setOnKeyListener((d, keyCode, event) -> {
+            if (event.getAction() != KeyEvent.ACTION_DOWN
+                    || keyCode < KeyEvent.KEYCODE_0 || keyCode > KeyEvent.KEYCODE_9) {
+                return false;
+            }
+            digitKeys[keyCode - KeyEvent.KEYCODE_0].performClick();
+            return true;
+        });
+        final Window window = dialog.getWindow();
+        if (window != null) {
+            // Deliberately NOT fullscreen/edge-to-edge — see OffsetPanel: a fullscreen dialog window makes
+            // OxygenOS treat the panel as immersive and demand two back swipes.
+            window.setLayout(ui.pickerWidthPx(cfg), ViewGroup.LayoutParams.MATCH_PARENT);
+            window.setGravity(Gravity.END);
+            window.setBackgroundDrawable(new ColorDrawable(0xF0141414));
+        }
+        // Only where there is a D-pad. In touch mode this scrolls the title out of sight for nothing, since
+        // a focus ring is not drawn there anyway.
+        if (firstKey[0] != null && ui.deviceClass == UiMetrics.DeviceClass.TV) {
+            firstKey[0].post(firstKey[0]::requestFocus);
+        }
+        return dialog;
+    }
+
+    private static void appendDigit(int[] typed, int digit, Runnable render) {
+        if (typed[0] >= 1000) { // already four digits — further taps have nowhere to go
+            return;
+        }
+        typed[0] = typed[0] * 10 + digit;
+        render.run();
+    }
+
+    /** ":00" / ":30" — fills the minutes in one tap, so a typed "1" becomes 1ʰ00ᵐ or 1ʰ30ᵐ. */
+    private static void appendMinutes(int[] typed, int minutes, Runnable render) {
+        if (typed[0] >= 100) { // the minutes are already spoken for
+            return;
+        }
+        typed[0] = typed[0] * 100 + minutes;
+        render.run();
+    }
+
+    /** HHMM as typed → total minutes, capped. Minutes past 59 carry over, so a bare "90" means 1 h 30 m. */
+    private static int totalMinutes(int typed) {
+        return Math.min(MAX_MINUTES, (typed / 100) * 60 + typed % 100);
+    }
+
+    private static void appendUnit(SpannableStringBuilder text, String number, String unit) {
+        text.append(number);
+        final int start = text.length();
+        text.append(unit);
+        text.setSpan(new RelativeSizeSpan(0.5f), start, text.length(), 0);
+    }
+
+    private static LinearLayout keyRow(final Activity activity, final int rowHeight) {
+        final LinearLayout line = new LinearLayout(activity);
+        line.setOrientation(LinearLayout.HORIZONTAL);
+        line.setWeightSum(3f);
+        final LinearLayout.LayoutParams lp = new LinearLayout.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT, rowHeight);
+        lp.topMargin = Utils.dpToPx(8);
+        line.setLayoutParams(lp);
+        return line;
+    }
+
+    /** A bare key: bold text on nothing, as VLC's are — only the touch ripple marks it out. */
+    private static TextView keyButton(final Activity activity, final UiMetrics ui,
+                                      final String label, final Runnable onTap) {
+        final TextView key = new TextView(activity);
+        key.setText(label);
+        key.setTextColor(Color.WHITE);
+        key.setTextSize(TypedValue.COMPLEX_UNIT_SP, ui.sp(18));
+        key.setTypeface(Typeface.DEFAULT_BOLD);
+        key.setGravity(Gravity.CENTER);
+        key.setClickable(true);
+        key.setFocusable(true);
+        // Weight, no width: three keys divide the column whatever it measures, at any panel size. Sizing
+        // them in pixels instead is what once squeezed this keypad down to its middle column.
+        key.setLayoutParams(new LinearLayout.LayoutParams(
+                0, ViewGroup.LayoutParams.MATCH_PARENT, 1f));
+        key.setBackground(new RippleDrawable(ColorStateList.valueOf(0x40FFFFFF), null, null));
+        key.setOnClickListener(v -> onTap.run());
+        return key;
+    }
+
+    /** One of two equal-width actions sharing the foot of the column. */
+    private static TextView actionButton(final Activity activity, final UiMetrics ui,
+                                        final String label, final int color) {
+        final TextView action = new TextView(activity);
+        action.setText(label.toUpperCase(Locale.getDefault()));
+        action.setTextColor(color);
+        action.setTextSize(TypedValue.COMPLEX_UNIT_SP, ui.textAction());
+        action.setTypeface(Typeface.DEFAULT_BOLD);
+        action.setGravity(Gravity.CENTER);
+        action.setClickable(true);
+        action.setFocusable(true);
+        // One line, always: wrapping once turned "START" into "STAR"/"T". Should a column still come up
+        // short, an ellipsis is a legible failure where a broken word is not.
+        action.setSingleLine(true);
+        action.setPadding(Utils.dpToPx(12), Utils.dpToPx(11), Utils.dpToPx(12), Utils.dpToPx(11));
+        final GradientDrawable mask = new GradientDrawable();
+        mask.setCornerRadius(Utils.dpToPx(8));
+        mask.setColor(Color.WHITE);
+        action.setBackground(new RippleDrawable(ColorStateList.valueOf(0x40FFFFFF), null, mask));
+        return action;
+    }
+}

--- a/app/src/main/java/com/brouken/player/OffsetPanel.java
+++ b/app/src/main/java/com/brouken/player/OffsetPanel.java
@@ -3,19 +3,16 @@ package com.brouken.player;
 import android.app.Activity;
 import android.app.Dialog;
 import android.content.res.ColorStateList;
-import android.content.res.Configuration;
 import android.graphics.Color;
 import android.graphics.Typeface;
 import android.graphics.drawable.ColorDrawable;
 import android.graphics.drawable.GradientDrawable;
 import android.graphics.drawable.RippleDrawable;
-import android.os.Build;
 import android.util.TypedValue;
 import android.view.Gravity;
 import android.view.View;
 import android.view.ViewGroup;
 import android.view.Window;
-import android.view.WindowInsets;
 import android.widget.ImageButton;
 import android.widget.LinearLayout;
 import android.widget.SeekBar;
@@ -187,27 +184,8 @@ final class OffsetPanel {
             apply.run();
         });
 
-        int padTop = 0;
-        int padBottom = 0;
-        final WindowInsets rootInsets = insetSource.getRootWindowInsets();
-        if (rootInsets != null) {
-            // Status bar is hidden while a picker is open (applyPickerBars), so its height is only breathing
-            // room. In portrait the status-bar height reads well; landscape is much shorter (and its status-bar
-            // inset can include the camera cutout), where that same height looks oversized — use a compact
-            // fixed inset there. Pad the bottom for the nav/gesture bar. dp keeps it density/resolution-adaptive.
-            final boolean landscape = activity.getResources().getConfiguration().orientation
-                    == Configuration.ORIENTATION_LANDSCAPE;
-            final int landscapeTop = ui.pickerTopPadLand();
-            if (Build.VERSION.SDK_INT >= 30) {
-                padTop = landscape ? landscapeTop : rootInsets.getInsets(WindowInsets.Type.statusBars()).top;
-                padBottom = rootInsets.getInsets(WindowInsets.Type.navigationBars()).bottom + ui.overscanV();
-            } else {
-                padTop = landscape ? landscapeTop : rootInsets.getSystemWindowInsetTop();
-                padBottom = rootInsets.getSystemWindowInsetBottom() + ui.overscanV();
-            }
-        }
-        final int hPad = Utils.dpToPx(24) + ui.overscanH();
-        root.setPadding(hPad, padTop + Utils.dpToPx(20), hPad, padBottom + Utils.dpToPx(24));
+        Utils.padForPickerInsets(activity, ui, insetSource, root, Utils.dpToPx(24) + ui.overscanH(),
+                Utils.dpToPx(20), Utils.dpToPx(24));
 
         final Dialog dialog = new Dialog(activity, android.R.style.Theme_Translucent_NoTitleBar);
         dialog.setContentView(root);

--- a/app/src/main/java/com/brouken/player/PlayerActivity.java
+++ b/app/src/main/java/com/brouken/player/PlayerActivity.java
@@ -429,6 +429,7 @@ public class PlayerActivity extends Activity {
     private android.app.Dialog qualityDialog;
     private android.app.Dialog playlistDialog;
     private android.app.Dialog skipOffsetDialog;
+    private android.app.Dialog sleepTimerDialog;
     private android.app.Dialog menuDialog;
     // While a picker panel is open the app must stay out of immersive/fullscreen, otherwise OxygenOS/ColorOS
     // applies its fullscreen back-gesture guard ("swipe again to go back") and the panel needs two swipes.
@@ -4177,26 +4178,7 @@ public class PlayerActivity extends Activity {
         // them. Use a FIXED inset captured now (the status bar is visible while the controls — and thus this
         // dialog — are shown): a dynamic inset listener would drop to 0 when hideController() flips the
         // activity to immersive flags, making the list visibly "jump" up under the still-visible status bar.
-        int padTop = 0;
-        int padBottom = 0;
-        final WindowInsets rootInsets = coordinatorLayout.getRootWindowInsets();
-        if (rootInsets != null) {
-            // Status bar is hidden while a picker is open (applyPickerBars), so its height is only breathing
-            // room. In portrait the status-bar height reads well; landscape is much shorter (and its status-bar
-            // inset can include the camera cutout), where that same height looks oversized — use a compact
-            // fixed inset there. Pad the bottom for the nav/gesture bar. dp keeps it density/resolution-adaptive.
-            final boolean landscape = getResources().getConfiguration().orientation
-                    == android.content.res.Configuration.ORIENTATION_LANDSCAPE;
-            final int landscapeTop = ui.pickerTopPadLand();
-            if (Build.VERSION.SDK_INT >= 30) {
-                padTop = landscape ? landscapeTop : rootInsets.getInsets(WindowInsets.Type.statusBars()).top;
-                padBottom = rootInsets.getInsets(WindowInsets.Type.navigationBars()).bottom + ui.overscanV();
-            } else {
-                padTop = landscape ? landscapeTop : rootInsets.getSystemWindowInsetTop();
-                padBottom = rootInsets.getSystemWindowInsetBottom() + ui.overscanV();
-            }
-        }
-        scrollView.setPadding(ui.overscanH(), padTop, ui.overscanH(), padBottom);
+        Utils.padForPickerInsets(this, ui, coordinatorLayout, scrollView, ui.overscanH(), 0, 0);
 
         if (playlistDialog != null) {
             playlistDialog.dismiss();
@@ -4439,26 +4421,7 @@ public class PlayerActivity extends Activity {
 
         final android.widget.ScrollView scrollView = new android.widget.ScrollView(this);
         scrollView.addView(listLayout);
-        int padTop = 0;
-        int padBottom = 0;
-        final WindowInsets rootInsets = coordinatorLayout.getRootWindowInsets();
-        if (rootInsets != null) {
-            // Status bar is hidden while a picker is open (applyPickerBars), so its height is only breathing
-            // room. In portrait the status-bar height reads well; landscape is much shorter (and its status-bar
-            // inset can include the camera cutout), where that same height looks oversized — use a compact
-            // fixed inset there. Pad the bottom for the nav/gesture bar. dp keeps it density/resolution-adaptive.
-            final boolean landscape = getResources().getConfiguration().orientation
-                    == android.content.res.Configuration.ORIENTATION_LANDSCAPE;
-            final int landscapeTop = ui.pickerTopPadLand();
-            if (Build.VERSION.SDK_INT >= 30) {
-                padTop = landscape ? landscapeTop : rootInsets.getInsets(WindowInsets.Type.statusBars()).top;
-                padBottom = rootInsets.getInsets(WindowInsets.Type.navigationBars()).bottom + ui.overscanV();
-            } else {
-                padTop = landscape ? landscapeTop : rootInsets.getSystemWindowInsetTop();
-                padBottom = rootInsets.getSystemWindowInsetBottom() + ui.overscanV();
-            }
-        }
-        scrollView.setPadding(ui.overscanH(), padTop, ui.overscanH(), padBottom);
+        Utils.padForPickerInsets(this, ui, coordinatorLayout, scrollView, ui.overscanH(), 0, 0);
 
         if (qualityDialog != null) {
             qualityDialog.dismiss();
@@ -4636,26 +4599,7 @@ public class PlayerActivity extends Activity {
 
         final android.widget.ScrollView scrollView = new android.widget.ScrollView(this);
         scrollView.addView(listLayout);
-        int padTop = 0;
-        int padBottom = 0;
-        final WindowInsets rootInsets = coordinatorLayout.getRootWindowInsets();
-        if (rootInsets != null) {
-            // Status bar is hidden while a picker is open (applyPickerBars), so its height is only breathing
-            // room. In portrait the status-bar height reads well; landscape is much shorter (and its status-bar
-            // inset can include the camera cutout), where that same height looks oversized — use a compact
-            // fixed inset there. Pad the bottom for the nav/gesture bar. dp keeps it density/resolution-adaptive.
-            final boolean landscape = getResources().getConfiguration().orientation
-                    == android.content.res.Configuration.ORIENTATION_LANDSCAPE;
-            final int landscapeTop = ui.pickerTopPadLand();
-            if (Build.VERSION.SDK_INT >= 30) {
-                padTop = landscape ? landscapeTop : rootInsets.getInsets(WindowInsets.Type.statusBars()).top;
-                padBottom = rootInsets.getInsets(WindowInsets.Type.navigationBars()).bottom + ui.overscanV();
-            } else {
-                padTop = landscape ? landscapeTop : rootInsets.getSystemWindowInsetTop();
-                padBottom = rootInsets.getSystemWindowInsetBottom() + ui.overscanV();
-            }
-        }
-        scrollView.setPadding(ui.overscanH(), padTop, ui.overscanH(), padBottom);
+        Utils.padForPickerInsets(this, ui, coordinatorLayout, scrollView, ui.overscanH(), 0, 0);
 
         if (menuDialog != null) {
             menuDialog.dismiss();
@@ -4924,12 +4868,172 @@ public class PlayerActivity extends Activity {
         button.setLayoutParams(params);
     }
 
+    // ---- Sleep timer ------------------------------------------------------------------------------------
+    // Two shapes of "stop once I am asleep" in one list, because they answer different nights: a duration,
+    // for a film playing on into an empty room, and "after this file", for a series whose autoplay would
+    // otherwise run until morning. Session-only — nothing is persisted, so a timer can never outlive the
+    // sitting that set it.
+    //
+    // Firing closes the player rather than only pausing it. In an api session (a resolver handing over a
+    // temporary link) the position is written nowhere on disk and reaches the launcher solely through the
+    // result intent that finish() builds, so pausing and then being killed overnight would lose the very
+    // position the timer exists to protect. Closing also frees the decoder and the receiver's audio lock.
+
+    private static final int[] SLEEP_PRESETS_MIN = {15, 30, 45, 60, 90};
+    private static final long SLEEP_WARN_MS = 30_000;   // fade + notice window ahead of the close
+    private static final long SLEEP_TICK_MS = 1000;
+    private static final long SLEEP_FADE_TICK_MS = 250; // fine enough a ramp to read as a fade, not a step
+
+    private long sleepDeadlineMs;      // uptimeMillis deadline; 0 = nothing armed
+    private int sleepSetMinutes;       // what was picked, for the ✓ in the list
+    private boolean sleepAtEndOfItem;  // stop when the current file ends, instead of on a clock
+    private boolean sleepWarned;
+
+    private final Runnable sleepTickRunnable = new Runnable() {
+        @Override
+        public void run() {
+            final long remaining = sleepRemainingMs();
+            if (remaining <= 0) {
+                fireSleepTimer();
+                return;
+            }
+            if (remaining <= SLEEP_WARN_MS) {
+                if (!sleepWarned) {
+                    sleepWarned = true;
+                    Utils.showText(playerView, getString(R.string.sleep_timer_warning,
+                            Math.round(remaining / 1000f)));
+                }
+                // Ease the sound out rather than cut it — the one warning that still lands with the screen
+                // already dark. A no-op on a passthrough output, where the player has no gain of its own to
+                // give; the notice above covers that case.
+                if (player != null) {
+                    player.setVolume(baseVolume() * (remaining / (float) SLEEP_WARN_MS));
+                }
+                playerView.postDelayed(this, SLEEP_FADE_TICK_MS);
+            } else {
+                playerView.postDelayed(this, SLEEP_TICK_MS);
+            }
+        }
+    };
+
+    /** Arms a duration; {@code minutes <= 0} turns the timer off. */
+    private void armSleepTimer(final int minutes) {
+        cancelSleepTimer();
+        if (minutes <= 0) {
+            Utils.showText(playerView, getString(R.string.sleep_timer_cancelled));
+            return;
+        }
+        sleepSetMinutes = minutes;
+        // uptimeMillis, to match the handler's own clock. That it does not advance in deep sleep is no
+        // constraint here: a sleep timer runs with the video playing and the screen awake.
+        sleepDeadlineMs = SystemClock.uptimeMillis() + minutes * 60_000L;
+        playerView.postDelayed(sleepTickRunnable, SLEEP_TICK_MS);
+        Utils.showText(playerView, getString(R.string.sleep_timer_set, formatSleepDuration(minutes)));
+    }
+
+    private void armSleepAtEndOfItem() {
+        cancelSleepTimer();
+        sleepAtEndOfItem = true;
+        applySleepAtEndOfItem();
+        Utils.showText(playerView, getString(R.string.sleep_timer_set,
+                getString(R.string.sleep_timer_end_of_item)));
+    }
+
+    /** Clears whatever was armed and undoes the fade — the way back from every off/cancel path. */
+    private void cancelSleepTimer() {
+        playerView.removeCallbacks(sleepTickRunnable);
+        sleepDeadlineMs = 0;
+        sleepSetMinutes = 0;
+        sleepWarned = false;
+        if (sleepAtEndOfItem) {
+            sleepAtEndOfItem = false;
+            applySleepAtEndOfItem();
+        }
+        applyVolumeMode();
+    }
+
+    // Media3's own end-of-item pause is the entire mechanism; the listener below turns that pause into a
+    // close. Re-applied after every player rebuild (a quality switch makes a new instance).
+    private void applySleepAtEndOfItem() {
+        if (player != null) {
+            player.setPauseAtEndOfMediaItems(sleepAtEndOfItem);
+        }
+    }
+
+    private long sleepRemainingMs() {
+        return sleepDeadlineMs == 0 ? 0 : Math.max(0, sleepDeadlineMs - SystemClock.uptimeMillis());
+    }
+
+    private void fireSleepTimer() {
+        playerView.removeCallbacks(sleepTickRunnable);
+        sleepDeadlineMs = 0;
+        sleepSetMinutes = 0;
+        sleepAtEndOfItem = false;
+        sleepWarned = false;
+        // Write the position before closing: finish() carries it out of an api session in its result intent,
+        // and savePlayer covers the ordinary one. Deliberately no applyVolumeMode() — restoring the level for
+        // the last instants before the window goes would put the sound back at full.
+        savePlayer();
+        if (player != null) {
+            player.pause();
+        }
+        finish();
+    }
+
+    /** "15 min" / "1 h" / "1 h 30 min" — whole hours lose the minutes. */
+    private String formatSleepDuration(final int minutes) {
+        if (minutes % 60 == 0) {
+            return getString(R.string.sleep_timer_hours, String.valueOf(minutes / 60));
+        }
+        if (minutes > 60) {
+            return getString(R.string.sleep_timer_hours_minutes, minutes / 60, minutes % 60);
+        }
+        return getString(R.string.sleep_timer_minutes, minutes);
+    }
+
+    /** Detail line for the overflow row: what is armed, or null when nothing is. */
+    private String sleepTimerSummary() {
+        if (sleepAtEndOfItem) {
+            return getString(R.string.sleep_timer_end_of_item);
+        }
+        final long remaining = sleepRemainingMs();
+        return remaining > 0 ? Utils.formatMilis(remaining) : null;
+    }
+
+    private void showSleepTimerMenu() {
+        final List<MenuItem> items = new ArrayList<>();
+        items.add(new MenuItem(getString(R.string.sleep_timer_off), null,
+                !sleepAtEndOfItem && sleepRemainingMs() == 0, () -> armSleepTimer(0)));
+        for (final int minutes : SLEEP_PRESETS_MIN) {
+            final boolean current = !sleepAtEndOfItem && sleepSetMinutes == minutes;
+            items.add(new MenuItem(formatSleepDuration(minutes),
+                    current ? Utils.formatMilis(sleepRemainingMs()) : null,
+                    current, () -> armSleepTimer(minutes)));
+        }
+        items.add(new MenuItem(getString(R.string.sleep_timer_end_of_item), null, sleepAtEndOfItem,
+                this::armSleepAtEndOfItem));
+        items.add(new MenuItem(getString(R.string.sleep_timer_custom), null, false,
+                this::showSleepTimerCustomDialog));
+        showSideMenu(getString(R.string.sleep_timer_title), items);
+    }
+
+    private void showSleepTimerCustomDialog() {
+        if (sleepTimerDialog != null) {
+            sleepTimerDialog.dismiss();
+        }
+        sleepTimerDialog = DurationPanel.create(this, ui, coordinatorLayout, brandColor(),
+                getString(R.string.sleep_timer_title), this::armSleepTimer);
+        showPickerDialog(sleepTimerDialog);
+    }
+
     // Overflow menu: everything used rarely or once per session lives here so the main row stays calm.
     private void showMoreMenu() {
         final List<MenuItem> items = new ArrayList<>();
         if (player != null) {
             items.add(new MenuItem(R.drawable.ic_speed_24dp, getString(R.string.speed_title),
                     formatSpeed(player.getPlaybackParameters().speed), false, this::showSpeedDialog));
+            items.add(new MenuItem(R.drawable.ic_sleep_24dp, getString(R.string.sleep_timer_title),
+                    sleepTimerSummary(), false, this::showSleepTimerMenu));
         }
         if (buttonSkipOffset != null && buttonSkipOffset.getVisibility() == View.VISIBLE) {
             items.add(new MenuItem(R.drawable.ic_skip_offset_24dp, getString(R.string.button_skip_offset), null, false, this::showSkipOffsetDialog));
@@ -5533,6 +5637,7 @@ public class PlayerActivity extends Activity {
         if (mPrefs.skipSilence) {
             player.setSkipSilenceEnabled(true);
         }
+        applySleepAtEndOfItem();
 
         youTubeOverlay.player(player);
         playerView.setPlayer(player);
@@ -5697,8 +5802,13 @@ public class PlayerActivity extends Activity {
      */
     private void applyVolumeMode() {
         if (player != null) {
-            player.setVolume(systemVolume ? 1f : Math.min(playerVolume, 100f) / 100f);
+            player.setVolume(baseVolume());
         }
+    }
+
+    /** The player gain the current volume mode asks for — the level a fade ramps down from and back to. */
+    private float baseVolume() {
+        return systemVolume ? 1f : Math.min(playerVolume, 100f) / 100f;
     }
 
     private void savePlayer() {
@@ -5845,6 +5955,11 @@ public class PlayerActivity extends Activity {
         if (skipOffsetDialog != null) {
             skipOffsetDialog.dismiss();
             skipOffsetDialog = null;
+        }
+        // Only the panel goes: this runs on a quality switch too, and an armed timer has to ride across that.
+        if (sleepTimerDialog != null) {
+            sleepTimerDialog.dismiss();
+            sleepTimerDialog = null;
         }
         if (menuDialog != null) {
             menuDialog.dismiss();
@@ -6039,6 +6154,11 @@ public class PlayerActivity extends Activity {
         @Override
         public void onPlayWhenReadyChanged(boolean playWhenReady, int reason) {
             if (playWhenReady) {
+                return;
+            }
+            // The end-of-item pause Media3 was asked for on behalf of the sleep timer — turn it into a close.
+            if (sleepAtEndOfItem && reason == Player.PLAY_WHEN_READY_CHANGE_REASON_END_OF_MEDIA_ITEM) {
+                fireSleepTimer();
                 return;
             }
             // Whatever was posted would now run against a paused player, which is the one thing to avoid.
@@ -6252,7 +6372,10 @@ public class PlayerActivity extends Activity {
             } else if (state == Player.STATE_ENDED) {
                 cancelLoadWatchdog();
                 playbackFinished = true;
-                if (apiAccess) {
+                // A single item, or the last of a playlist, ends here rather than in an end-of-item pause.
+                if (sleepAtEndOfItem) {
+                    fireSleepTimer();
+                } else if (apiAccess) {
                     finish();
                 }
             }
@@ -7157,7 +7280,8 @@ public class PlayerActivity extends Activity {
     }
 
     private void dismissOpenPickers() {
-        final android.app.Dialog[] pickers = { qualityDialog, playlistDialog, skipOffsetDialog, menuDialog };
+        final android.app.Dialog[] pickers = { qualityDialog, playlistDialog, skipOffsetDialog,
+                sleepTimerDialog, menuDialog };
         for (final android.app.Dialog d : pickers) {
             if (d != null && d.isShowing()) {
                 d.dismiss();

--- a/app/src/main/java/com/brouken/player/Utils.java
+++ b/app/src/main/java/com/brouken/player/Utils.java
@@ -476,6 +476,51 @@ class Utils {
             return new Rational(format.width, format.height);
     }
 
+    /**
+     * Pads a side-panel's content for the system bars, the way every picker in this app wants it.
+     *
+     * The status bar is hidden while a picker is open (applyPickerBars), so its height is only breathing
+     * room — but breathing room the content genuinely needs, since the window spans the full height and the
+     * camera cutout lives up there. Hence the height is read IGNORING VISIBILITY: {@code getInsets()} reports
+     * zero for a bar that is currently hidden, and a panel opened from another panel (the skip-offset and
+     * sleep-timer panels come off a side menu, which has already turned the bars off) would then get no top
+     * padding at all and put its header under the cutout. The playlist panel only ever escaped this by being
+     * opened straight off the controls, while the bars were still up.
+     *
+     * In portrait the status-bar height reads well; landscape is much shorter (and its status-bar inset can
+     * include the camera cutout), where that same height looks oversized — use a compact fixed inset there.
+     * Pad the bottom for the nav/gesture bar. dp keeps it density/resolution-adaptive.
+     *
+     * @param insetSource any attached view, used to read the window insets
+     * @param target      the view whose padding is set (horizontal padding comes from the caller's own grid)
+     */
+    public static void padForPickerInsets(final Activity activity, final UiMetrics ui, final View insetSource,
+                                         final View target, final int hPad,
+                                         final int extraTopPx, final int extraBottomPx) {
+        final boolean landscape = activity.getResources().getConfiguration().orientation
+                == Configuration.ORIENTATION_LANDSCAPE;
+        int padTop = landscape ? ui.pickerTopPadLand() : ui.dp(24);
+        int padBottom = ui.overscanV();
+        final WindowInsets rootInsets = insetSource.getRootWindowInsets();
+        if (rootInsets != null) {
+            if (Build.VERSION.SDK_INT >= 30) {
+                if (!landscape) {
+                    padTop = rootInsets.getInsetsIgnoringVisibility(WindowInsets.Type.statusBars()).top;
+                }
+                padBottom = rootInsets.getInsetsIgnoringVisibility(
+                        WindowInsets.Type.navigationBars()).bottom + ui.overscanV();
+            } else {
+                // No ignoring-visibility variant before 30, and the legacy inset drops to 0 just the same
+                // once the bars are off — so the floor above stands in for it.
+                if (!landscape) {
+                    padTop = Math.max(padTop, rootInsets.getSystemWindowInsetTop());
+                }
+                padBottom = Math.max(padBottom, rootInsets.getSystemWindowInsetBottom() + ui.overscanV());
+            }
+        }
+        target.setPadding(hPad, padTop + extraTopPx, hPad, padBottom + extraBottomPx);
+    }
+
     public static String formatMilis(long time) {
         final int totalSeconds = Math.abs((int) time / 1000);
         final int seconds = totalSeconds % 60;

--- a/app/src/main/res/drawable/ic_backspace_24dp.xml
+++ b/app/src/main/res/drawable/ic_backspace_24dp.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Material Symbols "backspace". VLC's own ic_backspace.xml is GPLv2+ © VideoLAN, so the glyph comes
+     from Material instead — this repository is public domain and cannot carry that header. -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:pathData="M22,3H7C6.31,3 5.77,3.35 5.41,3.88L0,12l5.41,8.11c0.36,0.53 0.9,0.89 1.59,0.89h15c1.1,0 2,-0.9 2,-2V5C24,3.9 23.1,3 22,3zM19,15.59L17.59,17 14,13.41 10.41,17 9,15.59 12.59,12 9,8.41 10.41,7 14,10.59 17.59,7 19,8.41 15.41,12 19,15.59z" />
+</vector>

--- a/app/src/main/res/drawable/ic_sleep_24dp.xml
+++ b/app/src/main/res/drawable/ic_sleep_24dp.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Material Symbols "snooze" (Google Fonts, snooze_black_48dp), the glyph VLC uses for its sleep timer. -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:pathData="M10,11h2.63l-3.72,4.35C8.36,16 8.82,17 9.67,17L14,17c0.55,0 1,-0.45 1,-1s-0.45,-1 -1,-1h-2.63l3.72,-4.35c0.55,-0.65 0.09,-1.65 -0.76,-1.65L10,9c-0.55,0 -1,0.45 -1,1s0.45,1 1,1zM21.3,6.42c-0.35,0.42 -0.98,0.48 -1.41,0.13l-3.07,-2.56c-0.42,-0.36 -0.48,-0.99 -0.12,-1.41 0.35,-0.42 0.98,-0.48 1.41,-0.13l3.07,2.56c0.42,0.36 0.48,0.99 0.12,1.41zM2.7,6.42c0.35,0.43 0.98,0.48 1.4,0.13l3.07,-2.56c0.43,-0.36 0.49,-0.99 0.13,-1.41 -0.35,-0.43 -0.98,-0.48 -1.4,-0.13L2.82,5.01c-0.42,0.36 -0.48,0.99 -0.12,1.41zM12,6c3.86,0 7,3.14 7,7s-3.14,7 -7,7 -7,-3.14 -7,-7 3.14,-7 7,-7m0,-2c-4.97,0 -9,4.03 -9,9s4.03,9 9,9 9,-4.03 9,-9 -4.03,-9 -9,-9z" />
+</vector>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -155,4 +155,17 @@
     <string name="pref_subtitle_style_bold">Полужирный стиль</string>
     <string name="pref_subtitle_style_bold_on">Использовать полужирный шрифт как обычный</string>
     <string name="pref_subtitle_style_bold_off">Использовать стандартный шрифт по умолчанию</string>
+    <string name="sleep_timer_title">Таймер сна</string>
+    <string name="sleep_timer_off">Выкл</string>
+    <string name="sleep_timer_end_of_item">После текущего файла</string>
+    <string name="sleep_timer_custom">Своё…</string>
+    <string name="sleep_timer_minutes">%1$d мин</string>
+    <string name="sleep_timer_hours">%1$s ч</string>
+    <string name="sleep_timer_hours_minutes">%1$d ч %2$d мин</string>
+    <string name="sleep_timer_set">Таймер сна: %1$s</string>
+    <string name="sleep_timer_cancelled">Таймер сна выключен</string>
+    <string name="sleep_timer_warning">Таймер сна: закрытие через %1$d с</string>
+    <string name="sleep_timer_start">Старт</string>
+    <string name="sleep_timer_backspace">Удалить цифру</string>
+    <string name="sleep_timer_stop">Стоп</string>
 </resources>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -155,4 +155,17 @@
     <string name="pref_subtitle_style_bold">Жирний стиль</string>
     <string name="pref_subtitle_style_bold_on">Використовувати жирний шрифт замість звичайного</string>
     <string name="pref_subtitle_style_bold_off">Використовувати звичайний шрифт за замовчуванням</string>
+    <string name="sleep_timer_title">Таймер сну</string>
+    <string name="sleep_timer_off">Вимк</string>
+    <string name="sleep_timer_end_of_item">Після поточного файлу</string>
+    <string name="sleep_timer_custom">Своє…</string>
+    <string name="sleep_timer_minutes">%1$d хв</string>
+    <string name="sleep_timer_hours">%1$s год</string>
+    <string name="sleep_timer_hours_minutes">%1$d год %2$d хв</string>
+    <string name="sleep_timer_set">Таймер сну: %1$s</string>
+    <string name="sleep_timer_cancelled">Таймер сну вимкнено</string>
+    <string name="sleep_timer_warning">Таймер сну: закриття через %1$d с</string>
+    <string name="sleep_timer_start">Старт</string>
+    <string name="sleep_timer_backspace">Видалити цифру</string>
+    <string name="sleep_timer_stop">Стоп</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -171,4 +171,17 @@
     <string name="pref_subtitle_style_bold">Bold style</string>
     <string name="pref_subtitle_style_bold_on">Use bold typeface as regular</string>
     <string name="pref_subtitle_style_bold_off">Use default regular typeface</string>
+    <string name="sleep_timer_title">Sleep timer</string>
+    <string name="sleep_timer_off">Off</string>
+    <string name="sleep_timer_end_of_item">After the current file</string>
+    <string name="sleep_timer_custom">Custom…</string>
+    <string name="sleep_timer_minutes">%1$d min</string>
+    <string name="sleep_timer_hours">%1$s h</string>
+    <string name="sleep_timer_hours_minutes">%1$d h %2$d min</string>
+    <string name="sleep_timer_set">Sleep timer: %1$s</string>
+    <string name="sleep_timer_cancelled">Sleep timer off</string>
+    <string name="sleep_timer_warning">Sleep timer: closing in %1$d s</string>
+    <string name="sleep_timer_start">Start</string>
+    <string name="sleep_timer_backspace">Delete</string>
+    <string name="sleep_timer_stop">Stop</string>
 </resources>


### PR DESCRIPTION
A sleep timer in the overflow menu, in two shapes, plus a fix to the top inset every picker panel reads.

## The timer

One list off the overflow row: **Off / 15 / 30 / 45 min / 1 h / 1 h 30 min / After the current file / Custom…**

Two shapes because two different nights need answering — a duration for a film playing on into an empty room, and "after the current file" for a series whose autoplay would otherwise run until morning. The second is Media3's own `setPauseAtEndOfMediaItems`; a `PLAY_WHEN_READY_CHANGE_REASON_END_OF_MEDIA_ITEM` listener turns that pause into a close, and `STATE_ENDED` covers the single item that ends rather than pausing.

Firing **closes** the player instead of only pausing it. Under an api session — a resolver handing over a temporary link — the position is written nowhere on disk and reaches the launcher solely through the result intent `finish()` builds, so pausing and then being killed overnight would lose the very position the timer exists to protect. Closing also frees the decoder and the receiver's audio lock.

The last 30 s fade the sound out and post a notice — a warning that still lands with the screen already dark. Nothing is persisted: the timer is a `playerView` callback and cannot outlive the sitting that set it. While it runs, the remaining time shows as the overflow row's detail, the way the playback speed does.

## The keypad

Modelled on VLC's `dialog_time_picker`: keys with a layout **weight** rather than a width, so three of them divide whatever the column measures at any panel size; a backspace beside the readout; `:00` / `:30` to fill the minutes in one tap. Entry is alarm-clock style, so a bare `90` means 1 h 30 m, and the readout carries the wall-clock time the duration lands on. On TV the remote's number keys type straight in.

Portrait stacks the keypad under the readout as that picker does; landscape sets it beside — four finger-sized rows plus a readout plus actions do not fit 312 dp of height, which a bottom sheet never has to solve.

Icons come from Material Symbols (`snooze`, `backspace`), not from VLC's own files: this repository is public domain and cannot carry a GPL header.

## The inset fix

`WindowInsets.getInsets(statusBars())` reports **zero for a bar that is currently hidden**, and `applyPickerBars()` hides the status bar while any picker is open. A panel opened from another panel therefore got no top padding at all and put its header under the camera cutout — which is why the skip-offset panel and this keypad were both affected while the playlist panel was not: the playlist opens straight off the controls, with the bars still up.

Now read ignoring visibility, with a floor for API < 30. The block was duplicated in four places (playlist, quality, side menu, offset panel); one `Utils.padForPickerInsets` serves them all.

## Checked

By hand on a phone emulator matched to a 1080p device, both orientations: the list, the keypad, typing `1` then `:30` → `1ʰ30ᵐ` with the right "until …" time, Start arming the timer and the remaining time appearing on the overflow row.

Not exercised: the fade and close at the moment the timer expires, and TV (D-pad focus order, remote number keys).
