### PR TITLE
Let the sleep timer readout grow past a key row

### DIFF
--- a/app/src/main/java/com/brouken/player/DurationPanel.java
+++ b/app/src/main/java/com/brouken/player/DurationPanel.java
@@ -112,11 +112,14 @@ final class DurationPanel {
         valueRow.setOrientation(LinearLayout.HORIZONTAL);
         valueRow.setGravity(Gravity.CENTER_VERTICAL);
         // A key row's height and margin, so the readout and the backspace share the centre line of the
-        // "1 2 3" row instead of hovering a few pixels above it.
+        // "1 2 3" row instead of hovering a few pixels above it. A minimum rather than a fixed height:
+        // rowHeight does not follow the system font scale but the 24sp readout does, and at the largest
+        // scales a fixed row would crop it.
         final LinearLayout.LayoutParams valueLp = new LinearLayout.LayoutParams(
-                ViewGroup.LayoutParams.MATCH_PARENT, rowHeight);
+                ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT);
         valueLp.topMargin = Utils.dpToPx(8);
         valueRow.setLayoutParams(valueLp);
+        valueRow.setMinimumHeight(rowHeight);
         readoutColumn.addView(valueRow);
 
         final TextView value = new TextView(activity);


### PR DESCRIPTION
The readout row in `DurationPanel` was given a key row's fixed height in dp, while the value inside it is 24sp and therefore follows the system font scale. At the largest scales the digits were cropped.

Asks for that height as a minimum instead: the row still shares the centre line of the "1 2 3" key row, but grows when the text needs more.

Shared by both panels built on `DurationPanel` — the sleep timer and the skip offset.

The commit was written on `fix/timer-layout-and-playlist-subs` on 4 Aug but never reached master; the rest of that branch did. Cherry-picked onto current master unchanged.

Built and installed on a phone. Not yet observed at a large font scale — at the default scale the layout is unchanged, which is the point.
