### PR TITLE
Stop resume positions leaking between files, and forget watched ones

### DIFF
--- a/app/src/main/java/com/brouken/player/PlayerActivity.java
+++ b/app/src/main/java/com/brouken/player/PlayerActivity.java
@@ -5930,8 +5930,16 @@ public class PlayerActivity extends Activity {
             if (haveMedia) {
                 // Prevent overwriting temporarily inaccessible media position
                 if (player.isCurrentMediaItemSeekable()) {
-                    mPrefs.updatePosition(player.getCurrentPosition());
-                    rememberEpisodePosition(player.getCurrentMediaItemIndex(), player.getCurrentPosition());
+                    // A clip watched to its end is remembered as unwatched: keeping the end as its
+                    // position reopens it already finished — seeked to the last frame and paused, since
+                    // initializePlayer only autoplays from zero. Keyed on STATE_ENDED and not on being
+                    // near the end, because savePlayer is also how a recovery rebuild carries the
+                    // position across a released player: a decoder that wedges in the closing seconds
+                    // has to come back where it was, not at the start.
+                    final long position = player.getPlaybackState() == Player.STATE_ENDED
+                            ? 0 : player.getCurrentPosition();
+                    mPrefs.updatePosition(position);
+                    rememberEpisodePosition(player.getCurrentMediaItemIndex(), position);
                 }
                 mPrefs.updateMeta(getSelectedTrack(C.TRACK_TYPE_AUDIO),
                         getSelectedTrack(C.TRACK_TYPE_TEXT),
@@ -6142,9 +6150,12 @@ public class PlayerActivity extends Activity {
             }
             final int oldIndex = oldPosition.mediaItemIndex;
             final int newIndex = newPosition.mediaItemIndex;
-            // Leaving an episode (auto-advance or manual jump): remember where we left it.
+            // Leaving an episode: remember where we left it, except that an auto transition means it
+            // played to its end, so that one is remembered as unwatched. Keeping its end would send a
+            // manual jump back to it straight to its last frame, from where it advances off again.
             if (oldIndex != newIndex) {
-                rememberEpisodePosition(oldIndex, oldPosition.positionMs);
+                rememberEpisodePosition(oldIndex,
+                        reason == Player.DISCONTINUITY_REASON_AUTO_TRANSITION ? 0 : oldPosition.positionMs);
             }
             // Manually jumping back to an already-watched episode: resume where we left it. Auto-advance
             // (gapless) keeps starting the next episode from the beginning, as it should. The follow-up

--- a/app/src/main/java/com/brouken/player/Prefs.java
+++ b/app/src/main/java/com/brouken/player/Prefs.java
@@ -5,6 +5,7 @@ import android.content.Context;
 import android.content.SharedPreferences;
 import android.net.Uri;
 import android.preference.PreferenceManager;
+import android.provider.DocumentsContract;
 
 import androidx.media3.exoplayer.DefaultRenderersFactory;
 import androidx.media3.ui.AspectRatioFrameLayout;
@@ -434,25 +435,34 @@ class Prefs {
             return (long) val;
 
         // Return position for uri from limited scope (loaded after using Next action)
-        if (ContentResolver.SCHEME_CONTENT.equals(mediaUri.getScheme())) {
-            final String searchPath = SubtitleUtils.getTrailPathFromUri(mediaUri);
-            if (searchPath == null || searchPath.length() < 1)
-                return 0L;
-            final Set<String> keySet = positions.keySet();
-            final Object[] keys = keySet.toArray();
+        final String searchId = documentIdentity(mediaUri);
+        if (searchId != null) {
+            final Object[] keys = positions.keySet().toArray();
             for (int i = keys.length; i > 0; i--) {
                 final String key = (String) keys[i - 1];
-                final Uri uri = Uri.parse(key);
-                if (ContentResolver.SCHEME_CONTENT.equals(uri.getScheme())) {
-                    final String keyPath = SubtitleUtils.getTrailPathFromUri(uri);
-                    if (searchPath.equals(keyPath)) {
-                        return (long) positions.get(key);
-                    }
+                if (searchId.equals(documentIdentity(Uri.parse(key)))) {
+                    return (long) positions.get(key);
                 }
             }
         }
 
         return 0L;
+    }
+
+    // How two uris for one document compare. The picker hands out .../document/<id> and the folder
+    // walk hands out .../tree/<tree>/document/<id> for the same file: same authority, same document
+    // id, different string. The id is what has to match — the tail of the path alone drops the
+    // storage volume, which is the only thing telling Movies/1.mkv on a memory card apart from
+    // Movies/1.mkv in internal storage. Null for anything that is not a document uri.
+    private static String documentIdentity(final Uri uri) {
+        if (!ContentResolver.SCHEME_CONTENT.equals(uri.getScheme())) {
+            return null;
+        }
+        try {
+            return uri.getAuthority() + '/' + DocumentsContract.getDocumentId(uri);
+        } catch (IllegalArgumentException e) {
+            return null;
+        }
     }
 
     public void updateOrientation() {


### PR DESCRIPTION
Two defects in the remembered playback position, independent of #82 (this branch is cut from `master`).

## 1. A position could be read back for the wrong file

`Prefs.getPosition()` looks the position up by exact URI string, and falls back for `content://` media to matching the **tail of the path**. The fallback is load-bearing: one file arrives as two different strings depending on how the user reached it —

| | |
|---|---|
| SAF picker / VIEW intent | `content://…externalstorage.documents/document/primary%3AMovies%2FS01E03.mkv` |
| next/prev arrows (`findNext` → `findUriInScope` → `DocumentFile.getUri()`) | `content://…externalstorage.documents/tree/primary%3AMovies/document/primary%3AMovies%2FS01E03.mkv` |

— which is what the original *"Load video position when mixing scope and full uris"* was for.

But the tail after the last colon throws away the authority and the storage volume, which is exactly what distinguishes files. `Movies/1.mkv` on a memory card inherited the position of `Movies/1.mkv` in internal storage; a document id holding no colon collapsed to a bare number any provider could collide with; and the scan runs newest-first, so a stale entry won.

Nothing clamps the result — it feeds `setMediaItem(item, position)` raw — so a position borrowed from a longer file seeks past the end of the real one.

Compare the **authority plus the document id** instead, via `DocumentsContract.getDocumentId`, which understands both `…/document/<id>` and `…/tree/<t>/document/<id>`. Same match for the two shapes of one file, nothing else. Stored keys are unchanged, so existing positions keep working, and the fallback no longer dereferences `getPath()` on a stored key that may be opaque.

## 2. A clip watched to the end was remembered at its end

Nothing reset a finished clip, so `savePlayer` stored its duration. Reopening it seeked to the last frame and stopped there, **paused** — `initializePlayer` only autoplays from zero — so it neither played nor started over. A playlist episode behaved the same way: auto-advance stored the finished episode at its duration, and jumping back to it landed on its last frame and advanced straight off it again.

Remember zero instead when the player is in `STATE_ENDED`, and for an episode when it is left by a `DISCONTINUITY_REASON_AUTO_TRANSITION` — which is what "it finished" looks like in a playlist.

Those signals rather than a "near the end" window on purpose: `savePlayer` is also how the decoder-recovery rebuilds (`recoverByForcingHevcForDolbyVision`, `recoverByDisablingTunneling`, `recoverByRevokingAudioMime`) carry the position across a released player. A proximity threshold would restart a 90-minute film from zero when its decoder wedged two seconds before the end, drop a live channel to the back of its DVR window on any return from the background, and hand the launcher an `API_POSITION` near zero for an episode the viewer had all but finished. `STATE_ENDED` is IDLE on those paths, `READY` on the others, so none of them are touched.

## Testing

Manual, no test infrastructure in this repo.

- Resume across the arrows still works, both directions (picker → arrows and arrows → picker) — this is what the fallback exists for.
- Two files at the same relative path on two volumes: watching one no longer moves the other's position.
- A clip watched to the end reopens at 0 and plays; stopped mid-file it still resumes mid-file, paused.
- In a playlist, an auto-advanced episode restarts when jumped back to; a partly watched one still resumes.
- Unchanged: exact-URI resume from the launcher, MediaStore-mode files (not document URIs, so only the exact match applies, as before), and a quality switch mid-playback.
