### PR TITLE
Stop telling the launcher a video was watched that never played

### DIFF
--- a/app/src/main/java/com/brouken/player/PlayerActivity.java
+++ b/app/src/main/java/com/brouken/player/PlayerActivity.java
@@ -2077,11 +2077,7 @@ public class PlayerActivity extends Activity {
                         intent.putExtra(API_DURATION, (int) player.getDuration());
                     }
                     if (player.isCurrentMediaItemSeekable()) {
-                        if (mPrefs.persistentMode) {
-                            intent.putExtra(API_POSITION, (int) mPrefs.nonPersitentPosition);
-                        } else {
-                            intent.putExtra(API_POSITION, (int) player.getCurrentPosition());
-                        }
+                        intent.putExtra(API_POSITION, (int) player.getCurrentPosition());
                     }
                 }
             }
@@ -2192,6 +2188,11 @@ public class PlayerActivity extends Activity {
                 if (text != null) {
                     final Uri parsedUri = Uri.parse(text);
                     if (parsedUri.isAbsolute()) {
+                        // A shared link is new media, not a continuation: end whatever session was
+                        // running, as the VIEW branch above does through handleViewIntent. Otherwise the
+                        // launcher's return_result stays armed and finish() reports this link's progress
+                        // against the episode the launcher asked for.
+                        resetApiAccess();
                         mPrefs.updateMedia(this, parsedUri, null);
                         focusPlay = true;
                         initializePlayer();
@@ -2563,6 +2564,9 @@ public class PlayerActivity extends Activity {
         apiAccess = false;
         apiAccessPartial = false;
         intentReturnResult = false;
+        // The end-of-playback flag belongs to the session being reported. Left set, the next launcher
+        // session inherits it and finish() reports a video watched to its end that the user just started.
+        playbackFinished = false;
         apiTitle = null;
         apiThumbnailUri = null;
         apiSegments = null;
@@ -6478,7 +6482,12 @@ public class PlayerActivity extends Activity {
                 // (Re)arm the watchdog: if this buffering never resolves to STATE_READY, it is a stuck load.
                 playerView.removeCallbacks(loadTimeoutRunnable);
                 playerView.postDelayed(loadTimeoutRunnable, VIDEO_LOAD_TIMEOUT_MS);
-            } else if (state == Player.STATE_ENDED) {
+            // Only real media can end. initializePlayer prepares unconditionally, and a prepare with no
+            // media items reports STATE_ENDED at once, so the empty state — a launcher start with nothing
+            // to resume, the fallback after a fatal error, a deleted file — would otherwise count as a
+            // video watched to its end and report that to the launcher. Same guard as on the end controls
+            // above.
+            } else if (state == Player.STATE_ENDED && haveMedia) {
                 cancelLoadWatchdog();
                 playbackFinished = true;
                 // A single item, or the last of a playlist, ends here rather than in an end-of-item pause.

--- a/app/src/main/java/com/brouken/player/Utils.java
+++ b/app/src/main/java/com/brouken/player/Utils.java
@@ -793,7 +793,12 @@ class Utils {
                         activity.releasePlayer();
                         Uri uri = DocumentFile.fromFile(pathFile).getUri();
                         if (video) {
-                            activity.mPrefs.setPersistent(true);
+                            // Picking a file ends whatever session was running — the same thing the SAF
+                            // chooser does in onActivityResult. This one is a dialog, so that callback
+                            // never runs, and without this the launcher's return_result stayed armed
+                            // while persistent mode came back on: finish() then reported this file
+                            // against the launcher's episode, with a position of -1.
+                            activity.resetApiAccess();
                             activity.mPrefs.updateMedia(activity, uri, null);
                             activity.searchSubtitles();
                         } else {


### PR DESCRIPTION
Three defects in the result `finish()` hands back to a launcher that started playback with `return_result`. All pre-existing and inherited from upstream; independent of #82 and #83, and cut from `master` like them.

The launcher reads `end_by` first: on `"playback_completion"` it marks the item fully watched and drops its resume point, and it ignores a `position` that is not positive. So both a false completion and a negative position destroy the viewer's progress.

## 1. The empty state counted as a finished video

`initializePlayer` prepares unconditionally, including on the empty-state branch where no media items were ever set — and Media3 answers a `prepare()` on an empty timeline with `STATE_ENDED` immediately:

```java
// ExoPlayerImpl.prepare()
playbackInfo = maskPlaybackState(playbackInfo, playbackInfo.timeline.isEmpty() ? STATE_ENDED : STATE_BUFFERING);
```

So the empty state — a launcher start with nothing to resume, the fallback after a fatal error, a deleted file — set `playbackFinished`, and while an api session was still open it called `finish()` too.

The bad one is the error fallback: a stream that failed fatally was reported to the launcher as **watched to its end** the moment the user closed the error screen, having never played a frame. Requiring `haveMedia` fixes it — the same guard the end controls one line above already carry.

Side effect worth knowing: closing the error screen in a launcher session no longer closes the activity. That auto-close was a by-product of this bug; `skipMediaAfterFatalError` exists precisely to fall back to the empty state.

## 2. `playbackFinished` was never cleared

Its only write is one-way, and `resetApiAccess()` — which wipes the other 25 session fields, `intentReturnResult` included — did not touch it. With `launchMode="singleTask"` one ended playback poisoned every later session in that activity instance: watch anything non-api to its end, then start an episode from the launcher, stop it after a minute, and the launcher is told it completed. It stays that way until the task is actually killed, which is why it reads as intermittent.

## 3. `finish()` read the position from the wrong side of a `persistentMode` test

The persistent arm reads `nonPersitentPosition`, which is only ever written when persistent mode is **off** and otherwise holds the `-1` that `updateMedia` leaves — so it always reported `-1`, and the launcher discarded the viewing as "Invalid state".

It looked dead because `intentReturnResult` and `persistentMode` are normally cleared together, but the legacy/TV file chooser broke the pairing: it turns persistent mode back on without ending the api session, unlike the SAF chooser, which calls `resetApiAccess()` from `onActivityResult` — a dialog has no such callback. `onNewIntent`'s shared-link branch had the same gap.

Both now end the session, and the position is taken from the player unconditionally: correct in either mode, and fresher than anything `Prefs` holds (`nonPersitentPosition` is only as recent as the last `savePlayer`, which PiP can leave stale).

## Testing

Manual, with `adb logcat -s LAMPA` reading back what the player actually sent.

- Launcher episode with a dead stream → error screen → close it: no result sent, empty state stays. Was `Playback completed`.
- Local file watched to the end, then a launcher episode stopped after a minute: `Playback stopped [position=…]`. Was `Playback completed`.
- With file access set to *legacy*, a launcher episode → folder button → pick a local file → Back: no result. Was `Invalid state [position=-1, …]`.
- Unchanged: a launcher episode watched to the end still reports completion; one stopped halfway still reports its position; a playlist still reports the episode actually playing as the result `data`; the sleep timer's "to the end of the file" still reports completion; a plain non-api file played to its end still shows the end-of-playback controls.
