### PR TITLE
Let the preferred audio language fall back down a list

### DIFF
--- a/app/src/main/java/com/brouken/player/AudioLanguagePriorityDialog.java
+++ b/app/src/main/java/com/brouken/player/AudioLanguagePriorityDialog.java
@@ -1,0 +1,234 @@
+package com.brouken.player;
+
+import android.content.Context;
+import android.content.res.ColorStateList;
+import android.util.TypedValue;
+import android.view.Gravity;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.ImageButton;
+import android.widget.LinearLayout;
+import android.widget.ScrollView;
+import android.widget.TextView;
+
+import androidx.appcompat.app.AlertDialog;
+import androidx.core.content.ContextCompat;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+
+/**
+ * Editor for an ordered list of preferred languages: the player walks it top to bottom and plays the
+ * first language the media actually carries.
+ *
+ * Reordering is done with per-row up/down buttons rather than by dragging. Dragging on Android TV is
+ * "focus the handle, press OK, hold a direction, press OK again", which is worse than two buttons for
+ * everyone — and buttons need no RecyclerView, so a list of two to five entries stays a plain
+ * LinearLayout that is simply rebuilt after every change. The rebuild has to hand focus back to the
+ * button that was just pressed, or a remote would be thrown out of the list on every single press.
+ */
+final class AudioLanguagePriorityDialog {
+
+    interface Listener {
+        void onLanguagesPicked(List<String> languages);
+    }
+
+    // Child positions inside a row: the label sits at 0.
+    private static final int UP = 1;
+    private static final int DOWN = 2;
+    private static final int REMOVE = 3;
+
+    private AudioLanguagePriorityDialog() {
+    }
+
+    /**
+     * @param allLanguages every selectable code mapped to its label, in the order the picker lists them
+     * @param pinned       codes worth offering first (device languages, languages of the open media)
+     */
+    static void show(final Context context, final String title, final List<String> initial,
+                     final LinkedHashMap<String, String> allLanguages, final List<String> pinned,
+                     final Listener listener) {
+        final List<String> languages = new ArrayList<>(initial);
+
+        final LinearLayout list = new LinearLayout(context);
+        list.setOrientation(LinearLayout.VERTICAL);
+        list.setPadding(Utils.dpToPx(16), Utils.dpToPx(8), Utils.dpToPx(16), Utils.dpToPx(8));
+
+        final ScrollView scroll = new ScrollView(context);
+        scroll.addView(list);
+
+        rebuild(context, list, languages, allLanguages, pinned, -1, 0);
+
+        new AlertDialog.Builder(context)
+                .setTitle(title)
+                .setView(scroll)
+                .setNegativeButton(android.R.string.cancel, null)
+                .setPositiveButton(android.R.string.ok,
+                        (dialog, which) -> listener.onLanguagesPicked(languages))
+                .show();
+    }
+
+    /**
+     * @param focusRow   row to hand the focus back to after the rebuild, or -1 to leave focus alone
+     * @param focusChild which of that row's buttons to prefer: UP, DOWN or REMOVE
+     */
+    private static void rebuild(final Context context, final LinearLayout list,
+                                final List<String> languages,
+                                final LinkedHashMap<String, String> allLanguages,
+                                final List<String> pinned,
+                                final int focusRow, final int focusChild) {
+        list.removeAllViews();
+
+        if (languages.isEmpty()) {
+            final TextView empty = new TextView(context);
+            empty.setText(R.string.pref_language_audio_none);
+            empty.setPadding(0, Utils.dpToPx(8), 0, Utils.dpToPx(16));
+            list.addView(empty);
+        }
+
+        for (int i = 0; i < languages.size(); i++) {
+            final int index = i;
+            final LinearLayout row = new LinearLayout(context);
+            row.setOrientation(LinearLayout.HORIZONTAL);
+            row.setGravity(Gravity.CENTER_VERTICAL);
+
+            final TextView label = new TextView(context);
+            label.setText(label(allLanguages, languages.get(i)));
+            label.setLayoutParams(new LinearLayout.LayoutParams(
+                    0, ViewGroup.LayoutParams.WRAP_CONTENT, 1f));
+            row.addView(label);
+
+            final ColorStateList tint = ColorStateList.valueOf(label.getCurrentTextColor());
+            final ImageButton up = iconButton(context, R.drawable.ic_arrow_upward_24dp,
+                    context.getString(R.string.pref_language_audio_move_up), tint);
+            Utils.setButtonEnabled(context, up, index > 0);
+            up.setOnClickListener(v -> {
+                Collections.swap(languages, index, index - 1);
+                rebuild(context, list, languages, allLanguages, pinned, index - 1, UP);
+            });
+            final ImageButton down = iconButton(context, R.drawable.ic_arrow_downward_24dp,
+                    context.getString(R.string.pref_language_audio_move_down), tint);
+            Utils.setButtonEnabled(context, down, index < languages.size() - 1);
+            down.setOnClickListener(v -> {
+                Collections.swap(languages, index, index + 1);
+                rebuild(context, list, languages, allLanguages, pinned, index + 1, DOWN);
+            });
+            final ImageButton remove = iconButton(context, R.drawable.ic_close_24dp,
+                    context.getString(R.string.pref_language_audio_remove), tint);
+            remove.setOnClickListener(v -> {
+                languages.remove(index);
+                // The row is gone, so focus the one that slid into its place — or the last one left.
+                // Emptying the list leaves no row at all, and restoreFocus falls back to "Add".
+                rebuild(context, list, languages, allLanguages, pinned,
+                        Math.max(0, Math.min(index, languages.size() - 1)), REMOVE);
+            });
+            // Disabled buttons still take a D-pad stop otherwise, so the first row's "up" would swallow
+            // a press that should have moved the focus out of the list.
+            up.setFocusable(up.isEnabled());
+            down.setFocusable(down.isEnabled());
+            row.addView(up);
+            row.addView(down);
+            row.addView(remove);
+            list.addView(row);
+        }
+
+        final TextView add = new TextView(context);
+        add.setText(R.string.pref_language_audio_add);
+        add.setGravity(Gravity.CENTER_VERTICAL);
+        add.setClickable(true);
+        add.setFocusable(true);
+        add.setCompoundDrawablePadding(Utils.dpToPx(12));
+        add.setCompoundDrawablesRelativeWithIntrinsicBounds(R.drawable.ic_add_24dp, 0, 0, 0);
+        add.setCompoundDrawableTintList(ColorStateList.valueOf(add.getCurrentTextColor()));
+        add.setPadding(0, Utils.dpToPx(12), 0, Utils.dpToPx(12));
+        add.setBackgroundResource(themeAttr(context, android.R.attr.selectableItemBackground));
+        add.setOnClickListener(v -> showPicker(context, list, languages, allLanguages, pinned));
+        list.addView(add);
+
+        restoreFocus(list, focusRow, focusChild, add);
+    }
+
+    /**
+     * removeAllViews drops the focused view, and the framework then parks the focus on the first
+     * focusable in the window — the dialog's buttons. Put it back where the user was.
+     */
+    private static void restoreFocus(final LinearLayout list, final int focusRow,
+                                     final int focusChild, final View fallback) {
+        if (focusRow < 0) {
+            return;
+        }
+        final View row = focusRow < list.getChildCount() ? list.getChildAt(focusRow) : null;
+        View target = null;
+        if (row instanceof ViewGroup) {
+            // The pressed button can be the one that just became disabled (moved to an end of the
+            // list, or removed the last row), so fall back through the row's other buttons.
+            for (final int child : new int[]{focusChild, UP, DOWN, REMOVE}) {
+                final View candidate = ((ViewGroup) row).getChildAt(child);
+                if (candidate != null && candidate.isFocusable()) {
+                    target = candidate;
+                    break;
+                }
+            }
+        }
+        final View focus = target != null ? target : fallback;
+        focus.post(focus::requestFocus);
+    }
+
+    private static void showPicker(final Context context, final LinearLayout list,
+                                   final List<String> languages,
+                                   final LinkedHashMap<String, String> allLanguages,
+                                   final List<String> pinned) {
+        final List<String> codes = new ArrayList<>();
+        for (final String code : pinned) {
+            if (!languages.contains(code) && !codes.contains(code)) {
+                codes.add(code);
+            }
+        }
+        for (final String code : allLanguages.keySet()) {
+            if (!languages.contains(code) && !codes.contains(code)) {
+                codes.add(code);
+            }
+        }
+        final String[] labels = new String[codes.size()];
+        for (int i = 0; i < codes.size(); i++) {
+            labels[i] = label(allLanguages, codes.get(i));
+        }
+        new AlertDialog.Builder(context)
+                .setTitle(R.string.pref_language_audio_add)
+                .setItems(labels, (dialog, which) -> {
+                    languages.add(codes.get(which));
+                    rebuild(context, list, languages, allLanguages, pinned,
+                            languages.size() - 1, UP);
+                })
+                .show();
+    }
+
+    private static String label(final LinkedHashMap<String, String> allLanguages, final String code) {
+        final String label = allLanguages.get(code);
+        return label != null ? label : code;
+    }
+
+    private static ImageButton iconButton(final Context context, final int iconRes,
+                                          final String description, final ColorStateList tint) {
+        final ImageButton button = new ImageButton(context);
+        button.setImageResource(iconRes);
+        button.setImageTintList(tint);
+        button.setContentDescription(description);
+        button.setBackground(null);
+        // Foreground, not background: a RippleDrawable set as an ImageButton background hides the glyph.
+        button.setForeground(ContextCompat.getDrawable(context,
+                themeAttr(context, android.R.attr.selectableItemBackgroundBorderless)));
+        // 48dp tap target, 24dp glyph — ImageView scales the vector up to the whole view otherwise.
+        button.setPadding(Utils.dpToPx(12), Utils.dpToPx(12), Utils.dpToPx(12), Utils.dpToPx(12));
+        button.setLayoutParams(new LinearLayout.LayoutParams(Utils.dpToPx(48), Utils.dpToPx(48)));
+        return button;
+    }
+
+    private static int themeAttr(final Context context, final int attr) {
+        final TypedValue value = new TypedValue();
+        context.getTheme().resolveAttribute(attr, value, true);
+        return value.resourceId;
+    }
+}

