### PR TITLE
Boost the volume where audio effects are unavailable

### DIFF
--- a/app/src/main/java/com/brouken/player/BoostAudioProcessor.java
+++ b/app/src/main/java/com/brouken/player/BoostAudioProcessor.java
@@ -1,0 +1,59 @@
+package com.brouken.player;
+
+import androidx.media3.common.C;
+import androidx.media3.common.audio.BaseAudioProcessor;
+
+import java.nio.ByteBuffer;
+
+/**
+ * Volume boost applied to the PCM stream itself, used where the LoudnessEnhancer effect is not
+ * available: some devices (Lenovo/MediaTek among them) gate third-party audio effects, handing out an
+ * effect that never reaches AudioFlinger — it stays uninitialized and silently does nothing. See
+ * Utils.applyBoost, which routes the boost to whichever of the two actually works.
+ * <p>
+ * Media3 ships a GainProcessor, but it casts the scaled sample straight to short: an overflowing peak
+ * wraps around into noise instead of clipping, which is exactly what boosting produces.
+ */
+class BoostAudioProcessor extends BaseAudioProcessor {
+
+    // Written on the app thread at every volume change, read on the playback thread.
+    private volatile float gain = 1f;
+
+    void setGain(float gain) {
+        this.gain = gain;
+    }
+
+    @Override
+    protected AudioFormat onConfigure(AudioFormat inputAudioFormat) {
+        // NOT_SET keeps this processor out of the chain: passthrough bitstreams and any other encoding
+        // are passed on untouched.
+        return inputAudioFormat.encoding == C.ENCODING_PCM_16BIT
+                || inputAudioFormat.encoding == C.ENCODING_PCM_FLOAT
+                ? inputAudioFormat : AudioFormat.NOT_SET;
+    }
+
+    @Override
+    public void queueInput(ByteBuffer inputBuffer) {
+        if (!inputBuffer.hasRemaining()) {
+            // The pipeline drains itself with the shared empty buffer, which replaceOutputBuffer(0)
+            // would hand straight back — copying a buffer onto itself throws.
+            return;
+        }
+        // Read once: the gesture can change it while a buffer is being scaled.
+        final float gain = this.gain;
+        final ByteBuffer outputBuffer = replaceOutputBuffer(inputBuffer.remaining());
+        if (gain == 1f) {
+            outputBuffer.put(inputBuffer);
+        } else if (inputAudioFormat.encoding == C.ENCODING_PCM_16BIT) {
+            while (inputBuffer.hasRemaining()) {
+                final int sample = Math.round(inputBuffer.getShort() * gain);
+                outputBuffer.putShort((short) Math.max(Short.MIN_VALUE, Math.min(Short.MAX_VALUE, sample)));
+            }
+        } else {
+            while (inputBuffer.hasRemaining()) {
+                outputBuffer.putFloat(Math.max(-1f, Math.min(1f, inputBuffer.getFloat() * gain)));
+            }
+        }
+        outputBuffer.flip();
+    }
+}

--- a/app/src/main/java/com/brouken/player/PlayerActivity.java
+++ b/app/src/main/java/com/brouken/player/PlayerActivity.java
@@ -105,6 +105,7 @@ import androidx.media3.common.TrackSelectionOverride;
 import androidx.media3.common.Timeline;
 import androidx.media3.common.TrackSelectionParameters;
 import androidx.media3.common.Tracks;
+import androidx.media3.common.audio.AudioProcessor;
 import androidx.media3.common.util.StuckPlayerException;
 import androidx.media3.datasource.DefaultDataSource;
 import androidx.media3.datasource.DefaultHttpDataSource;
@@ -122,6 +123,7 @@ import androidx.media3.exoplayer.SeekParameters;
 import androidx.media3.exoplayer.analytics.AnalyticsListener;
 import androidx.media3.exoplayer.audio.AudioRendererEventListener;
 import androidx.media3.exoplayer.audio.AudioSink;
+import androidx.media3.exoplayer.audio.DefaultAudioSink;
 import androidx.media3.exoplayer.audio.ForwardingAudioSink;
 import androidx.media3.exoplayer.mediacodec.MediaCodecSelector;
 import androidx.media3.exoplayer.mediacodec.MediaCodecUtil;
