### PR TITLE
Let Back out of the player on TV boxes below Android 13

### DIFF
--- a/app/src/main/java/com/brouken/player/PlayerActivity.java
+++ b/app/src/main/java/com/brouken/player/PlayerActivity.java
@@ -2455,7 +2455,11 @@ public class PlayerActivity extends Activity {
             }
         }
 
-        if (isTvBox && !controllerVisibleFully) {
+        // BACK is excluded: it is handled in onBackPressed(), and hijacking it here breaks the
+        // framework's key tracking. Without super.dispatchKeyEvent the DOWN event never reaches
+        // KeyEvent.dispatch(), so the UP event is not marked as tracking and Activity.onKeyUp never
+        // calls onBackPressed() — leaving Back dead below Android 13, where it still arrives as a key.
+        if (isTvBox && !controllerVisibleFully && event.getKeyCode() != KeyEvent.KEYCODE_BACK) {
             if (event.getAction() == KeyEvent.ACTION_DOWN) {
                 onKeyDown(event.getKeyCode(), event);
             } else if (event.getAction() == KeyEvent.ACTION_UP) {


### PR DESCRIPTION
On a TV box the key branch in `dispatchKeyEvent` handled the event itself and returned without calling `super`, which skips `KeyEvent.dispatch` and with it the tracking flag the UP event needs. `Activity.onKeyUp` then never called `onBackPressed`, so below Android 13 — where Back still arrives as a key event — Back did nothing at all and there was no way out of playback.

With the controls fully visible the event did go through `super`, so Back worked there — but all it did was hide the controls, putting the player straight back into the state where Back is dead. Android 13 and newer were unaffected: Back reaches the activity through `OnBackInvokedCallback`.

Back is now excluded from that branch, as the lock mode above it already does. It is handled in `onBackPressed` anyway, which stays the single place deciding what Back means.

Reported on a Nvidia Shield Pro (Android TV 11), where Back does not react at all; a Dune HD Homatics (Android TV 14) shows the "press Back again" confirmation and exits normally. The build compiles; the fix has not been exercised on the Shield yet.