--- a/app/src/main/java/com/brouken/player/PlayerActivity.java
+++ b/app/src/main/java/com/brouken/player/PlayerActivity.java
@@ -4741,12 +4741,14 @@ public class PlayerActivity extends Activity {
         final TrackGroup group;
         final int trackIndex;
         final boolean selected;
+        final String language; // ISO-639-2/T, null when the track declares none
 
-        AudioChoice(String label, TrackGroup group, int trackIndex, boolean selected) {
+        AudioChoice(String label, TrackGroup group, int trackIndex, boolean selected, String language) {
             this.label = label;
             this.group = group;
             this.trackIndex = trackIndex;
             this.selected = selected;
+            this.language = language;
         }
     }
 
@@ -4772,7 +4774,8 @@ public class PlayerActivity extends Activity {
                 if (label == null || label.isEmpty()) {
                     label = getString(R.string.audio_track_number, number);
                 }
-                choices.add(new AudioChoice(label, trackGroup, i, group.isTrackSelected(i)));
+                choices.add(new AudioChoice(label, trackGroup, i, group.isTrackSelected(i),
+                        Utils.toIso3Language(format.language)));
             }
         }
         return choices;
@@ -4830,11 +4833,59 @@ public class PlayerActivity extends Activity {
             return;
         }
         final List<MenuItem> items = new ArrayList<>();