@@ -187,6 +189,8 @@ public class PlayerActivity extends Activity {
     private MediaSession mediaSession;
     private DefaultTrackSelector trackSelector;
     public static LoudnessEnhancer loudnessEnhancer;
+    // Boost fallback for devices where the effect above is a no-op, see BoostAudioProcessor
+    public static BoostAudioProcessor boostProcessor;
 
     private CustomDefaultTrackNameProvider trackNameProvider;
     // Track names read from the container (MP4 udta/name, MKV TrackEntry/Name), and the resolved
@@ -6683,6 +6687,7 @@ public class PlayerActivity extends Activity {
             player.release();
             player = null;
             audioSink = null;
+            boostProcessor = null;
         }
 
         trackSelector = new DefaultTrackSelector(this);
@@ -6752,8 +6757,15 @@ public class PlayerActivity extends Activity {
             @Override
             protected AudioSink buildAudioSink(Context context, boolean enableFloatOutput,
                                                 boolean enableAudioTrackPlaybackParams) {
-                AudioSink sink = super.buildAudioSink(context, enableFloatOutput,
-                        enableAudioTrackPlaybackParams);
+                // Same sink the base class builds, plus the boost processor — it has to be in the chain
+                // from the start, since the chain is fixed once the sink exists. Silence skipping and
+                // playback speed are appended after it by DefaultAudioProcessorChain, as before.
+                boostProcessor = new BoostAudioProcessor();
+                AudioSink sink = new DefaultAudioSink.Builder(context)
+                        .setEnableFloatOutput(enableFloatOutput)
+                        .setEnableAudioTrackPlaybackParams(enableAudioTrackPlaybackParams)
+                        .setAudioProcessors(new AudioProcessor[]{boostProcessor})
+                        .build();
                 audioSink = new AudioPassthroughDenylistSink(sink, revokedAudioMimes);
                 return audioSink;
             }
@@ -7188,6 +7200,7 @@ public class PlayerActivity extends Activity {
             player.release();
             player = null;
             audioSink = null;
+            boostProcessor = null;
         }
         stopSkipPolling();
         cancelSegmentFinder();

--- a/app/src/main/java/com/brouken/player/Utils.java
+++ b/app/src/main/java/com/brouken/player/Utils.java
@@ -225,6 +225,10 @@ class Utils {
     }
 
     public static boolean canBoostVolume() {
+        return PlayerActivity.boostProcessor != null || boostEffectUsable();
+    }
+
+    private static boolean boostEffectUsable() {
         try {
             return PlayerActivity.loudnessEnhancer != null && PlayerActivity.loudnessEnhancer.hasControl();
         } catch (Exception e) {
@@ -234,18 +238,27 @@ class Utils {
     }
 
     /**
-     * Pushes boostLevel into the effect. Also called right after a LoudnessEnhancer is created, because
-     * boostLevel outlives both the effect and the activity, so a fresh effect starts at zero gain while
-     * the level still says otherwise.
+     * Pushes boostLevel into whichever boost actually works on this device: the LoudnessEnhancer effect
+     * where it does (it compresses rather than clips, so it takes far more gain), otherwise the PCM
+     * processor. Also called right after a LoudnessEnhancer is created, because boostLevel outlives both
+     * the effect and the activity, so a fresh effect starts at zero gain while the level still says
+     * otherwise.
      */
     static void applyBoost() {
-        if (PlayerActivity.loudnessEnhancer == null)
-            return;
-        try {
-            PlayerActivity.loudnessEnhancer.setTargetGain(PlayerActivity.boostLevel * 200);
-            PlayerActivity.loudnessEnhancer.setEnabled(PlayerActivity.boostLevel > 0);
-        } catch (Exception e) {
-            e.printStackTrace();
+        boolean applied = false;
+        if (PlayerActivity.loudnessEnhancer != null) {
+            try {
+                PlayerActivity.loudnessEnhancer.setTargetGain(PlayerActivity.boostLevel * 200);
+                PlayerActivity.loudnessEnhancer.setEnabled(PlayerActivity.boostLevel > 0);
+                applied = true;
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
+        }
+        if (PlayerActivity.boostProcessor != null) {
+            // Straight amplitude, so the gain matches what the OSD says (200% = twice as loud); clipping
+            // rules out the effect's 20 dB ceiling anyway.
+            PlayerActivity.boostProcessor.setGain(applied ? 1f : 1f + PlayerActivity.boostLevel * 0.1f);
         }
     }
 


### PR DESCRIPTION
On some devices third-party audio effects are gated: `LoudnessEnhancer` is constructed but stays uninitialized (the request never reaches AudioFlinger), so `setTargetGain`/`hasControl` throw and `canBoostVolume()` reported false. The volume gesture then stopped at 100% with no way into the boost zone. Reproduced on a Lenovo TB132FU (MediaTek, Android 14), where the audio chain is held by Dolby.

The boost is now applied to the PCM stream by `BoostAudioProcessor`, installed in the audio sink's processor chain (silence skipping and playback speed are still appended after it, as before). The effect keeps priority where it works, since it compresses rather than clips and so takes far more gain; `Utils.applyBoost` picks between the two in one place and falls back on its own if the effect throws.

Media3 ships a `GainProcessor`, but it casts the scaled sample straight to `short` — an overflowing peak wraps around into noise instead of clipping, which is exactly what boosting produces, so the processor here clamps.

Passthrough bitstreams carry no PCM and are left untouched, the same as with the effect.

Tested on the Lenovo tablet: playback is stable and the volume now goes past 100%.