### PR TITLE
Treat a truncated local file as unplayable media, not a crash

### DIFF
--- a/app/src/main/java/com/brouken/player/PlayerActivity.java
+++ b/app/src/main/java/com/brouken/player/PlayerActivity.java
@@ -7447,6 +7447,14 @@ public class PlayerActivity extends Activity {
         if (Utils.isSupportedNetworkUri(currentMediaUri())) {
             return 0;
         }
+        // A local file that stops short of its own container index: the extractor re-opens the source
+        // near the end to read a trailing moov or the Matroska cues, and the read lands past the last
+        // byte there is — a download that never finished, a truncated copy. The file's fault, not the
+        // app's, and the same thing isBrokenNetworkSource already forgives on a remote stream. Matched
+        // by code because Media3 raises ContentDataSourceException with no cause to walk.
+        if (error.errorCode == PlaybackException.ERROR_CODE_IO_READ_POSITION_OUT_OF_RANGE) {
+            return R.string.error_playback_general;
+        }
         for (Throwable t = error; t != null; t = t.getCause()) {
             if (t instanceof SecurityException) {
                 return R.string.error_media_access_expired;


### PR DESCRIPTION
Fixes JUST-PLUS-PLAYER-2S.

## What happens

A video opened over a `content://` URI (SAF) whose bytes stop short of its own container index fails when the extractor re-opens the source near the end — a trailing `moov` on a non-faststart MP4, the cues on a Matroska. Media3's `ContentDataSource.open` raises `ContentDataSourceException` with `ERROR_CODE_IO_READ_POSITION_OUT_OF_RANGE` and, by construction, no cause.

That is an unfinished download or a truncated copy: the file's problem, not the player's.

## Why it looked like a crash

`isBrokenNetworkSource` already forgives exactly this class of failure on a remote stream — its comment even names "an unfinished torrent piece, a malformed rip" — but it is gated on the URI being a network one. The local-media equivalent, `mediaUnavailableMessage`, only walked the cause chain for `SecurityException` and `FileNotFoundException`, neither of which is present here, so the error fell all the way through to `Sentry.captureException` and the fatal `TYPE_SOURCE` branch: a full-screen "Something went wrong" for a plainly broken file.

It also looped. Nothing forgot the clip, so closing the error screen resumed the activity, `onStart` re-prepared the same dead URI, and the error came straight back — visible in the reported session as the same failure twice, 25 seconds apart.

## The change

One code check in `mediaUnavailableMessage`, after the existing network gate. The error then takes the branch a missing file already takes: one-line message, empty state, clip forgotten when no persisted grant is held (which breaks the loop), and nothing reported.

No new strings — `error_playback_general` ("Couldn't play this video.") was already present in all three locales and referenced from nowhere.

## Testing

Manual, on a non-faststart MP4 truncated before its `moov` and opened through the Files app so the player gets a `content://` URI: snackbar over the empty state instead of the error screen, and reopening the app no longer brings it back. A clip with an expired grant still reports "Access to this video has expired", and a network stream answering 416 still takes the broken-stream path with its retries.
