### PR TITLE
Surface a pending update in the player controls

### DIFF
--- a/app/src/main/java/com/brouken/player/PlayerActivity.java
+++ b/app/src/main/java/com/brouken/player/PlayerActivity.java
@@ -138,6 +138,7 @@ import com.brouken.player.skip.NetworkSegmentsSource;
 import com.brouken.player.skip.SegmentFinder;
 import com.brouken.player.skip.SkipManager;
 import com.brouken.player.skip.SkipSegment;
+import com.brouken.player.update.UpdateInfo;
 import com.brouken.player.update.UpdateUi;
 import com.brouken.player.update.Updater;
 import com.bumptech.glide.Glide;
@@ -426,6 +427,7 @@ public class PlayerActivity extends Activity {
     private ImageButton buttonQuality;
     private ImageButton buttonAudio;
     private ImageButton buttonMore;
+    private ImageButton buttonUpdate;
     private ImageButton buttonSkipOffset;
     private android.app.Dialog qualityDialog;
     private android.app.Dialog playlistDialog;
@@ -985,6 +987,24 @@ public class PlayerActivity extends Activity {
         buttonMore.setOnLongClickListener(view -> {
             openSettings();
             return true;
+        });
+
+        // The only ambient sign that a release is waiting. It exists solely while one is (see
+        // refreshUpdateButton) and lives in the controls, which are on screen only when the user asked for
+        // them — so nothing is ever interrupted, and the brand colour is what makes it findable anyway.
+        buttonUpdate = new ImageButton(this, null, 0, R.style.ExoStyledControls_Button_Bottom);
+        buttonUpdate.setImageResource(R.drawable.ic_update_24dp);
+        buttonUpdate.setId(View.generateViewId());
+        buttonUpdate.setContentDescription(getString(R.string.button_update));
+        buttonUpdate.setVisibility(View.GONE);
+        // Tint the glyph, never the background: a background on these buttons swallows it.
+        buttonUpdate.setImageTintList(ColorStateList.valueOf(ContextCompat.getColor(this, R.color.brand)));
+        buttonUpdate.setOnClickListener(view -> {
+            final UpdateInfo info = mPrefs.updatePending;
+            if (info != null) {
+                UpdateUi.showAvailableDialog(this, info, skipUpdate(info),
+                        player != null && player.isPlaying());
+            }
         });
 
         buttonSkipOffset = new ImageButton(this, null, 0, R.style.ExoStyledControls_Button_Bottom);
@@ -1603,6 +1623,9 @@ public class PlayerActivity extends Activity {
         if (!isTvBox) {
             displayParent.addView(buttonRotation);
         }
+        // "Update available" sits immediately before the gear — one insertion point that lands in the same
+        // place on a phone and on TV, because the gear ends the bottom bar on both.
+        controls.addView(buttonUpdate);
         // "More" (overflow) always lives at the end of the bottom bar.
         controls.addView(buttonMore);
 
@@ -1615,6 +1638,8 @@ public class PlayerActivity extends Activity {
         if (mPrefs.repeatToggle) {
             styleClusterButton(exoRepeat);
         }
+        styleClusterButton(buttonUpdate);
+        refreshUpdateButton();
         styleClusterButton(buttonMore);
         styleClusterButton(buttonAspectRatio);
         if (buttonPiP != null) {
@@ -1779,10 +1804,15 @@ public class PlayerActivity extends Activity {
     }
 
     // Silent, non-intrusive self-update check. Only the sideloaded universal build self-updates
-    // (BuildConfig.ENABLE_UPDATE); the check runs only on an idle launch (no media intent), is
-    // throttled to once a day, and the "update available" dialog is shown only while nothing is
-    // playing — it must never cover a video the user just launched.
-    private static final long UPDATE_CHECK_INTERVAL_MS = 24 * 60 * 60 * 1000L;
+    // (BuildConfig.ENABLE_UPDATE), since everywhere else a store does it.
+    //
+    // Checking and telling are deliberately separate. The check is one background request, it disturbs
+    // nobody, and it now runs on every launch (throttled to an hour) — gating it on an idle launch meant
+    // it never ran at all for anyone who reaches the player through another app's intent, which is how
+    // most people arrive, so a hotfix could sit unseen for weeks. What stays gated is the *dialog*: it is
+    // only ever raised on an idle launch with nothing playing. Every other find surfaces as the
+    // brand-coloured button beside the gear, which is visible only once the user asks for the controls.
+    private static final long UPDATE_CHECK_INTERVAL_MS = 60 * 60 * 1000L;
 
     private void maybeCheckForUpdate(final Intent launchIntent) {
         if (!BuildConfig.ENABLE_UPDATE || !mPrefs.autoUpdate) {
@@ -1792,27 +1822,45 @@ public class PlayerActivity extends Activity {
         final boolean launchedIdle = launchIntent.getData() == null
                 && !Intent.ACTION_SEND.equals(action)
                 && !"com.brouken.player.action.SHORTCUT_VIDEOS".equals(action);
-        if (!launchedIdle) {
-            return;
-        }
         final long now = System.currentTimeMillis();
         if (now - mPrefs.updateLastCheck < UPDATE_CHECK_INTERVAL_MS) {
             return;
         }
         mPrefs.setUpdateLastCheck(now);
         Updater.find(info -> runOnUiThread(() -> {
-            if (isFinishing() || info == null) {
+            if (isFinishing()) {
                 return;
             }
-            if (info.versionCode == mPrefs.updateSkippedVersionCode) {
+            // Remembered so the button survives the launches the throttle skips; cleared when there is
+            // nothing on offer any more, so a pulled release takes the button down with it.
+            final boolean offer = info != null && info.versionCode != mPrefs.updateSkippedVersionCode;
+            mPrefs.setUpdatePending(offer ? info : null);
+            refreshUpdateButton();
+            if (!offer || !launchedIdle) {
                 return;
             }
             if (haveMedia && player != null && player.isPlaying()) {
                 return;
             }
-            UpdateUi.showAvailableDialog(PlayerActivity.this, info,
-                    () -> mPrefs.setUpdateSkippedVersionCode(info.versionCode));
+            UpdateUi.showAvailableDialog(PlayerActivity.this, info, skipUpdate(info), false);
         }));
+    }
+
+    private void refreshUpdateButton() {
+        if (buttonUpdate != null) {
+            // autoUpdate is the off switch for the whole feature, so it has to take a remembered find with
+            // it — otherwise turning updates off would leave the button sitting there.
+            final boolean show = BuildConfig.ENABLE_UPDATE && mPrefs.autoUpdate && mPrefs.updatePending != null;
+            buttonUpdate.setVisibility(show ? View.VISIBLE : View.GONE);
+        }
+    }
+
+    private Runnable skipUpdate(final UpdateInfo info) {
+        return () -> {
+            mPrefs.setUpdateSkippedVersionCode(info.versionCode);
+            mPrefs.setUpdatePending(null);
+            refreshUpdateButton();
+        };
     }
 
     @Override

--- a/app/src/main/java/com/brouken/player/Prefs.java
+++ b/app/src/main/java/com/brouken/player/Prefs.java
@@ -11,6 +11,8 @@ import android.text.TextUtils;
 import androidx.media3.exoplayer.DefaultRenderersFactory;
 import androidx.media3.ui.AspectRatioFrameLayout;
 
+import com.brouken.player.update.UpdateInfo;
+
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.ObjectInputStream;
@@ -71,6 +73,7 @@ class Prefs {
     private static final String PREF_KEY_AUTO_UPDATE = "autoUpdate";
     private static final String PREF_KEY_UPDATE_LAST_CHECK = "updateLastCheck";
     private static final String PREF_KEY_UPDATE_SKIPPED = "updateSkippedVersionCode";
+    private static final String PREF_KEY_UPDATE_PENDING = "updatePending";
     private static final String PREF_KEY_REVOKED_AUDIO_MIMES = "revokedAudioMimes";
     private static final String PREF_KEY_REVOKED_AUDIO_MIMES_RELEARNED = "revokedAudioMimesRelearned";
 
@@ -150,6 +153,9 @@ class Prefs {
     public boolean autoUpdate = true;
     public long updateLastCheck = 0L;
     public int updateSkippedVersionCode = 0;
+    // Last update the check found, remembered across launches so the button beside the gear is there from
+    // the first frame instead of only on the launches where the hourly throttle lets a request through.
+    public UpdateInfo updatePending;
     // Audio sample mimes (Format.sampleMimeType, e.g. MimeTypes.AUDIO_DTS) this device has proven
     // cannot passthrough — see PlayerActivity.recoverByRevokingAudioMime(). Never auto-expires;
     // only the "Reset learned audio workarounds" setting or a full app data reset clears it.
@@ -222,6 +228,12 @@ class Prefs {
         speed = mSharedPreferences.getFloat(PREF_KEY_SPEED, speed);
         updateLastCheck = mSharedPreferences.getLong(PREF_KEY_UPDATE_LAST_CHECK, updateLastCheck);
         updateSkippedVersionCode = mSharedPreferences.getInt(PREF_KEY_UPDATE_SKIPPED, updateSkippedVersionCode);
+        updatePending = UpdateInfo.fromJson(mSharedPreferences.getString(PREF_KEY_UPDATE_PENDING, null));
+        // A remembered find that has since been installed or skipped is not an offer any more.
+        if (updatePending != null && (updatePending.versionCode <= BuildConfig.VERSION_CODE
+                || updatePending.versionCode == updateSkippedVersionCode)) {
+            updatePending = null;
+        }
         loadUserPreferences();
     }
 
@@ -414,6 +426,17 @@ class Prefs {
         this.updateSkippedVersionCode = versionCode;
         final SharedPreferences.Editor sharedPreferencesEditor = mSharedPreferences.edit();
         sharedPreferencesEditor.putInt(PREF_KEY_UPDATE_SKIPPED, versionCode);
+        sharedPreferencesEditor.apply();
+    }
+
+    public void setUpdatePending(final UpdateInfo info) {
+        this.updatePending = info;
+        final SharedPreferences.Editor sharedPreferencesEditor = mSharedPreferences.edit();
+        if (info == null) {
+            sharedPreferencesEditor.remove(PREF_KEY_UPDATE_PENDING);
+        } else {
+            sharedPreferencesEditor.putString(PREF_KEY_UPDATE_PENDING, info.toJson());
+        }
         sharedPreferencesEditor.apply();
     }
 

--- a/app/src/main/java/com/brouken/player/SettingsActivity.java
+++ b/app/src/main/java/com/brouken/player/SettingsActivity.java
@@ -200,7 +200,7 @@ public class SettingsActivity extends AppCompatActivity {
                                 return;
                             }
                             if (info != null) {
-                                UpdateUi.showAvailableDialog(activity, info, null);
+                                UpdateUi.showAvailableDialog(activity, info, null, false);
                             } else {
                                 Toast.makeText(activity, R.string.update_none, Toast.LENGTH_SHORT).show();
                             }

--- a/app/src/main/java/com/brouken/player/update/UpdateInfo.java
+++ b/app/src/main/java/com/brouken/player/update/UpdateInfo.java
@@ -1,5 +1,8 @@
 package com.brouken.player.update;
 
+import org.json.JSONException;
+import org.json.JSONObject;
+
 /**
  * One available update, resolved from a GitHub release. Immutable data holder.
  */
@@ -24,5 +27,40 @@ public final class UpdateInfo {
         this.changelog = changelog;
         this.apkUrl = apkUrl;
         this.size = size;
+    }
+
+    /**
+     * Serialises the whole find into one string, so Prefs can keep it across process death: the check is
+     * throttled, and without a remembered result the "update available" button would come and go with
+     * whichever launch happened to hit the network.
+     */
+    public String toJson() {
+        final JSONObject json = new JSONObject();
+        try {
+            json.put("versionCode", versionCode);
+            json.put("tagName", tagName);
+            json.put("versionName", versionName);
+            json.put("changelog", changelog);
+            json.put("apkUrl", apkUrl);
+            json.put("size", size);
+        } catch (JSONException e) {
+            return null;
+        }
+        return json.toString();
+    }
+
+    /** Inverse of {@link #toJson()}; null for anything unreadable. */
+    public static UpdateInfo fromJson(final String raw) {
+        if (raw == null || raw.isEmpty()) {
+            return null;
+        }
+        try {
+            final JSONObject json = new JSONObject(raw);
+            return new UpdateInfo(json.optInt("versionCode"), json.optString("tagName"),
+                    json.optString("versionName"), json.optString("changelog"),
+                    json.optString("apkUrl"), json.optLong("size"));
+        } catch (JSONException e) {
+            return null;
+        }
     }
 }

--- a/app/src/main/java/com/brouken/player/update/UpdateUi.java
+++ b/app/src/main/java/com/brouken/player/update/UpdateUi.java
@@ -28,8 +28,11 @@ public final class UpdateUi {
     /**
      * Shows the "update available" dialog. {@code onSkip} — when non-null — adds a "Skip this
      * version" button that runs it (used by the silent auto-check; the manual check passes null).
+     * {@code warnPlaybackStops} spells out that installing ends the film: the dialog is reachable
+     * mid-playback from the button beside the gear, and the installer takes the process with it.
      */
-    public static void showAvailableDialog(final Activity activity, final UpdateInfo info, final Runnable onSkip) {
+    public static void showAvailableDialog(final Activity activity, final UpdateInfo info,
+                                           final Runnable onSkip, final boolean warnPlaybackStops) {
         if (activity.isFinishing()) {
             return;
         }
@@ -40,6 +43,9 @@ public final class UpdateUi {
 
         final SpannableStringBuilder text = new SpannableStringBuilder(header);
         text.setSpan(new StyleSpan(Typeface.BOLD), 0, text.length(), Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
+        if (warnPlaybackStops) {
+            text.append("\n").append(activity.getString(R.string.update_stops_playback));
+        }
         if (!changelog.isEmpty()) {
             text.append("\n\n").append(MarkdownRenderer.render(changelog));
         }

--- a/app/src/main/res/drawable/ic_update_24dp.xml
+++ b/app/src/main/res/drawable/ic_update_24dp.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:tint="#FFFFFF"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M12,4V1L8,5l4,4V6c3.31,0 6,2.69 6,6 0,1.01 -0.25,1.97 -0.7,2.8l1.46,1.46C19.54,15.03 20,13.57 20,12c0,-4.42 -3.58,-8 -8,-8zM12,18c-3.31,0 -6,-2.69 -6,-6 0,-1.01 0.25,-1.97 0.7,-2.8L5.24,7.74C4.46,8.97 4,10.43 4,12c0,4.42 3.58,8 8,8v3l4,-4 -4,-4v3z" />
+</vector>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -112,6 +112,8 @@
     <string name="button_quality">Качество видео</string>
     <string name="button_audio_track">Аудио</string>
     <string name="button_more">Ещё</string>
+    <string name="button_update">Доступно обновление</string>
+    <string name="update_stops_playback">Плеер закроется для установки — позиция сохранится.</string>
     <string name="audio_title">Аудиодорожка</string>
     <string name="subtitle_title">Субтитры</string>
     <string name="subtitle_off">Выключены</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -119,6 +119,8 @@
     <string name="button_quality">Якість відео</string>
     <string name="button_audio_track">Аудіо</string>
     <string name="button_more">Ще</string>
+    <string name="button_update">Доступне оновлення</string>
+    <string name="update_stops_playback">Плеєр закриється для встановлення — позиція збережеться.</string>
     <string name="audio_title">Аудіодоріжка</string>
     <string name="subtitle_title">Субтитри</string>
     <string name="subtitle_off">Вимкнено</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -115,6 +115,7 @@
     <string name="update_now">Update</string>
     <string name="update_later">Later</string>
     <string name="update_skip">Skip this version</string>
+    <string name="update_stops_playback">The player will close to install — your position is saved.</string>
     <string name="time_ends_at">Ends at %s</string>
     <string name="time_ends_at_inline">until %1$s</string>
     <string name="playlist">Playlist</string>
@@ -135,6 +136,7 @@
     <string name="button_quality">Video quality</string>
     <string name="button_audio_track">Audio</string>
     <string name="button_more">More</string>
+    <string name="button_update">Update available</string>
     <string name="audio_title">Audio track</string>
     <string name="subtitle_title">Subtitles</string>
     <string name="subtitle_off">Off</string>


### PR DESCRIPTION
## Problem

The self-updater was in place but effectively silent. `maybeCheckForUpdate()` returned early unless the launch was idle, so anyone who reaches the player through another app's intent — the common case — never triggered a check at all. On top of that the check was throttled to 24 hours, so even a launch that did qualify could be half a day behind a hotfix.

## Change

Checking and telling are now separate concerns.

- **Check** runs on every launch, throttled to one hour. It is a single background request; the idle-launch gate is gone.
- **Result** is remembered in `Prefs.updatePending` (the `UpdateInfo` serialised to JSON), so a find survives process death and the button does not blink in and out with whichever launch happens to hit the network. It is dropped once installed, skipped, or no longer offered.
- **Dialog** stays gated exactly as before: idle launch, nothing playing.
- **Everything else** surfaces as a brand-coloured button in the bottom control pill, immediately before the gear — the same insertion point on phone and TV. The controls are only on screen when the user asked for them, so playback is never interrupted.
- The dialog is now reachable mid-playback, and installing ends the session, so it says so when something is playing.

## Verification

Built against the real `v1.0.2` release with the local build stamped lower.

- Phone (`ddd_test`), launched **with a video in the intent** — the path that previously never checked: the check ran, `updatePending` was written, no dialog appeared, the button showed up before the gear. Tapping it opened the dialog with the changelog and the playback warning. "Skip this version" removed the button and recorded `updateSkippedVersionCode`. Playback continued throughout.
- TV (`tv_720p`): same position in the row, D-pad reaches it.
- `assembleLatestAmazonDebug` builds; `ENABLE_UPDATE` is false there, so no button.

Not exercised live: the download/install path itself, which is unchanged.
