### PR TITLE
Align the sleep timer panel and read playlist subtitles

### DIFF
--- a/app/src/main/java/com/brouken/player/DurationPanel.java
+++ b/app/src/main/java/com/brouken/player/DurationPanel.java
@@ -111,6 +111,12 @@ final class DurationPanel {
         final LinearLayout valueRow = new LinearLayout(activity);
         valueRow.setOrientation(LinearLayout.HORIZONTAL);
         valueRow.setGravity(Gravity.CENTER_VERTICAL);
+        // A key row's height and margin, so the readout and the backspace share the centre line of the
+        // "1 2 3" row instead of hovering a few pixels above it.
+        final LinearLayout.LayoutParams valueLp = new LinearLayout.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT, rowHeight);
+        valueLp.topMargin = Utils.dpToPx(8);
+        valueRow.setLayoutParams(valueLp);
         readoutColumn.addView(valueRow);
 
         final TextView value = new TextView(activity);
@@ -207,7 +213,7 @@ final class DurationPanel {
         actions.setGravity(Gravity.END);
         final LinearLayout.LayoutParams actionsLp = new LinearLayout.LayoutParams(
                 ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT);
-        actionsLp.topMargin = Utils.dpToPx(12);
+        actionsLp.topMargin = Utils.dpToPx(landscape ? 8 : 12);
         actions.setLayoutParams(actionsLp);
 
         final Dialog dialog = new Dialog(activity, android.R.style.Theme_Translucent_NoTitleBar);

--- a/app/src/main/java/com/brouken/player/PlayerActivity.java
+++ b/app/src/main/java/com/brouken/player/PlayerActivity.java
@@ -594,6 +594,7 @@ public class PlayerActivity extends Activity {
     static final String API_VIDEO_LIST_EPISODE = "video_list.episode";
     static final String API_VIDEO_LIST_IMDB_ID = "video_list.imdb_id";
     static final String API_VIDEO_LIST_ID = "video_list.id";
+    static final String API_VIDEO_LIST_SUBTITLES = "video_list.subtitles";
     static final String API_SEASON = "season";
     static final String API_EPISODE = "episode";
     static final String API_IMDB_ID = "imdb_id";
@@ -3501,6 +3502,7 @@ public class PlayerActivity extends Activity {
         final String[] episodes = getSmartStringArray(bundle, API_VIDEO_LIST_EPISODE);
         final String[] imdbIds = getSmartStringArray(bundle, API_VIDEO_LIST_IMDB_ID);
         final String[] tmdbIds = getSmartStringArray(bundle, API_VIDEO_LIST_ID);
+        final Parcelable[] subtitles = getSmartParcelableArray(bundle, API_VIDEO_LIST_SUBTITLES);
 
         apiMediaItems.clear();
         apiPlaylistSegments.clear();
@@ -3548,10 +3550,16 @@ public class PlayerActivity extends Activity {
             if (dataUri != null && uri.equals(dataUri)) {
                 apiPlaylistStartIndex = apiMediaItems.size();
             }
-            apiMediaItems.add(new MediaItem.Builder()
+            final MediaItem.Builder itemBuilder = new MediaItem.Builder()
                     .setUri(uri)
-                    .setMediaMetadata(metadataBuilder.build())
-                    .build());
+                    .setMediaMetadata(metadataBuilder.build());
+            // Per-episode external subtitles. They have to ride on the item itself: a playlist replaces the
+            // single media item wholesale, so the apiSubs of a lone video never reach it.
+            final List<MediaItem.SubtitleConfiguration> itemSubs = readPlaylistSubtitles(subtitles, i);
+            if (!itemSubs.isEmpty()) {
+                itemBuilder.setSubtitleConfigurations(itemSubs);
+            }
+            apiMediaItems.add(itemBuilder.build());
             // Keep segments aligned by index with apiMediaItems (null when absent)
             apiPlaylistSegments.add(segments != null && i < segments.length ? segments[i] : null);
             // Episode metadata, aligned by index (null when absent). Stored, not yet used.
@@ -3571,6 +3579,42 @@ public class PlayerActivity extends Activity {
         for (int i = 0; i < apiPlaylistPositions.length; i++) {
             apiPlaylistPositions[i] = C.TIME_UNSET;
         }
+    }
+
+    /**
+     * One entry of {@code video_list.subtitles}: a Bundle per playlist item carrying parallel {@code uris}
+     * and {@code names} arrays, which is the shape Lampa sends. Nothing is pre-selected — the same as a
+     * single video launched with {@code subs} but no {@code subs.enable}.
+     */
+    private List<MediaItem.SubtitleConfiguration> readPlaylistSubtitles(Parcelable[] items, int index) {
+        final List<MediaItem.SubtitleConfiguration> result = new ArrayList<>();
+        if (items == null || index >= items.length || !(items[index] instanceof Bundle)) {
+            return result;
+        }
+        final Bundle item = (Bundle) items[index];
+        final Parcelable[] uris = getSmartParcelableArray(item, "uris");
+        if (uris == null) {
+            return result;
+        }
+        final String[] names = getSmartStringArray(item, "names");
+        for (int i = 0; i < uris.length; i++) {
+            if (!(uris[i] instanceof Uri)) {
+                continue;
+            }
+            final String name = names != null && i < names.length ? names[i] : null;
+            result.add(SubtitleUtils.buildSubtitle(this, (Uri) uris[i], name, false));
+        }
+        return result;
+    }
+
+    /** As {@link #getSmartStringArray}: an array or an array list, since senders use both. */
+    private static Parcelable[] getSmartParcelableArray(Bundle bundle, String key) {
+        final Parcelable[] array = bundle.getParcelableArray(key);
+        if (array != null) {
+            return array;
+        }
+        final ArrayList<Parcelable> list = bundle.getParcelableArrayList(key);
+        return list == null ? null : list.toArray(new Parcelable[0]);
     }
 
     // Reads two parallel extras (labels + urls) into an insertion-ordered label->url map, sorted from


### PR DESCRIPTION
Two independent fixes found while going over the player with fresh eyes.

### Sleep timer layout

In landscape the readout row was only as tall as its own text, so `0h 00m` and the backspace sat above the centre line of the `1 2 3` row, and STOP/START ended up floating between two key rows. The row now takes a key row's height and margin, and the gap above the actions is tightened so they sit right under the field's underline.

### Per-episode subtitles

Subtitles a launcher supplies with `video_list` never reached the player. They were only read from `subs`, which lands on the single media item that a playlist replaces wholesale — so a queue always played without them, while the same episode launched on its own had subtitles.

`video_list.subtitles` is now read as a Bundle per entry with parallel `uris` and `names` arrays, and the configurations are attached to each `MediaItem`. Both a `Parcelable[]` and an `ArrayList` are accepted, since sending them through `putParcelableArrayListExtra` produces the latter. Nothing is pre-selected, which matches a lone video launched with `subs` but no `subs.enable`.

### Testing

The timer panel was checked on a phone in landscape with the debug build. The subtitle change compiles and is installed, but has not yet been exercised against a launcher that actually sends `video_list.subtitles` — worth confirming with a plugin that provides per-episode subtitles before this is relied on.