+        String selectedLanguage = null;
         for (final AudioChoice choice : choices) {
             items.add(new MenuItem(choice.label, null, choice.selected,
                     () -> applyAudio(choice)));
+            if (choice.selected) {
+                selectedLanguage = choice.language;
+            }
+        }
+        // The moment a language is worth preferring is the moment it gets picked by hand — the settings
+        // screen is nowhere near it. Offered only after a deliberate pick (an override exists), and
+        // only while that language does not already lead the list: every other row of this menu
+        // applies to one clip, this one to all of them.
+        final List<String> preferred = Utils.splitLanguages(mPrefs.languageAudio);
+        if (selectedLanguage != null && hasOverrideType(C.TRACK_TYPE_AUDIO)
+                && (preferred.isEmpty() || !preferred.get(0).equals(selectedLanguage))) {
+            final String language = selectedLanguage;
+            items.add(new MenuItem(R.drawable.ic_star_24dp,
+                    getString(R.string.audio_prefer_language, languageDisplayName(language)),
+                    null, false, () -> preferAudioLanguage(language)));
         }
         showSideMenu(getString(R.string.audio_title), items);
+    }
+
+    /**
+     * Moves one language to the head of the audio priority list. The track playing right now is an
+     * explicit override and stays put, but the selector is updated too — the next item of a playlist
+     * is selected by this same player, which is never rebuilt on this path.
+     */
+    private void preferAudioLanguage(final String language) {
+        final List<String> languages = Utils.splitLanguages(mPrefs.languageAudio);
+        languages.remove(language);
+        languages.add(0, language);
+        mPrefs.setLanguageAudio(TextUtils.join(",", languages));
+        applyPreferredAudioLanguages();
+        Utils.showText(playerView, getString(R.string.audio_prefer_language_done,
+                languageDisplayName(language)));
+    }
+
+    /**
+     * Ordered fallback chain: the selector walks the list and takes the first language the media
+     * actually carries. An empty list leaves the media's own order alone.
+     */
+    private void applyPreferredAudioLanguages() {
+        if (trackSelector == null) {
+            return;
+        }
+        final List<String> languages = Utils.splitLanguages(mPrefs.languageAudio);
+        if (languages.isEmpty()) {
+            return;
+        }
+        trackSelector.setParameters(trackSelector.buildUponParameters()
+                .setPreferredAudioLanguages(languages.toArray(new String[0]))
+        );
     }
 
     // ExoPlayer invents an empty CEA-608 track for every HLS stream whose playlist declares no closed
