### PR TITLE
Give the brief skip button five seconds instead of three

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ It is a fork of [Just (Video) Player](https://github.com/moneytoo/Player) by Mar
  * Skip intros, recaps, ad breaks and end credits — segments are drawn right on the time bar
  * Segments come from the launching app, or are looked up online in SkipDB, SkipMe.db, IntroHater, IntroDB, TheIntroDB and Aniskip
  * The sources vote: a segment several databases agree on is used, and its timing is taken from the most reliable one rather than averaged
- * Separately for the intro and the end credits: a Skip button for three seconds, a Skip button for the whole segment, or skip automatically
+ * Separately for the intro and the end credits: a Skip button for five seconds, a Skip button for the whole segment, or skip automatically
  * Every skip can be undone, and an automatic skip can be cancelled before it happens
  * A session offset slider for when a database is a few seconds off
 

--- a/app/src/main/java/com/brouken/player/PlayerActivity.java
+++ b/app/src/main/java/com/brouken/player/PlayerActivity.java
@@ -680,7 +680,7 @@ public class PlayerActivity extends Activity {
     // How long a timed pill stays up: the "undo" offer after a jump, and brief mode's Skip offer. The
     // pref_skip_mode_brief option names these seconds out loud ("Skip button for 3 seconds"), so changing
     // this means changing that string in every locale too.
-    static final long SKIP_NOTICE_MS = 3000;
+    static final long SKIP_NOTICE_MS = 5000;
     // Faint groove the pill's countdown underline drains along; transparent when there is no underline.
     static final int SKIP_PILL_GROOVE_COLOR = 0x33FFFFFF;
     // Segment highlights (see CustomDefaultTimeBar): a *_FILL band across the segment plus a crisp boundary

--- a/app/src/main/java/com/brouken/player/Prefs.java
+++ b/app/src/main/java/com/brouken/player/Prefs.java
@@ -75,7 +75,7 @@ class Prefs {
     private static final String PREF_KEY_REVOKED_AUDIO_MIMES_RELEARNED = "revokedAudioMimesRelearned";
 
     // How a skippable segment is offered. BRIEF shows the Skip button for PlayerActivity.SKIP_NOTICE_MS and
-    // then leaves the picture alone; the option's name says "3 seconds", so that constant and the
+    // then leaves the picture alone; the option's name says "5 seconds", so that constant and the
     // pref_skip_mode_brief strings have to move together.
     public static final String SKIP_MODE_BRIEF = "brief";
     public static final String SKIP_MODE_BUTTON = "button";

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -65,7 +65,7 @@
     <string name="pref_skip_enabled_on">Пропускать заставки и рекламные сегменты от запускающего приложения</string>
     <string name="pref_skip_enabled_off">Воспроизводить как есть</string>
     <string name="pref_skip_mode">Заставка</string>
-    <string name="pref_skip_mode_brief">Кнопка «Пропустить» на 3 секунды</string>
+    <string name="pref_skip_mode_brief">Кнопка «Пропустить» на 5 секунд</string>
     <string name="pref_skip_mode_button">Кнопка «Пропустить» на весь сегмент</string>
     <string name="pref_skip_mode_auto">Пропускать автоматически</string>
     <string name="pref_skip_mode_credits">Финальные титры</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -66,7 +66,7 @@
     <string name="pref_skip_enabled_on">Пропускати заставки та рекламні сегменти від застосунку</string>
     <string name="pref_skip_enabled_off">Відтворювати контент як є</string>
     <string name="pref_skip_mode">Заставка</string>
-    <string name="pref_skip_mode_brief">Кнопка «Пропустити» на 3 секунди</string>
+    <string name="pref_skip_mode_brief">Кнопка «Пропустити» на 5 секунд</string>
     <string name="pref_skip_mode_button">Кнопка «Пропустити» на весь сегмент</string>
     <string name="pref_skip_mode_auto">Пропускати автоматично</string>
     <string name="pref_skip_mode_credits">Кінцеві титри</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -67,7 +67,7 @@
     <string name="pref_skip_enabled_on">Skip intros and ad segments provided by the launching app</string>
     <string name="pref_skip_enabled_off">Play content as is</string>
     <string name="pref_skip_mode">Intro</string>
-    <string name="pref_skip_mode_brief">Skip button for 3 seconds</string>
+    <string name="pref_skip_mode_brief">Skip button for 5 seconds</string>
     <string name="pref_skip_mode_button">Skip button for the whole segment</string>
     <string name="pref_skip_mode_auto">Skip automatically</string>
     <string name="pref_skip_mode_credits">End credits</string>


### PR DESCRIPTION
Three seconds is not long enough to notice the button appear, decide, and reach for it — by the time a hand is moving the offer is gone, and a segment only offers itself once.

`PlayerActivity.SKIP_NOTICE_MS` goes from 3000 to 5000. It drives the countdown shown on the pill as well as the hide timer, so the number on screen follows the constant with no other change.

The option is named after that duration, so its strings move with it:

- `pref_skip_mode_brief` in `values`, `values-uk` and `values-ru` — the only three locales that define it.
- The README line under **Skip segments**.

The `Prefs.SKIP_MODE_BRIEF` comment already warned that the constant and those strings have to move together; it now names the new figure.

## Testing

Builds clean. Not yet exercised on a device — worth watching one intro to confirm the pill counts 5 → 1 and the button is still gone by the time the segment ends.
