### PR TITLE
Keep the scrubber dot in front of the segment highlights

### DIFF
--- a/app/src/main/java/com/brouken/player/CustomDefaultTimeBar.java
+++ b/app/src/main/java/com/brouken/player/CustomDefaultTimeBar.java
@@ -9,6 +9,7 @@ import android.view.MotionEvent;
 
 import androidx.annotation.Nullable;
 import androidx.media3.ui.DefaultTimeBar;
+import androidx.media3.ui.TimeBar;
 
 import java.lang.reflect.Field;
 
@@ -18,6 +19,9 @@ class CustomDefaultTimeBar extends DefaultTimeBar {
     private Rect progressBar;
     private boolean scrubbing;
     private int scrubbingStartX;
+    private boolean scrubbingNow;
+    private int playheadLeft;
+    private int playheadRight;
 
     private final Paint skipPaint = new Paint();
     private long[] skipStartsMs;
@@ -54,6 +58,23 @@ class CustomDefaultTimeBar extends DefaultTimeBar {
         } catch (NoSuchFieldException | IllegalAccessException e) {
             e.printStackTrace();
         }
+        // The scrubber grows while the bar is being dragged (DefaultTimeBar.drawPlayhead), and the base
+        // class keeps that flag private — this listener spans exactly the same window.
+        addListener(new OnScrubListener() {
+            @Override
+            public void onScrubStart(TimeBar timeBar, long position) {
+                scrubbingNow = true;
+            }
+
+            @Override
+            public void onScrubMove(TimeBar timeBar, long position) {
+            }
+
+            @Override
+            public void onScrubStop(TimeBar timeBar, long position, boolean canceled) {
+                scrubbingNow = false;
+            }
+        });
     }
 
     /**
@@ -91,6 +112,19 @@ class CustomDefaultTimeBar extends DefaultTimeBar {
         if (barWidth <= 0) {
             return;
         }
+        // Media3 paints the playhead inside super.onDraw above, so everything below lands on top of it —
+        // and the fill is opaque, which swallowed the coral dot whole while it sat inside a segment. Keep
+        // the dot's own patch clear instead, so it stays the frontmost mark on the bar: it is what the
+        // viewer is tracking. Bounds as in DefaultTimeBar.drawPlayhead.
+        if (scrubberBar != null) {
+            final int radius = playheadRadius();
+            final int playheadX = Math.min(Math.max(scrubberBar.right, scrubberBar.left), progressBar.right);
+            playheadLeft = playheadX - radius;
+            playheadRight = playheadX + radius;
+        } else {
+            playheadLeft = 0;
+            playheadRight = 0;
+        }
         // Each segment gets a soft fill band across its whole width, plus ~1.5dp crisp hairlines on the
         // boundaries (chapter-divider style). The band demarcates the region while the edges frame it,
         // both staying lighter in weight than the coral scrubber.
@@ -105,15 +139,43 @@ class CustomDefaultTimeBar extends DefaultTimeBar {
             }
             if (skipFillColors != null && right > left) {
                 skipPaint.setColor(skipFillColors[i]);
-                canvas.drawRect(left, progressBar.top, right, progressBar.bottom, skipPaint);
+                drawBand(canvas, left, right);
             }
             skipPaint.setColor(skipColors[i]);
-            canvas.drawRect(left, progressBar.top, left + hairWidth, progressBar.bottom, skipPaint);
+            drawBand(canvas, left, left + hairWidth);
             // Second hairline at the segment end, only when there's room for it to read as a separate edge.
             if (right - left > hairWidth * 2) {
-                canvas.drawRect(right - hairWidth, progressBar.top, right, progressBar.bottom, skipPaint);
+                drawBand(canvas, right - hairWidth, right);
             }
         }
+    }
+
+    /** Paints a bar-height band, leaving the playhead's patch clear so the scrubber stays in front of it. */
+    private void drawBand(Canvas canvas, int left, int right) {
+        if (right <= left) {
+            return;
+        }
+        if (right > playheadLeft && left < playheadRight) {
+            if (left < playheadLeft) {
+                canvas.drawRect(left, progressBar.top, playheadLeft, progressBar.bottom, skipPaint);
+            }
+            if (right > playheadRight) {
+                canvas.drawRect(playheadRight, progressBar.top, right, progressBar.bottom, skipPaint);
+            }
+            return;
+        }
+        canvas.drawRect(left, progressBar.top, right, progressBar.bottom, skipPaint);
+    }
+
+    /** The radius Media3 is currently drawing the scrubber with — same rule as DefaultTimeBar.drawPlayhead. */
+    private int playheadRadius() {
+        if (scrubbingNow || isFocused()) {
+            return getResources().getDimensionPixelSize(R.dimen.exo_styled_progress_dragged_thumb_size) / 2;
+        }
+        // Disabled (an unseekable stream): the base class draws no dot, so nothing has to be kept clear.
+        return isEnabled()
+                ? getResources().getDimensionPixelSize(R.dimen.exo_styled_progress_enabled_thumb_size) / 2
+                : 0;
     }
 
     private static float clamp(float value) {


### PR DESCRIPTION
On the time bar the red scrubber dot rendered *behind* the skip-segment highlights: the band and its boundary hairlines cut straight through the dot, and since the fill colour is opaque (`SKIP_FILL_COLOR`) the dot disappeared completely while the playhead was inside an intro segment.

## Cause

`CustomDefaultTimeBar.onDraw` starts with `super.onDraw(canvas)`, and Media3's `DefaultTimeBar.onDraw` is `drawTimeBar()` followed by `drawPlayhead()` — so the circle is already on the canvas before the highlights are drawn. The three `drawRect` calls that follow span `progressBar.top..bottom`; the bar is 2dp tall and the dot is 12dp wide, so they overwrite exactly its central stripe. (Checked against the local `lib-ui-release.aar` — stock Media3 1.11.0-beta01, no patches.)

## Fix

The highlights now leave the playhead's own patch clear instead of painting over it, so Media3 stays the only thing that draws the dot — no duplicated colour or paint. The patch follows the same radius rule as `drawPlayhead()` (`(scrubbing || isFocused()) ? dragged : enabled`), taken from the same dimens the layout hands the base class, so the enlarged dot is covered too. The base class keeps its `scrubbing` flag private, but that window is exactly `onScrubStart`..`onScrubStop`, so the view listens to itself for it.

`Canvas.clipOutRect` is avoided deliberately — it is API 26+ against a minSdk of 23, and the `Region.Op.DIFFERENCE` alternative is deprecated; splitting the rect needs no version branch.

## Verified on the tv_720p emulator (API 36), 4x zoom on the bar, segment 1–180 s with the playhead inside it

| | before | after |
|---|---|---|
| dot inside a segment | band and hairline cut through the circle | solid circle, band resuming flush on both sides |
| time bar focused (18dp dot) | same | enlarged dot also clear, no tinted ring |
| clip with no segments | — | bar unchanged |