@@ -5583,19 +5634,9 @@ public class PlayerActivity extends Activity {
                     .setTunnelingEnabled(true)
             );
         }
-        switch (mPrefs.languageAudio) {
-            case Prefs.TRACK_DEFAULT:
-                break;
-            case Prefs.TRACK_DEVICE:
-                trackSelector.setParameters(trackSelector.buildUponParameters()
-                        .setPreferredAudioLanguages(Utils.getDeviceLanguages())
-                );
-                break;
-            default:
-                trackSelector.setParameters(trackSelector.buildUponParameters()
-                        .setPreferredAudioLanguages(mPrefs.languageAudio)
-                );
-        }
+        // Ordered fallback chain: the selector walks the list and takes the first language the media
+        // actually carries. An empty list leaves the media's own order alone.
+        applyPreferredAudioLanguages();
         final CaptioningManager captioningManager = (CaptioningManager) getSystemService(Context.CAPTIONING_SERVICE);
         if (!captioningManager.isEnabled()) {
             trackSelector.setParameters(trackSelector.buildUponParameters()
@@ -5908,7 +5949,19 @@ public class PlayerActivity extends Activity {
      */
     void openSettings() {
         settingsBefore = mPrefs.snapshot();
-        startActivityForResult(new Intent(this, SettingsActivity.class), REQUEST_SETTINGS);
+        final Intent intent = new Intent(this, SettingsActivity.class);
+        // Lets the audio language picker put the languages of the clip on screen right now on top,
+        // instead of burying them somewhere in the device's several hundred locales.
+        final List<String> languages = new ArrayList<>();
+        for (final AudioChoice choice : buildAudioChoices()) {
+            if (choice.language != null && !languages.contains(choice.language)) {
+                languages.add(choice.language);
+            }
+        }
+        if (!languages.isEmpty()) {
+            intent.putExtra(SettingsActivity.EXTRA_MEDIA_LANGUAGES, languages.toArray(new String[0]));
+        }
+        startActivityForResult(intent, REQUEST_SETTINGS);
     }
 
     /**

--- a/app/src/main/java/com/brouken/player/Prefs.java
+++ b/app/src/main/java/com/brouken/player/Prefs.java
@@ -6,6 +6,7 @@ import android.content.SharedPreferences;
 import android.net.Uri;
 import android.preference.PreferenceManager;
 import android.provider.DocumentsContract;
+import android.text.TextUtils;
 
 import androidx.media3.exoplayer.DefaultRenderersFactory;
 import androidx.media3.ui.AspectRatioFrameLayout;
@@ -86,8 +87,9 @@ class Prefs {
     public static final String SKIP_UNDO_AUTO = "auto";
     public static final String SKIP_UNDO_OFF = "off";
 
-    public static final String TRACK_DEFAULT = "default";
-    public static final String TRACK_DEVICE = "device";
+    // Legacy shapes of PREF_KEY_LANGUAGE_AUDIO, still read once by migrateLanguageAudio.
+    private static final String TRACK_DEFAULT = "default";
+    private static final String TRACK_DEVICE = "device";
 
     final Context mContext;
     final SharedPreferences mSharedPreferences;
@@ -131,7 +133,9 @@ class Prefs {
     public String fileAccess = "auto";
     public int decoderPriority = DefaultRenderersFactory.EXTENSION_RENDERER_MODE_ON;
     public boolean mapDV7ToHevc = false;
-    public String languageAudio = TRACK_DEVICE;
+    // Preferred audio languages, most wanted first: comma-separated ISO-639-2/T codes ("ukr,eng").
+    // Empty means no preference at all, i.e. whatever the media itself puts first.
+    public String languageAudio = "";
     public boolean subtitleStyleEmbedded = true;
     public boolean subtitleStyleBold = false;
     public boolean skipEnabled = true;
@@ -233,7 +237,7 @@ class Prefs {
         fileAccess = mSharedPreferences.getString(PREF_KEY_FILE_ACCESS, fileAccess);
         decoderPriority = Integer.parseInt(mSharedPreferences.getString(PREF_KEY_DECODER_PRIORITY, String.valueOf(decoderPriority)));
         mapDV7ToHevc = mSharedPreferences.getBoolean(PREF_KEY_MAP_DV7, mapDV7ToHevc);
-        languageAudio = mSharedPreferences.getString(PREF_KEY_LANGUAGE_AUDIO, languageAudio);
+        languageAudio = getLanguageAudio(mContext);
         subtitleStyleEmbedded = mSharedPreferences.getBoolean(PREF_KEY_SUBTITLE_STYLE_EMBEDDED, subtitleStyleEmbedded);
         subtitleStyleBold = mSharedPreferences.getBoolean(PREF_KEY_SUBTITLE_STYLE_BOLD, subtitleStyleBold);
         skipEnabled = mSharedPreferences.getBoolean(PREF_KEY_SKIP_ENABLED, skipEnabled);
@@ -253,6 +257,43 @@ class Prefs {
         // process restarted — including for the player rebuild that follows leaving the settings screen.
         revokedAudioMimes = mSharedPreferences.getStringSet(
                 PREF_KEY_REVOKED_AUDIO_MIMES, Collections.emptySet());
+    }
+
+    public void setLanguageAudio(final String languages) {
+        this.languageAudio = languages;
+        setLanguageAudio(mContext, languages);
+    }
+
+    /**
+     * The audio language setting used to hold one value: "default" (no preference), "device" (the
+     * system languages) or a single ISO-639-2/T code. It is now an ordered list of codes, so the two
+     * legacy keywords are converted once and written back — a stored code is already a valid
+     * one-entry list. A missing key is a fresh install, which starts from the device languages, the
+     * same tracks "device" used to pick.
+     *
+     * Every read goes through here, not just the one in loadUserPreferences: the settings screen is
+     * exported (ACTION_APPLICATION_PREFERENCES), so it can be the first thing a fresh process opens,
+     * with no Prefs instance ever built — and it would otherwise offer "device" as if it were a
+     * language, then persist it.
+     *
+     * Note the list is a snapshot from here on: unlike the old "device", it no longer follows a later
+     * change of the device language. That is the point — what the dialog shows is what plays.
+     */
+    public static String getLanguageAudio(final Context context) {
+        final SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(context);
+        final String stored = preferences.getString(PREF_KEY_LANGUAGE_AUDIO, null);
+        if (stored != null && !TRACK_DEFAULT.equals(stored) && !TRACK_DEVICE.equals(stored)) {
+            return stored;
+        }
+        final String migrated = TRACK_DEFAULT.equals(stored)
+                ? "" : TextUtils.join(",", Utils.getDeviceLanguages());
+        preferences.edit().putString(PREF_KEY_LANGUAGE_AUDIO, migrated).apply();
+        return migrated;
+    }
+
+    public static void setLanguageAudio(final Context context, final String languages) {
+        PreferenceManager.getDefaultSharedPreferences(context).edit()
+                .putString(PREF_KEY_LANGUAGE_AUDIO, languages).apply();
     }
 
     public void updateMedia(final Context context, final Uri uri, final String type) {

--- a/app/src/main/java/com/brouken/player/SettingsActivity.java
+++ b/app/src/main/java/com/brouken/player/SettingsActivity.java
@@ -4,6 +4,7 @@ import android.content.res.Configuration;
 import android.graphics.Color;
 import android.os.Build;
 import android.os.Bundle;
+import android.text.TextUtils;
 import android.view.View;
 import android.widget.LinearLayout;
 
@@ -33,6 +34,9 @@ import java.util.Locale;
 import java.util.MissingResourceException;
 
 public class SettingsActivity extends AppCompatActivity {
+
+    /** ISO-639-2/T codes of the audio tracks in the clip the player has open, if any. */
+    public static final String EXTRA_MEDIA_LANGUAGES = "mediaLanguages";
 
     static RecyclerView recyclerView;
 
@@ -143,14 +147,20 @@ public class SettingsActivity extends AppCompatActivity {
                 listPreferenceFileAccess.setEntryValues(values.toArray(new String[0]));
             }
 
-            ListPreference listPreferenceLanguageAudio = findPreference("languageAudio");
-            if (listPreferenceLanguageAudio != null) {
-                LinkedHashMap<String, String> entries = new LinkedHashMap<>();
-                entries.put(Prefs.TRACK_DEFAULT, getString(R.string.pref_language_track_default));
-                entries.put(Prefs.TRACK_DEVICE, getString(R.string.pref_language_track_device));
-                entries.putAll(getLanguages());
-                listPreferenceLanguageAudio.setEntries(entries.values().toArray(new String[0]));
-                listPreferenceLanguageAudio.setEntryValues(entries.keySet().toArray(new String[0]));
+            Preference preferenceLanguageAudio = findPreference("languageAudio");
+            if (preferenceLanguageAudio != null) {
+                final LinkedHashMap<String, String> languages = getLanguages();
+                updateLanguageSummary(preferenceLanguageAudio, languages);
+                preferenceLanguageAudio.setOnPreferenceClickListener(preference -> {
+                    AudioLanguagePriorityDialog.show(requireContext(),
+                            getString(R.string.pref_language_audio),
+                            Utils.splitLanguages(Prefs.getLanguageAudio(requireContext())),
+                            languages, pinnedLanguages(), picked -> {
+                                Prefs.setLanguageAudio(requireContext(), TextUtils.join(",", picked));
+                                updateLanguageSummary(preference, languages);
+                            });
+                    return true;
+                });
             }
 
             Preference resetAudioWorkarounds = findPreference("resetRevokedAudioMimes");
@@ -202,6 +212,37 @@ public class SettingsActivity extends AppCompatActivity {
             if (Build.VERSION.SDK_INT >= 29) {
                 recyclerView = getListView();
             }
+        }
+
+        /** The chosen languages, in order, or a note that nothing is preferred. */
+        private void updateLanguageSummary(final Preference preference,
+                                           final LinkedHashMap<String, String> languages) {
+            final List<String> chosen = Utils.splitLanguages(Prefs.getLanguageAudio(requireContext()));
+            if (chosen.isEmpty()) {
+                preference.setSummary(R.string.pref_language_audio_none);
+                return;
+            }
+            final List<String> labels = new ArrayList<>();
+            for (final String code : chosen) {
+                final String label = languages.get(code);
+                labels.add(label != null ? label : code);
+            }
+            preference.setSummary(TextUtils.join(", ", labels));
+        }
+
+        /** Offered at the top of the picker: what the device speaks, and what the open media carries. */
+        private List<String> pinnedLanguages() {
+            final List<String> pinned = new ArrayList<>(Arrays.asList(Utils.getDeviceLanguages()));
+            final String[] media = requireActivity().getIntent()
+                    .getStringArrayExtra(EXTRA_MEDIA_LANGUAGES);
+            if (media != null) {
+                for (final String language : media) {
+                    if (!pinned.contains(language)) {
+                        pinned.add(language);
+                    }
+                }
+            }
+            return pinned;
         }
 
         LinkedHashMap<String, String> getLanguages() {

--- a/app/src/main/java/com/brouken/player/Utils.java
+++ b/app/src/main/java/com/brouken/player/Utils.java
@@ -46,8 +46,11 @@ import android.widget.Toast;
 import androidx.annotation.RequiresApi;
 import androidx.core.text.HtmlCompat;
 import androidx.documentfile.provider.DocumentFile;
+import androidx.annotation.OptIn;
 import androidx.media3.common.Format;
 import androidx.media3.common.MimeTypes;
+import androidx.media3.common.util.UnstableApi;
+import androidx.media3.common.util.Util;
 
 import com.obsez.android.lib.filechooser.ChooserDialog;
 import com.sigpwned.chardet4j.Chardet;
@@ -70,6 +73,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.MissingResourceException;
 
 class Utils {
 
@@ -918,13 +922,58 @@ class Utils {
         if (Build.VERSION.SDK_INT >= 24) {
             final LocaleList localeList = Resources.getSystem().getConfiguration().getLocales();
             for (int i = 0; i < localeList.size(); i++) {
-                locales.add(localeList.get(i).getISO3Language());
+                addLanguage(locales, localeList.get(i));
             }
         } else {
-            final Locale locale = Resources.getSystem().getConfiguration().locale;
-            locales.add(locale.getISO3Language());
+            addLanguage(locales, Resources.getSystem().getConfiguration().locale);
         }
         return locales.toArray(new String[0]);
+    }
+
+    // The system list often names the same language twice (uk-UA, uk-Cyrl); the audio priority list
+    // this seeds must not show it twice.
+    private static void addLanguage(final List<String> languages, final Locale locale) {
+        final String language = toIso3Language(locale.getLanguage());
+        if (language != null && !languages.contains(language)) {
+            languages.add(language);
+        }
+    }
+
+    /**
+     * Folds whatever a container declared ("en", "eng", "en-US") onto the ISO-639-2/T code the audio
+     * priority list is keyed by, so a stored preference and a track's language can be compared at all.
+     * Returns null when there is no usable language.
+     *
+     * Media3 normalizes first because Locale alone cannot: getISO3Language returns any 3-letter input
+     * unchanged, and Matroska muxers routinely tag the bibliographic form ("ger", "fre", "cze"), which
+     * would then never match the terminological code ("deu", "fra", "ces") everything else produces.
+     */
+    @OptIn(markerClass = UnstableApi.class)
+    public static String toIso3Language(final String language) {
+        if (language == null || language.isEmpty() || "und".equals(language)) {
+            return null;
+        }
+        try {
+            // Not new Locale(language): that treats the whole string as the language, so "en-US" would
+            // have no 3-letter form at all.
+            final String iso3 = Locale.forLanguageTag(
+                    Util.normalizeLanguageCode(language.replace('_', '-'))).getISO3Language();
+            return iso3.isEmpty() ? null : iso3;
+        } catch (MissingResourceException e) {
+            return null;
+        }
+    }
+
+    /** The stored audio priority list ("ukr,eng") as a mutable list, blanks dropped. */
+    public static List<String> splitLanguages(final String languages) {
+        final List<String> list = new ArrayList<>();
+        for (String language : languages.split(",")) {
+            language = language.trim();
+            if (!language.isEmpty() && !list.contains(language)) {
+                list.add(language);
+            }
+        }
+        return list;
     }
 
     public static ComponentName getSystemComponent(Context context, Intent intent) {

--- a/app/src/main/res/drawable/ic_arrow_downward_24dp.xml
+++ b/app/src/main/res/drawable/ic_arrow_downward_24dp.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:pathData="M20,12l-1.41,-1.41L13,16.17V4h-2v12.17l-5.58,-5.59L4,12l8,8 8,-8z" />
+</vector>

--- a/app/src/main/res/drawable/ic_arrow_upward_24dp.xml
+++ b/app/src/main/res/drawable/ic_arrow_upward_24dp.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:pathData="M4,12l1.41,1.41L11,7.83V20h2V7.83l5.58,5.59L20,12l-8,-8 -8,8z" />
+</vector>

--- a/app/src/main/res/drawable/ic_star_24dp.xml
+++ b/app/src/main/res/drawable/ic_star_24dp.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:pathData="M12,17.27L18.18,21l-1.64,-7.03L22,9.24l-7.19,-0.61L12,2 9.19,8.63 2,9.24l5.46,4.73L5.82,21z" />
+</vector>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -118,6 +118,8 @@
     <string name="speed_title">Скорость воспроизведения</string>
     <string name="speed_normal">Обычная</string>
     <string name="audio_track_number">Дорожка %1$d</string>
+    <string name="audio_prefer_language">Всегда предпочитать: %1$s</string>
+    <string name="audio_prefer_language_done">%1$s теперь первый среди предпочитаемых языков озвучки</string>
     <string name="quality_title">Качество видео</string>
     <string name="quality_auto">Авто</string>
     <string name="quality_auto_description">Оптимальное качество</string>
@@ -144,6 +146,11 @@
     <string name="pref_language_audio">Звуковая дорожка по умолчанию</string>
     <string name="pref_language_track_device">Языки устройства</string>
     <string name="pref_language_track_default">По умолчанию</string>
+    <string name="pref_language_audio_none">Не задано — играет первая дорожка файла</string>
+    <string name="pref_language_audio_add">Добавить язык</string>
+    <string name="pref_language_audio_move_up">Выше</string>
+    <string name="pref_language_audio_move_down">Ниже</string>
+    <string name="pref_language_audio_remove">Убрать</string>
     <string name="pref_map_dv7_on">Воспроизведение контента Dolby Vision profile 7 на дисплеях HDR</string>
     <string name="pref_reset_audio_workarounds">Сбросить выученные аудио-обходы</string>
     <string name="pref_reset_audio_workarounds_summary">Забыть аудиоформаты, которые это устройство научилось декодировать вместо прямой передачи</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -125,6 +125,8 @@
     <string name="speed_title">Швидкість відтворення</string>
     <string name="speed_normal">Звичайна</string>
     <string name="audio_track_number">Доріжка %1$d</string>
+    <string name="audio_prefer_language">Завжди надавати перевагу: %1$s</string>
+    <string name="audio_prefer_language_done">%1$s тепер перша серед бажаних мов озвучення</string>
     <string name="quality_title">Якість відео</string>
     <string name="quality_auto">Авто</string>
     <string name="quality_auto_description">Оптимальна якість</string>
@@ -148,6 +150,11 @@
     <string name="pref_language_audio">Звукова доріжка за замовчуванням</string>
     <string name="pref_language_track_device">Мова пристрою</string>
     <string name="pref_language_track_default">За замовчуванням</string>
+    <string name="pref_language_audio_none">Не задано — відтворюється перша доріжка файлу</string>
+    <string name="pref_language_audio_add">Додати мову</string>
+    <string name="pref_language_audio_move_up">Вище</string>
+    <string name="pref_language_audio_move_down">Нижче</string>
+    <string name="pref_language_audio_remove">Прибрати</string>
     <string name="pref_subtitle_header">Субтитри</string>
     <string name="pref_subtitle_style_embedded">Вбудовані стилі</string>
     <string name="pref_subtitle_style_embedded_on">Застосувати вбудовані стилі субтитрів</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -141,6 +141,8 @@
     <string name="speed_title">Playback speed</string>
     <string name="speed_normal">Normal</string>
     <string name="audio_track_number">Track %1$d</string>
+    <string name="audio_prefer_language">Always prefer %1$s</string>
+    <string name="audio_prefer_language_done">%1$s is now the first preferred audio language</string>
     <string name="quality_title">Video quality</string>
     <string name="quality_auto">Auto</string>
     <string name="quality_auto_description">Optimal quality</string>
@@ -164,6 +166,11 @@
     <string name="pref_language_audio">Default audio track</string>
     <string name="pref_language_track_device">Device languages</string>
     <string name="pref_language_track_default">Default</string>
+    <string name="pref_language_audio_none">Not set — the first audio track of the file plays</string>
+    <string name="pref_language_audio_add">Add language</string>
+    <string name="pref_language_audio_move_up">Move up</string>
+    <string name="pref_language_audio_move_down">Move down</string>
+    <string name="pref_language_audio_remove">Remove</string>
     <string name="pref_subtitle_header">Subtitle</string>
     <string name="pref_subtitle_style_embedded">Embedded styles</string>
     <string name="pref_subtitle_style_embedded_on">Apply embedded subtitle styles</string>

--- a/app/src/main/res/xml/root_preferences.xml
+++ b/app/src/main/res/xml/root_preferences.xml
@@ -11,11 +11,11 @@
             app:title="@string/pref_file_access"
             app:useSimpleSummaryProvider="true" />
 
-        <ListPreference
+        <!-- Ordered list of languages, edited in AudioLanguagePriorityDialog; the summary lists them.
+             No defaultValue: Prefs seeds the key from the device languages on first run. -->
+        <Preference
             app:key="languageAudio"
-            android:defaultValue="device"
-            app:title="@string/pref_language_audio"
-            app:useSimpleSummaryProvider="true" />
+            app:title="@string/pref_language_audio" />
 
         <SwitchPreferenceCompat
             app:key="frameRateMatching"


### PR DESCRIPTION
## Why

The audio language setting held a single choice. A device set to Ukrainian playing a release without a Ukrainian track fell through to whatever the file lists first — a Thai or Russian dub — with an English track sitting right there. There was no way to say "Ukrainian, and English if that is missing".

Media3's `setPreferredAudioLanguages` has always taken an ordered list; only the storage and the UI were limited to one entry.

## What changed

`languageAudio` now holds comma-separated ISO-639-2/T codes, walked top to bottom. An empty list means no preference at all, which is what the old `default` did.

- **Migration.** The three legacy shapes (`default`, `device`, a single code) are converted on the first read. A fresh install starts from the device languages, which is what `device` used to pick on every launch. It runs in `Prefs.getLanguageAudio(Context)` rather than only in `loadUserPreferences`, because the settings screen is exported via `ACTION_APPLICATION_PREFERENCES` and can be the first thing a fresh process opens, with no `Prefs` instance ever built.
- **Behaviour change worth naming:** the list is a snapshot from then on. Unlike the old `device`, it no longer follows a later change of the device language. That is deliberate — what the dialog shows is what plays.
- **Editor** (`AudioLanguagePriorityDialog`): per-row up/down/remove buttons instead of dragging. Dragging on Android TV is "focus the handle, press OK, hold a direction, press OK again", which is worse than two buttons for everyone — and buttons need no RecyclerView, so a short list stays a plain `LinearLayout` rebuilt after every change. The rebuild hands focus back to the button that was pressed, or a remote would be thrown out of the list on every press.
- **Add-language picker** reuses `SettingsActivity.getLanguages()` unchanged, with the device languages and the languages of the clip currently open pinned to the top.
- **"Prefer this language" row** in the audio menu, because the moment a language is worth preferring is the moment it gets picked by hand and the settings screen is nowhere near that moment. It appears only after a deliberate pick — every other row of that menu applies to one clip, this one to all of them.
- **Language tags are normalized** through Media3's `Util.normalizeLanguageCode` before comparison: Matroska muxers emit the bibliographic form (`ger`, `fre`, `cze`) while everything else here produces the terminological one (`deu`, `fra`, `ces`), and `Locale.getISO3Language` hands any three-letter input straight back. Without this the same language would appear twice in the list and the "already preferred" check would never match.

Precedence is unchanged: the language list only feeds the selector's scoring, a hand-picked track is still a hard `TrackSelectionOverride` applied afterwards, and `Prefs.updateMedia` still clears it when new media opens.

`Utils.getDeviceLanguages()` now de-duplicates and skips unusable codes. Its only other caller is `SubtitleFinder`, where this strictly reduces duplicate sidecar-subtitle probes.

## Testing

Built and installed on a phone (CPH2447). Pure list/code logic checked separately: bibliographic folding, all legacy migration shapes, and promoting a language.

Still to verify by hand:

- Migration on an install that had the old `device` value, and via App info → settings on a fresh process.
- A file with `rus` + `eng` + `tha` and no `ukr`: list `ukr, eng` should play English; removing `eng` should fall back to the file's first track.
- The reorder dialog driven by a D-pad only, on a TV emulator.
- That the up/down/remove glyphs render at the right size — the ripple is set as a foreground there, since a `RippleDrawable` background hides an `ImageButton`'s image.

## Translations

English, Ukrainian and Russian added by hand for the seven new strings; the rest is left to Weblate.
