### PR TITLE
Turn crash reporting off and take its setting off the screen

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,6 @@ It is a fork of [Just (Video) Player](https://github.com/moneytoo/Player) by Mar
  * A full-screen error page with plain-language messages instead of ExoPlayer codes, and Copy / Share / Upload log
  * Watchdogs for a load that never starts, a stall in the middle of a film, and a live stream that keeps dropping
  * Fallbacks for Dolby Vision profile 7, for tunneled playback that freezes the picture, and for HLS playlists served without an extension
- * Crash reporting that can be switched off in Settings → Privacy
 
 **Launcher integration**
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -48,6 +48,9 @@ android {
         // in local.properties/gradle.properties, -PSENTRY_DSN=, or the SENTRY_DSN env var (see above).
         // When empty, Sentry initialization is skipped (no-op) and the build still works.
         buildConfigField "String", "SENTRY_DSN", "\"${sentryDsn}\""
+        // Crash reporting is off and its setting is hidden. The reporting code stays in place —
+        // flipping this back to true restores both Sentry and the privacy category in settings.
+        buildConfigField "boolean", "ENABLE_CRASH_REPORTING", "false"
         if (abiFilter) {
             def abiCodeMap = ["x86": 1, "x86_64": 2, "armeabi-v7a": 3, "arm64-v8a": 4]
             versionCode = versionCode * 10 + abiCodeMap[abiFilter]

--- a/app/src/main/java/com/brouken/player/App.java
+++ b/app/src/main/java/com/brouken/player/App.java
@@ -31,6 +31,10 @@ public class App extends Application {
     }
 
     private void initSentry() {
+        // Turned off for everyone, not just as a default: the consent switch is hidden, so a stored
+        // "on" from an earlier build would otherwise keep reporting with no way to stop it.
+        if (!BuildConfig.ENABLE_CRASH_REPORTING)
+            return;
         final String dsn = BuildConfig.SENTRY_DSN;
         if (dsn == null || dsn.isEmpty())
             return;

--- a/app/src/main/java/com/brouken/player/ErrorActivity.java
+++ b/app/src/main/java/com/brouken/player/ErrorActivity.java
@@ -221,7 +221,8 @@ public class ErrorActivity extends AppCompatActivity {
         // would also load unrelated playback state.
         final android.content.SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(this);
         sb.append("Prefs: file access ").append(prefs.getString("fileAccess", "auto"))
-                .append(prefs.getBoolean("crashReporting", true) ? ", crash reporting on" : ", crash reporting off")
+                .append(BuildConfig.ENABLE_CRASH_REPORTING && prefs.getBoolean("crashReporting", false)
+                        ? ", crash reporting on" : ", crash reporting off")
                 .append('\n');
     }
 

--- a/app/src/main/java/com/brouken/player/Prefs.java
+++ b/app/src/main/java/com/brouken/player/Prefs.java
@@ -146,7 +146,7 @@ class Prefs {
     public String skipUndo = SKIP_UNDO_ALL;
     public boolean showClock = false;
     public boolean systemVolume = true;
-    public boolean crashReporting = true;
+    public boolean crashReporting = false;
     public boolean autoUpdate = true;
     public long updateLastCheck = 0L;
     public int updateSkippedVersionCode = 0;

--- a/app/src/main/java/com/brouken/player/SettingsActivity.java
+++ b/app/src/main/java/com/brouken/player/SettingsActivity.java
@@ -172,6 +172,11 @@ public class SettingsActivity extends AppCompatActivity {
                 });
             }
 
+            PreferenceCategory privacyCategory = findPreference("privacyCategory");
+            if (privacyCategory != null && !BuildConfig.ENABLE_CRASH_REPORTING) {
+                privacyCategory.setVisible(false);
+            }
+
             PreferenceCategory updateCategory = findPreference("updateCategory");
             if (!BuildConfig.ENABLE_UPDATE) {
                 if (updateCategory != null) {

--- a/app/src/main/res/xml/root_preferences.xml
+++ b/app/src/main/res/xml/root_preferences.xml
@@ -185,11 +185,14 @@
 
     </PreferenceCategory>
 
-    <PreferenceCategory app:title="@string/pref_privacy_header">
+    <!-- Hidden unless BuildConfig.ENABLE_CRASH_REPORTING — see SettingsActivity. -->
+    <PreferenceCategory
+        app:key="privacyCategory"
+        app:title="@string/pref_privacy_header">
 
         <SwitchPreferenceCompat
             app:key="crashReporting"
-            app:defaultValue="true"
+            app:defaultValue="false"
             app:summaryOn="@string/pref_crash_reporting_on"
             app:summaryOff="@string/pref_crash_reporting_off"
             app:title="@string/pref_crash_reporting" />


### PR DESCRIPTION
## What

Crash reporting is off and its setting is hidden. The functionality is kept — nothing is deleted.

One build flag does both, in the shape `ENABLE_UPDATE` already uses:

```gradle
buildConfigField "boolean", "ENABLE_CRASH_REPORTING", "false"
```

- `App.initSentry()` returns before `SentryAndroid.init(...)`.
- `SettingsActivity` hides the privacy category via `setVisible(false)` — the category gained `app:key="privacyCategory"` for that, same as `updateCategory`.
- Defaults flipped to `false` in `root_preferences.xml` and `Prefs`.
- The error report's "crash reporting on/off" line reads the flag too, so it cannot claim reporting is on while the SDK was never started.

Setting it back to `true` restores both Sentry and the switch.

## Why the flag gates initialization, not just the default

The consent switch is going away. On a build where the user had already turned reporting on, `crashReporting=true` is persisted; flipping the default alone would leave those installs reporting with nothing in the UI left to stop it. Gating `initSentry` covers stored values as well.

## What is deliberately untouched

`beforeSend` and its URL-query sanitisation, every `Sentry.captureException` call site in `PlayerActivity`, the dependency, the DSN plumbing and the manifest's auto-init opt-out all stay as they are. With the SDK uninitialized `captureException` is a no-op — the same path a build with an empty `SENTRY_DSN` has always taken.

## Testing

`assembleLatestUniversalDebug` builds clean; the generated `BuildConfig` carries `ENABLE_CRASH_REPORTING = false`. Not installed on a device for this change — worth a look that the privacy category is gone from settings and that `ErrorActivity` still opens on a crash (its handler is installed independently of Sentry).
