### PR TITLE
Name a rendition the same way in the quality menu and the header

### DIFF
--- a/app/src/main/java/com/brouken/player/PlayerActivity.java
+++ b/app/src/main/java/com/brouken/player/PlayerActivity.java
@@ -4364,8 +4364,10 @@ public class PlayerActivity extends Activity {
                     String details = codec == null ? dimensions : dimensions + "  •  " + codec;
                     String bitrate = format.bitrate > 0
                             ? getString(R.string.quality_bitrate, format.bitrate / 1_000_000f) : "";
+                    // Same label the header badge shows, so the two never disagree.
+                    String label = resolutionClass(format.width, format.height);
                     renditions.put(longSide, VideoQualityChoice.track(
-                            longSide + "p", details, bitrate,
+                            label != null ? label : longSide + "p", details, bitrate,
                             group.getMediaTrackGroup(), index, format.bitrate));
                 }
             }
@@ -6100,6 +6102,9 @@ public class PlayerActivity extends Activity {
     private class PlayerListener implements Player.Listener {
         @Override
         public void onVideoSizeChanged(VideoSize videoSize) {
+            // Fires when the new rendition actually renders, which is when getVideoFormat() finally
+            // reports it — onTracksChanged is too early for the header badge.
+            updateMediaInfo();
             // Media3 resets the content-frame AR to the video's natural AR on every size change (e.g. a
             // mid-stream video-track switch), silently dropping a forced ratio. Reassert it after that
             // update (posted, so it wins).


### PR DESCRIPTION
Opening an HLS stream whose variants are scope-cropped, picking the top rendition showed **1920** in the quality menu but **1080** in the player header — for one and the same rendition.

The two labels came from two unshared helpers. The header buckets a format into a tier via `resolutionClass()`; the menu built its own title as `longSide + "p"`. On a stream declaring `1920x960` / `1280x640` / `720x360` that gives "1920p" vs "1080p". Naming by the long side was wrong regardless: `p` counts scan lines, so every landscape rendition was mislabelled — a plain 1920x1080 stream showed as "1920p" too.

The menu title now comes from `resolutionClass()`, so the ticked row and the header always read the same string. Exact dimensions stay in the row subtitle (`1920 × 960 • H.264`), which is where the precise numbers belong.

A second issue in the same path is fixed here as well: the header badge went stale on every automatic quality switch. `onTracksChanged` fires while `getVideoFormat()` still reports the outgoing rendition, and nothing refreshed it afterwards — so on Auto the badge kept the previous resolution, and after a manual override it only caught up on the next controller re-show. It is now refreshed from `onVideoSizeChanged`, which fires when the new rendition actually renders.

Sticky quality and the sender-supplied SOURCE labels are untouched: `qualityNumber()` only ever parses SOURCE labels, never a rendition row's title.

## Verification

Debug build installed on a phone, played the reported HLS stream:

- menu reads 1080p / 720p / 480p and matches the header for whichever row is ticked
- picking 720p flips the header immediately, without reopening the controls
- on Auto the badge follows the rendition instead of freezing
- regression: a local 1920x1080 file still reads 1080p, and the quality button stays hidden with a single video track
