### PR TITLE
Remove the skip silence option

### DIFF
--- a/app/src/main/java/com/brouken/player/PlayerActivity.java
+++ b/app/src/main/java/com/brouken/player/PlayerActivity.java
@@ -6868,10 +6868,6 @@ public class PlayerActivity extends Activity {
                 .build();
         player.setAudioAttributes(audioAttributes, true);
         applyVolumeMode();
-
-        if (mPrefs.skipSilence) {
-            player.setSkipSilenceEnabled(true);
-        }
         applySleepAtEndOfItem();
 
         youTubeOverlay.player(player);
@@ -8768,7 +8764,6 @@ public class PlayerActivity extends Activity {
                 .append(", resize ").append(mPrefs.resizeMode)
                 .append(mPrefs.tunneling ? ", tunneling" : "")
                 .append(mPrefs.frameRateMatching ? ", frame rate matching" : "")
-                .append(mPrefs.skipSilence ? ", skip silence" : "")
                 .append(mPrefs.mapDV7ToHevc ? ", map DV7" : "");
         if (forceHevcForDolbyVision) {
             sb.append("\nRecovery: forced HEVC for Dolby Vision");

--- a/app/src/main/java/com/brouken/player/Prefs.java
+++ b/app/src/main/java/com/brouken/player/Prefs.java
@@ -52,7 +52,6 @@ class Prefs {
     private static final String PREF_KEY_AUTO_PIP = "autoPiP";
     private static final String PREF_KEY_DISABLE_VOLUME_BRIGHTNESS_GESTURES = "disableVolumeBrightnessGestures";
     private static final String PREF_KEY_TUNNELING = "tunneling";
-    private static final String PREF_KEY_SKIP_SILENCE = "skipSilence";
     private static final String PREF_KEY_FRAMERATE_MATCHING = "frameRateMatching";
     private static final String PREF_KEY_ALLOW_SYSTEM_FRAMERATE = "allowSystemFrameRate";
     private static final String PREF_KEY_REPEAT_TOGGLE = "repeatToggle";
@@ -136,7 +135,6 @@ class Prefs {
     public boolean disableVolumeBrightnessGestures = false;
 
     public boolean tunneling = false;
-    public boolean skipSilence = false;
     public boolean frameRateMatching = false;
     public boolean allowSystemFrameRate = true;
     public boolean repeatToggle = false;
@@ -259,7 +257,6 @@ class Prefs {
         disableVolumeBrightnessGestures = mSharedPreferences.getBoolean(
                 PREF_KEY_DISABLE_VOLUME_BRIGHTNESS_GESTURES, disableVolumeBrightnessGestures);
         tunneling = mSharedPreferences.getBoolean(PREF_KEY_TUNNELING, tunneling);
-        skipSilence = mSharedPreferences.getBoolean(PREF_KEY_SKIP_SILENCE, skipSilence);
         frameRateMatching = mSharedPreferences.getBoolean(PREF_KEY_FRAMERATE_MATCHING, frameRateMatching);
         allowSystemFrameRate = mSharedPreferences.getBoolean(PREF_KEY_ALLOW_SYSTEM_FRAMERATE, !Utils.isTvBox(mContext));
         repeatToggle = mSharedPreferences.getBoolean(PREF_KEY_REPEAT_TOGGLE, repeatToggle);

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -2,9 +2,6 @@
 <resources>
     <string name="pref_tunneling">التشغيل النفقي</string>
     <string name="pref_tunneling_summary">التشغيل النفقي يوفر دعم أفضل لجودة 4K/HDR، لكنه قد لا يعمل على جميع الأجهزة</string>
-    <string name="pref_skip_silence_off">شغل المحتوى كما هو</string>
-    <string name="pref_skip_silence_on">تخطي المقاطع الصامتة في البث الصوتي</string>
-    <string name="pref_skip_silence">تخطي الصمت</string>
     <string name="pref_auto_pip_off">لا تبدل لوضع الصورة المنبثقة تلقائيا</string>
     <string name="pref_auto_pip_on">تبديل لوضع الصورة المنبثقة عند الخروج من التطبيق</string>
     <string name="pref_auto_pip">صورة منبثقة تلقائيا</string>

--- a/app/src/main/res/values-az/strings.xml
+++ b/app/src/main/res/values-az/strings.xml
@@ -18,9 +18,6 @@
     <string name="pref_auto_pip">Avtomatik şəkil içində şəkil</string>
     <string name="pref_auto_pip_on">Tətbiqdən çıxarkən PiP-ə keçid et</string>
     <string name="pref_auto_pip_off">Avtomatik olaraq PiP-ə keçid etmə</string>
-    <string name="pref_skip_silence">Səssizliyi ötür</string>
-    <string name="pref_skip_silence_on">Səs axınında səssizlik hissələrin ötür</string>
-    <string name="pref_skip_silence_off">Məzmunu olduğu kimi oynat</string>
     <string name="video_resize_fit">Uyğunlaşdır</string>
     <string name="video_orientation_video">Video istiqamətləndirmə</string>
     <string name="request_scope">Xarici altyazıları avtomatik yükləmək və ya kataloqda növbəti fayla keçidi aktivləşdirmək üçün videolarınızı ehtiva edən ən üst qovluğa (məsələn, Filmlər) %s giriş icazəsi verin.</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -21,9 +21,6 @@
     <string name="pref_auto_pip">Automatický režim obrazu v obraze</string>
     <string name="pref_auto_pip_on">Přepnout do režimu obrazu v obraze při opouštění aplikace</string>
     <string name="pref_auto_pip_off">Nepřepínat automaticky do režimu obrazu v obraze</string>
-    <string name="pref_skip_silence">Přeskakování ticha</string>
-    <string name="pref_skip_silence_on">Přeskakovat části s tichem ve zvukové stopě</string>
-    <string name="pref_skip_silence_off">Přehrávat obsah tak, jak je</string>
     <string name="pref_repeat_toggle">Přepínač opakování</string>
     <string name="pref_repeat_toggle_summary">Extra tlačítko na nekonečné přehrávání videa dokola (vyžaduje restart aplikace)</string>
     <string name="pref_map_dv7">Dolby Vision profil 7</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -11,9 +11,6 @@
     <string name="delete_query">Diese Datei löschen\?</string>
     <string name="request_scope">Um automatisch externe Untertitel zu laden oder das Springen zur nächsten Datei in einem Verzeichnis zu aktivieren, gewähren Sie %s Zugriff auf den obersten Ordner, der Ihre Videos enthält (z. B. Filme).</string>
     <string name="pref_tunneling_summary">Tunneling bietet eine bessere Unterstützung für 4K/HDR-Inhalte, funktioniert aber möglicherweise nicht auf allen Geräten</string>
-    <string name="pref_skip_silence_off">Inhalt unverändert wiedergeben</string>
-    <string name="pref_skip_silence_on">Teile mit Stille im Audio-Stream überspringen</string>
-    <string name="pref_skip_silence">Stille überspringen</string>
     <string name="pref_auto_pip_off">Nicht automatisch auf Bild-im-Bild umschalten</string>
     <string name="pref_auto_pip_on">Beim Verlassen der Anwendung auf Bild-im-Bild umschalten</string>
     <string name="pref_auto_pip">Automatisches Bild-im-Bild</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -11,9 +11,6 @@
     <string name="delete_confirmation">Διαγραφή</string>
     <string name="delete_query">Διαγραφή αυτού του αρχείου;</string>
     <string name="pref_tunneling_summary">Η αναπαραγωγή σήραγγας (tunneling) παρέχει καλύτερη υποστήριξη περιεχομένου 4K/HDR, αλλά ενδέχεται να μη λειτουργεί σε όλες τις συσκευές</string>
-    <string name="pref_skip_silence_off">Αναπαραγωγή περιεχομένου ως έχει</string>
-    <string name="pref_skip_silence_on">Παράλειψη τμημάτων με σιωπή στη ροή ήχου</string>
-    <string name="pref_skip_silence">Παράλειψη σιωπής</string>
     <string name="pref_auto_pip_off">Χωρίς αυτόματη εναλλαγή σε εικόνα-εντός-εικόνας</string>
     <string name="pref_auto_pip_on">Εναλλαγή σε εικόνα-εντός-εικόνας κατά την έξοδο από την εφαρμογή</string>
     <string name="pref_auto_pip">Αυτόματη εικόνα-εντός-εικόνας</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -13,9 +13,6 @@
     <string name="pref_framerate_matching">Adaptación automática de la frecuencia de fotogramas</string>
     <string name="pref_general_header">General</string>
     <string name="pref_title">Ajustes</string>
-    <string name="pref_skip_silence_off">Reproducir contenido tal cual</string>
-    <string name="pref_skip_silence_on">Omitir partes con silencio en el flujo de audio</string>
-    <string name="pref_skip_silence">Omitir silencio</string>
     <string name="pref_auto_pip_off">No cambiar automáticamente a modo imagen en imagen</string>
     <string name="pref_auto_pip_on">Cambiar a modo imagen en imagen al salir de la aplicación</string>
     <string name="pref_auto_pip">Auto imagen en imagen</string>

--- a/app/src/main/res/values-et/strings.xml
+++ b/app/src/main/res/values-et/strings.xml
@@ -24,13 +24,10 @@
     <string name="pref_auto_pip">Automaatne pilt-pildis</string>
     <string name="pref_auto_pip_on">Rakendusest väljumisel lülita pilt-pildis vaade automaatselt sisse</string>
     <string name="pref_auto_pip_off">Ära lülita pilt-pildis vaadet automaatselt sisse</string>
-    <string name="pref_skip_silence">Jäta vaikus vahele</string>
     <string name="request_scope">Selleks, et rakendus saaks automaatselt välisest failist subtiitreid laadida ja kasutada kaustast järgmise faili automaatse esitamise võimalust, palun anna rakendusele %s ligipääs oma videote ülakaustale (nt. Movies).</string>
     <string name="pref_general_header">Üldised seadistused</string>
-    <string name="pref_skip_silence_on">Jäta vahele lõigud, kus helivoos on vaikus</string>
     <string name="pref_tunneling">Tunneldatud taasesitus</string>
     <string name="pref_tunneling_summary">Tunneldamine tagab parema 4K/HDR sisu toe, kuid ei pruugi toimida kõikides nutiseadmetes</string>
-    <string name="pref_skip_silence_off">Esita sisu sellisena nagu ta on loodud</string>
     <string name="pref_repeat_toggle">Lülita kordus sisse/välja</string>
     <string name="pref_repeat_toggle_summary">Lisavalik, mis võimaldab videot lõputult korrata (eeldab rakenduse taaskäivitamist)</string>
     <string name="pref_map_dv7">Varuvariant Dolby Visioni 7. profiili jaoks</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -11,9 +11,6 @@
     <string name="delete_confirmation">Supprimer</string>
     <string name="delete_query">Supprimer ce fichier \?</string>
     <string name="pref_tunneling_summary">Le mode tunnel permet une meilleure prise en charge des contenus 4K/HDR, mais il peut ne pas fonctionner sur tous les appareils</string>
-    <string name="pref_skip_silence_off">Lire le contenu tel quel</string>
-    <string name="pref_skip_silence_on">Sauter les parties avec du silence dans le flux audio</string>
-    <string name="pref_skip_silence">Passer les silences</string>
     <string name="pref_auto_pip_on">Passer en image dans l’image en quittant l’appli</string>
     <string name="pref_auto_pip_off">Ne pas passer automatiquement en image dans l’image</string>
     <string name="pref_auto_pip">Image dans l’image automatique</string>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -18,9 +18,6 @@
     <string name="pref_auto_pip">ऑटो पिक्चर-इन-पिक्चर</string>
     <string name="pref_auto_pip_on">ऐप छोड़ते समय PiP पर स्विच करें</string>
     <string name="pref_auto_pip_off">स्वचालित रूप से PiP पर स्विच न करें</string>
-    <string name="pref_skip_silence">स्किप साईलैंस</string>
-    <string name="pref_skip_silence_on">ऑडियो स्ट्रीम पर मौन के साथ वाले भागों को छोड़ें</string>
-    <string name="pref_skip_silence_off">कंटेंट को वैसे ही चलाएं जैसे वह है</string>
     <string name="pref_repeat_toggle">रिपीट टॉगल करें</string>
     <string name="pref_map_dv7">डॉल्बी विजन प्रोफाइल 7 फ़ॉलबैक</string>
     <string name="pref_map_dv7_off">डॉल्बी विजन युक्त यूएचडी ब्लू-रे कंटेंट वैसे ही चलाएं</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -15,9 +15,6 @@
     <string name="pref_framerate_matching_off">Nemoj mijenjati brzinu osvježavanja ekrana</string>
     <string name="pref_framerate_matching_on">Promijeni brzinu osvježavanja ekrana tako da odgovara brzini kadrova videa</string>
     <string name="pref_framerate_matching">Automatsko poklapanje brzine kadrova</string>
-    <string name="pref_skip_silence_off">Reproduciraj sadržaj onako kakav je</string>
-    <string name="pref_skip_silence_on">Preskoči dijelove s tišinom na audio prijenosu</string>
-    <string name="pref_skip_silence">Preskoči tišinu</string>
     <string name="pref_auto_pip_off">Nemoj automatski prebaciti na slika u slici</string>
     <string name="pref_auto_pip_on">Prije napuštanja programa prebaci na slika u slici</string>
     <string name="pref_auto_pip">Automatska slika u slici</string>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -10,9 +10,6 @@
     <string name="delete_confirmation">Hapus</string>
     <string name="delete_query">Hapus file ini\?</string>
     <string name="request_scope">Untuk memuat subtitle eksternal otomatis atau mengaktifkan skipping ke file berikutnya dalam direktori, berikan akses %s ke folder paling atas yang berisi video Anda (misalnya Film).</string>
-    <string name="pref_skip_silence_off">Mainkan konten apa adanya</string>
-    <string name="pref_skip_silence_on">Lewati bagian silence di aliran audio</string>
-    <string name="pref_skip_silence">Lewati keheningan</string>
     <string name="pref_auto_pip_off">Jangan secara otomatis berganti ke PiP</string>
     <string name="pref_auto_pip_on">Ganti ke PiP ketika keluar aplikasi</string>
     <string name="pref_auto_pip">Picture-in-picture otomatis</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -11,9 +11,6 @@
     <string name="delete_query">Eliminare questo file\?</string>
     <string name="request_scope">Per caricare automaticamente i sottotitoli esterni o abilitare il salto al file successivo in una directory, concedi l’accesso a %s alla cartella più in alto che contiene i tuoi video (ad esempio: Film).</string>
     <string name="pref_tunneling_summary">Il tunneling fornisce un migliore supporto per i contenuti 4K/HDR, ma potrebbe non funzionare su tutti i dispositivi</string>
-    <string name="pref_skip_silence_off">Riproduci il contenuto così com’è</string>
-    <string name="pref_skip_silence_on">Salta le parti con silenzio nel flusso audio</string>
-    <string name="pref_skip_silence">Salta il silenzio</string>
     <string name="pref_auto_pip_off">Non passare automaticamente all’immagine nell’immagine</string>
     <string name="pref_auto_pip_on">Passa all’immagine nell’immagine quando si lascia l’app</string>
     <string name="pref_auto_pip">Immagine nell’immagine automatica</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -20,13 +20,11 @@
     <string name="pref_file_access_auto">自動</string>
     <string name="button_crop">大きさ変更</string>
     <string name="pref_tunneling">トンネリング再生</string>
-    <string name="pref_skip_silence">無音をとばす</string>
     <string name="pref_framerate_matching_on">ディスプレイのリフレッシュレートを動画のフレームレートに切り替える</string>
     <string name="pref_auto_pip_off">自動的にPiPに切り替えない</string>
     <string name="pref_framerate_matching_off">ディスプレイのリフレッシュレートを変えない</string>
     <string name="pref_framerate_matching">自動でフレームレートを合わせる</string>
     <string name="pref_tunneling_summary">トンネリングは4KやHDRのコンテンツのために良いサポートを提供しますが、全ての端末では動作しないかもしれません</string>
-    <string name="pref_skip_silence_on">オーディオストリームで無音の部分をとばす</string>
     <string name="pref_auto_pip">自動ピクチャーインピクチャー</string>
     <string name="pref_auto_pip_on">アプリを離れるときにPiPに切り替える</string>
     <string name="pref_decoder_priority_prefer_device">端末のデコーダーを優先 (デフォルト)</string>
@@ -35,7 +33,6 @@
     <string name="pref_repeat_toggle">繰り返しトグル</string>
     <string name="pref_repeat_toggle_summary">動画の無限ループを許可する追加の制御 (アプリの再起動が必要)</string>
     <string name="pref_captioning_preferences">字幕の設定</string>
-    <string name="pref_skip_silence_off">コンテンツをそのまま再生する</string>
     <string name="pref_general_header">全般</string>
     <string name="pref_decoder_priority">優先するデコーダー</string>
     <string name="video_orientation_system">端末の向き</string>

--- a/app/src/main/res/values-km/strings.xml
+++ b/app/src/main/res/values-km/strings.xml
@@ -20,8 +20,6 @@
     <string name="pref_auto_pip">ស្វ័យរូបភាពក្នុងរូបភាព</string>
     <string name="pref_auto_pip_on">ប្ដូរទៅ PiP នៅពេលចេញពីកម្មវិធី</string>
     <string name="pref_auto_pip_off">ចូរកុំប្ដូរទៅ PiP ដោយស្វ័យប្រវត្តិ</string>
-    <string name="pref_skip_silence">រំលងភាពស្ងាត់</string>
-    <string name="pref_skip_silence_on">រំលងផ្នែកដែលស្ងប់ស្ងាត់លើខ្សែអូឌីយោ</string>
     <string name="shortcut_videos">វីដេអូ</string>
     <string name="button_open">បើក</string>
     <string name="button_crop">ប្ដូរទំហំ</string>
@@ -47,6 +45,5 @@
     <string name="pref_subtitle_style_bold">រចនាបថដិតក្រាស់</string>
     <string name="pref_subtitle_style_bold_on">ប្រើពុម្ពអក្សរដិតក្រាស់ជាធម្មតា</string>
     <string name="pref_subtitle_style_bold_off">ប្រើបុរេជម្រើសពុម្ពអក្សរធម្មតា</string>
-    <string name="pref_skip_silence_off">ចាក់មាតិកានៅជា</string>
     <string name="pref_repeat_toggle">ប៊ូតុងបិទបើកសាឡើងវិញ</string>
 </resources>

--- a/app/src/main/res/values-ml/strings.xml
+++ b/app/src/main/res/values-ml/strings.xml
@@ -6,7 +6,6 @@
     <string name="button_crop">വലുപ്പം മാറ്റുക</string>
     <string name="button_rotate">തിരിക്കുക</string>
     <string name="button_pip">ചിത്രത്തിൽ ചിത്രം</string>
-    <string name="pref_skip_silence">നിശബ്ദത ഒഴിവാക്കുക</string>
     <string name="pref_auto_pip">യാന്ത്രിക ചിത്രത്തിൽ ചിത്രം</string>
     <string name="pref_file_access_auto">യാന്ത്രികം</string>
     <string name="pref_dangerous_header">അപകടകരം ⚠️</string>
@@ -21,7 +20,6 @@
     <string name="pref_title">ക്രമീകരണങ്ങൾ</string>
     <string name="pref_general_header">പൊതുവായ</string>
     <string name="video_orientation_sensor">സ്വയം തിരിയുക</string>
-    <string name="pref_skip_silence_off">ഉള്ളടക്കം അതേപടി കളിക്കുക</string>
     <string name="shortcut_videos">വീഡിയോകൾ</string>
     <string name="pref_subtitle_style_embedded">ഉൾച്ചേർത്ത ശൈലികൾ</string>
     <string name="pref_subtitle_style_embedded_on">ഉൾച്ചേർത്ത ഉപശീർഷക ശൈലികൾ പ്രയോഗിക്കുക</string>

--- a/app/src/main/res/values-ms/strings.xml
+++ b/app/src/main/res/values-ms/strings.xml
@@ -18,7 +18,6 @@
     <string name="video_orientation_system">Putaran peranti</string>
     <string name="error_details">Perincian</string>
     <string name="pref_auto_pip_off">Jangan ubah ke mod tetingkap secara automatik</string>
-    <string name="pref_skip_silence">Langkau kesunyian</string>
     <string name="video_resize_fit">Padan</string>
     <string name="video_orientation_sensor">Putaran auto</string>
     <string name="pref_general_header">Umum</string>
@@ -27,12 +26,10 @@
     <string name="error_files_missing">Fail apl dinyahdayakan ataupun hilang</string>
     <string name="delete_query">Padam fail ini\?</string>
     <string name="pref_auto_pip_on">Ubah ke mod tetingkap ketika keluar apl</string>
-    <string name="pref_skip_silence_off">Mainkan kandungan seperti adanya</string>
     <string name="mediastore_empty">Tiada video yang terindeks. Untuk mengakses fail video pada storan yang ada, hidupkan pengimbasan media automatik pada tetapan sistem.</string>
     <string name="delete_confirmation">Padam</string>
     <string name="request_scope">Untuk memuatkan sari kata luaran atau menghidupkkan pelangkauan ke fail seterusnya di dalam direktori, benarkan %s akses ke folder paling atas yang mempunyai video anda (cth. Wagam).</string>
     <string name="pref_title">Tetapan</string>
-    <string name="pref_skip_silence_on">Langkau bahagian yang sunyi pada aliran audio</string>
     <string name="button_rotate">Putar</string>
     <string name="pref_file_access">Akses fail</string>
     <string name="pref_repeat_toggle_summary">Kawalan tambahan untuk menghidupkan ulangan video tanpa had (apl perlu dimulakan semula)</string>

--- a/app/src/main/res/values-nb-rNO/strings.xml
+++ b/app/src/main/res/values-nb-rNO/strings.xml
@@ -16,13 +16,10 @@
     <string name="pref_framerate_matching_on">Bytt skjermoppfriskningstakt for å samsvare med videorammetakt</string>
     <string name="request_scope">Innvilg %s tilgang til grunnmappen (f.eks «Filmer») som inneholder videoene dine for å laste eksterne undertekster eller hoppe til neste fil i mappen automatisk.</string>
     <string name="pref_framerate_matching_off">Ikke endre skjermoppfriskningstakt</string>
-    <string name="pref_skip_silence">Hopp over stillhet</string>
-    <string name="pref_skip_silence_off">Spill innholdet som det er</string>
     <string name="pref_general_header">Generelt</string>
     <string name="pref_title">Innstillinger</string>
     <string name="delete_confirmation">Slett</string>
     <string name="delete_query">Slett denne filen\?</string>
-    <string name="pref_skip_silence_on">Hoppe over deler med stillhet på audio stream</string>
     <string name="shortcut_videos">Videoer</string>
     <string name="pref_file_access">Filtilgang</string>
     <string name="pref_file_access_auto">Auto</string>

--- a/app/src/main/res/values-pa/strings.xml
+++ b/app/src/main/res/values-pa/strings.xml
@@ -10,7 +10,6 @@
     <string name="pref_title">ਸੈਟਿੰਗਾਂ</string>
     <string name="delete_query">ਕੀ ਇਸ ਫ਼ਾਈਲ ਨੂੰ ਮਿਟਾਉਣਾ ਹੈ\?</string>
     <string name="pref_framerate_matching">ਆਟੋ ਫਰੇਮ ਰੇਟ ਮੈਚਿੰਗ</string>
-    <string name="pref_skip_silence_off">ਕੰਟੈਂਟ ਨੂੰ ਜਿਵੇਂ ਹੈ, ਚਲਾਓ</string>
     <string name="pref_repeat_toggle">ਰਿਪੀਟ ਟੌਗਲ</string>
     <string name="pref_repeat_toggle_summary">ਅਣਮਿੱਥੇ ਸਮੇਂ ਲਈ ਵੀਡੀਓ ਲੂਪ ਦੀ ਆਗਿਆ ਦੇਣ ਲਈ ਵਾਧੂ ਨਿਯੰਤਰਣ (ਐਪ ਰੀਸਟਾਰਟ ਦੀ ਲੋੜ ਹੈ)</string>
     <string name="pref_map_dv7">ਡੌਲਬੀ ਵਿਜ਼ਨ ਪ੍ਰੋਫਾਈਲ 7 ਫਾਲਬੈਕ</string>
@@ -39,8 +38,6 @@
     <string name="pref_tunneling">ਟਨਲ ਕੀਤਾ ਪਲੇਬੈਕ</string>
     <string name="video_orientation_system">ਡਿਵਾਈਸ ਓਰੀਐਂਟੇਸ਼ਨ</string>
     <string name="request_scope">ਬਾਹਰੀ ਉਪਸਿਰਲੇਖਾਂ ਨੂੰ ਸਵੈਚਲਿਤ ਤੌਰ \'ਤੇ ਲੋਡ ਕਰਨ ਲਈ ਜਾਂ ਡਾਇਰੈਕਟਰੀ ਵਿੱਚ ਅਗਲੀ ਫਾਈਲ \'ਤੇ ਜਾਣ ਲਈ, %s ਨੂੰ ਤੁਹਾਡੇ ਵੀਡੀਓਜ਼ (ਉਦਾਹਰਨ ਲਈ ਮੂਵੀਜ਼) ਵਾਲੇ ਸਭ ਤੋਂ ਉੱਚੇ ਫੋਲਡਰ ਤੱਕ ਪਹੁੰਚ ਦਿਓ।</string>
-    <string name="pref_skip_silence">ਚੁੱਪ ਛੱਡੋ</string>
-    <string name="pref_skip_silence_on">ਆਡੀਓ ਸਟ੍ਰੀਮ \'ਤੇ ਚੁੱਪ ਵਾਲੇ ਹਿੱਸਿਆਂ ਨੂੰ ਛੱਡੋ</string>
     <string name="pref_general_header">ਆਮ</string>
     <string name="pref_framerate_matching_on">ਵੀਡੀਓ ਫਰੇਮ ਰੇਟ ਨਾਲ ਮੇਲ ਕਰਨ ਲਈ ਡਿਸਪਲੇ ਰਿਫ੍ਰੈਸ਼ ਰੇਟ ਨੂੰ ਬਦਲੋ</string>
     <string name="pref_framerate_matching_off">ਡਿਸਪਲੇ ਰਿਫਰੈਸ਼ ਰੇਟ ਨਾ ਬਦਲੋ</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -16,12 +16,9 @@
     <string name="video_orientation_system">Orientacja urządzenia</string>
     <string name="pref_auto_pip_off">Nie aktywuj PiP automatycznie</string>
     <string name="pref_auto_pip_on">Aktywuj PiP po wyjściu z aplikacji</string>
-    <string name="pref_skip_silence">Pomiń sekcje bez dźwięku</string>
     <string name="button_open">Otwórz</string>
     <string name="pref_framerate_matching_off">Nie zmieniaj częstotliwości ekranu</string>
     <string name="pref_auto_pip">Automatyczne picture-in-picture</string>
-    <string name="pref_skip_silence_on">Pomiń sekcje bez dźwięku w ścieżce dźwiękowej</string>
-    <string name="pref_skip_silence_off">Włączaj filmy bez zmian</string>
     <string name="pref_repeat_toggle_summary">Dodatkowa opcja zezwalająca na ciągłe powtarzanie filmu (wymaga restartu aplikacji)</string>
     <string name="button_rotate">Obróć</string>
     <string name="button_pip">Obraz-w-obrazie</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -17,7 +17,6 @@
     <string name="pref_framerate_matching_on">Alternar taxa de atualização da tela para corresponder à taxa de quadros do vídeo</string>
     <string name="button_crop">Redimensionar</string>
     <string name="pref_tunneling_summary">O tunelamento oferece melhor suporte para conteúdo 4K/HDR, mas pode não funcionar em todos os dispositivos</string>
-    <string name="pref_skip_silence">Pular silêncio</string>
     <string name="pref_file_access_auto">Automático</string>
     <string name="mediastore_empty">Nenhum arquivo de vídeo encontrado</string>
     <string name="pref_auto_pip">Picture-in-Picture automático</string>
@@ -30,8 +29,6 @@
     <string name="pref_decoder_priority">Prioridade do decodificador</string>
     <string name="pref_tunneling">Reprodução em túnel</string>
     <string name="pref_auto_pip_off">Não mudar automaticamente para PiP</string>
-    <string name="pref_skip_silence_on">Ignorar partes silenciosas em transmissões de áudio</string>
-    <string name="pref_skip_silence_off">Reproduzir conteúdo como está</string>
     <string name="pref_repeat_toggle_summary">Controle extra para permitir a repetição infinita do vídeo (requer a reinicialização do aplicativo)</string>
     <string name="button_pip">Picture-in-Picture</string>
     <string name="pref_file_access">Acesso aos arquivos</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -10,9 +10,6 @@
     <string name="video_orientation_video">Orientação do vídeo</string>
     <string name="video_resize_crop">Recortar</string>
     <string name="video_resize_fit">Ajustar</string>
-    <string name="pref_skip_silence_off">Reproduzir conteúdo \'as is\'</string>
-    <string name="pref_skip_silence_on">Ignorar partes do vídeo que não tenham fluxo de áudio</string>
-    <string name="pref_skip_silence">Ignorar silêncio</string>
     <string name="pref_auto_pip_off">Não alterar para PiP automaticamente</string>
     <string name="pref_auto_pip_on">Alterar para PiP ao sair da aplicação</string>
     <string name="pref_auto_pip">PIP automático</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -18,7 +18,6 @@
     <string name="pref_framerate_matching_off">Nu modificați rata de reîmprospătare a ecranului</string>
     <string name="pref_auto_pip">Imagine în imagine automată</string>
     <string name="pref_auto_pip_on">Comutați la PiP când părăsiți aplicația</string>
-    <string name="pref_skip_silence_off">Redă conținutul așa cum este</string>
     <string name="shortcut_videos">Videoclipuri</string>
     <string name="pref_auto_pip_off">Nu comutați automat la PiP</string>
     <string name="pref_repeat_toggle">Repetați comutatorul</string>
@@ -33,11 +32,9 @@
     <string name="pref_decoder_priority_prefer_app">Prefer decodorele de aplicații</string>
     <string name="pref_decoder_priority_only_device">Numai decodoare de dispozitiv</string>
     <string name="pref_shortcuts_header">Comenzi rapide</string>
-    <string name="pref_skip_silence">Sari peste tăcere</string>
     <string name="button_crop">Redimensiona</string>
     <string name="pref_tunneling">Redare tunelizată</string>
     <string name="button_rotate">Roti</string>
-    <string name="pref_skip_silence_on">Săriți părțile cu tăcere pe fluxul audio</string>
     <string name="button_open">Deschide</string>
     <string name="pref_tunneling_summary">Tunelarea oferă suport mai bun pentru conținutul 4K/HDR, dar este posibil să nu funcționeze pe toate dispozitivele</string>
     <string name="pref_map_dv7">Dolby Vision profil 7 rezervă</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -38,9 +38,6 @@
     <string name="delete_confirmation">Удалить</string>
     <string name="delete_query">Удалить этот файл\?</string>
     <string name="request_scope">Чтобы автоматически загружать внешние субтитры или переходить к следующему файлу в каталоге, предоставьте %s доступ к самой верхней папке, содержащей ваши видео (например, Movies).</string>
-    <string name="pref_skip_silence_off">Воспроизводить как есть</string>
-    <string name="pref_skip_silence_on">Пропускать фрагменты с тишиной в аудиопотоке</string>
-    <string name="pref_skip_silence">Пропускать тишину</string>
     <string name="pref_auto_pip_off">Не переключаться автоматически на картинку в картинке</string>
     <string name="pref_auto_pip_on">Переключение на картинку в картинке при выходе из приложения</string>
     <string name="pref_auto_pip">Автоматическая картинка в картинке</string>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -22,7 +22,6 @@
     <string name="pref_subtitle_header">Titulky</string>
     <string name="pref_tunneling">Tunelové prehrávanie</string>
     <string name="pref_auto_pip">Automatický režim obrazu v obraze</string>
-    <string name="pref_skip_silence">Preskočiť ticho</string>
     <string name="pref_repeat_toggle">Prepínač opakovania</string>
     <string name="pref_file_access">Prístup k súborom</string>
     <string name="pref_dangerous_header">Nebezpečné ⚠️</string>
@@ -36,7 +35,6 @@
     <string name="pref_decoder_priority_only_device">Len dekodéry zariadenia</string>
     <string name="pref_language_audio">Predvolená zvuková stopa</string>
     <string name="pref_framerate_matching">Automatické prispôsobenie snímkovej frekvencie</string>
-    <string name="pref_skip_silence_off">Prehrať obsah tak, ako je</string>
     <string name="mediastore_empty">Nenašli sa žiadne video súbory</string>
     <string name="pref_decoder_priority_prefer_device">Preferovať dekodéry zariadenia (predvolené)</string>
     <string name="pref_subtitle_style_embedded_on">Použiť vložené štýly titulkov</string>
@@ -47,7 +45,6 @@
     <string name="pref_auto_pip_off">Neprepínať automaticky na režim obrazu v obraze</string>
     <string name="pref_subtitle_style_embedded_off">Nepoužívať vložené štýly titulkov</string>
     <string name="pref_auto_pip_on">Prepnúť do režimu obrazu v obraze pri opustení aplikácie</string>
-    <string name="pref_skip_silence_on">Preskakovať časti s tichom vo zvukovej stope</string>
     <string name="pref_framerate_matching_on">Prepínať obnovovaciu frekvenciu displeja podľa snímkovej frekvencie videa</string>
     <string name="pref_map_dv7_on">Prehrávať obsah s Dolby Vision 7 profilom na HDR displejoch</string>
     <string name="pref_map_dv7_off">Prehrávať UHD Blu-ray obsah obsahujúci Dolby Vision tak, ako je</string>

--- a/app/src/main/res/values-ta/strings.xml
+++ b/app/src/main/res/values-ta/strings.xml
@@ -19,11 +19,8 @@
     <string name="open_subtitles">வசன வரிகளை ஏற்றவும்</string>
     <string name="error_files_missing">கோப்புகள் பயன்பாடு முடக்கப்பட்டுள்ளது அல்லது காணவில்லை</string>
     <string name="request_scope">வெளிப்புற வசனங்களைத் தானாக ஏற்ற அல்லது கோப்பகத்தில் அடுத்த கோப்பிற்குச் செல்வதை இயக்க, உங்கள் வீடியோக்கள் (எ.கா. திரைப்படங்கள்) உள்ள மேல்மட்ட கோப்புறைக்கு %s அணுகலை வழங்கவும்.</string>
-    <string name="pref_skip_silence_off">உள்ளடக்கத்தை அப்படியே இயக்கவும்</string>
     <string name="pref_repeat_toggle">மாற்றவும்</string>
     <string name="pref_tunneling_summary">சுரங்கப்பாதை 4K/HDR உள்ளடக்கத்திற்கு சிறந்த ஆதரவை வழங்குகிறது, ஆனால் எல்லா சாதனங்களிலும் வேலை செய்யாது</string>
-    <string name="pref_skip_silence">மௌனத்தைத் தவிர்க்கவும்</string>
-    <string name="pref_skip_silence_on">ஆடியோ ச்ட்ரீமில் ம silence னத்துடன் பகுதிகளைத் தவிர்க்கவும்</string>
     <string name="pref_repeat_toggle_summary">காலவரையின்றி லூப் வீடியோவை அனுமதிக்க கூடுதல் கட்டுப்பாடு (பயன்பாட்டை மறுதொடக்கம் தேவை)</string>
     <string name="pref_framerate_matching_on">வீடியோ பிரேம் வீதத்துடன் பொருந்த காட்சி புதுப்பிப்பு வீதத்தை மாற்றவும்</string>
     <string name="video_resize_crop">பயிர்</string>

--- a/app/src/main/res/values-th/strings.xml
+++ b/app/src/main/res/values-th/strings.xml
@@ -26,8 +26,5 @@
     <string name="pref_framerate_matching_off">อย่าเปลี่ยนอัตราการรีเฟรชแสดงผล</string>
     <string name="pref_auto_pip">ซ้อนภาพอัตโนมัติ</string>
     <string name="pref_auto_pip_off">อย่าเปลี่ยนไปใช้ PiP โดยอัตโนมัติ</string>
-    <string name="pref_skip_silence_off">เล่นเนื้อหาตามที่เป็นอยู่</string>
-    <string name="pref_skip_silence">ข้ามความเงียบ</string>
-    <string name="pref_skip_silence_on">ข้ามส่วนที่มีความเงียบในสตรีมเสียง</string>
     <string name="pref_framerate_matching">จับคู่อัตราเฟรมอัตโนมัติ</string>
 </resources>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -10,9 +10,6 @@
     <string name="delete_confirmation">Sil</string>
     <string name="delete_query">Bu dosya silinsin mi\?</string>
     <string name="request_scope">Harici alt yazıları otomatik olarak yüklemek veya bir dizindeki sonraki dosyaya atlamayı etkinleştirmek için videolarınızı içeren en üstteki klasöre (örn. Filmler) %s erişim izni verin.</string>
-    <string name="pref_skip_silence_off">İçeriği olduğu gibi oynat</string>
-    <string name="pref_skip_silence_on">Ses akışında sessiz olan bölümleri atla</string>
-    <string name="pref_skip_silence">Sessizliği atla</string>
     <string name="pref_auto_pip_off">Otomatik olarak resim içinde resime geçme</string>
     <string name="pref_auto_pip_on">Uygulamadan çıkarken resim içinde resime geç</string>
     <string name="pref_auto_pip">Otomatik resim içinde resim</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -53,9 +53,6 @@
     <string name="pref_auto_pip">Автоматичний режим PiP</string>
     <string name="pref_auto_pip_on">Перемикати автоматично на режим PiP при виході з додатку</string>
     <string name="pref_auto_pip_off">Не перемикатися автоматично на режим PiP</string>
-    <string name="pref_skip_silence">Пропускати тишу</string>
-    <string name="pref_skip_silence_on">Пропускати частини з тишею в аудіопотоці</string>
-    <string name="pref_skip_silence_off">Відтворювати контент як є</string>
     <string name="pref_repeat_toggle">Переключення повтору</string>
     <string name="pref_repeat_toggle_summary">Додатковий контроль, що дозволяє необмежений цикл відео (потрібно перезапустити додаток)</string>
     <string name="pref_disable_volume_brightness_gestures">Вимкнути жести гучності та яскравості</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -19,9 +19,6 @@
     <string name="pref_auto_pip">Tự động hình trong hình</string>
     <string name="pref_auto_pip_on">Chuyển sang hình trong hình khi rời khỏi ứng dụng</string>
     <string name="pref_auto_pip_off">Không tự động chuyển sang hình trong hình</string>
-    <string name="pref_skip_silence">Bỏ qua khoảng trống của âm thanh</string>
-    <string name="pref_skip_silence_on">Bỏ qua các phần có khoảng trống trên luồng âm thanh</string>
-    <string name="pref_skip_silence_off">Phát nội dung như hiện tại</string>
     <string name="pref_repeat_toggle">Bật/tắt lập lại</string>
     <string name="pref_repeat_toggle_summary">Kiểm soát bổ sung để cho phép video lặp lại vô thời hạn (yêu cầu khởi động lại ứng dụng)</string>
     <string name="button_open">Mở</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -11,9 +11,6 @@
     <string name="delete_query">删除这个文件？</string>
     <string name="request_scope">要自动加载外部字幕或启用跳到目录中的下一个文件，请允许%s访问包含您的视频（例如电影）的最顶层文件夹的。</string>
     <string name="pref_tunneling_summary">隧道模式为 4K/HDR 内容提供了更好的支持，但可能无法在所有设备上工作</string>
-    <string name="pref_skip_silence_off">按原样播放</string>
-    <string name="pref_skip_silence_on">跳过音频缺失部分</string>
-    <string name="pref_skip_silence">跳过无声片段</string>
     <string name="pref_auto_pip_off">不要自动切换到画中画</string>
     <string name="pref_auto_pip_on">离开本应用时切换至画中画</string>
     <string name="pref_auto_pip">自动画中画</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -21,9 +21,6 @@
     <string name="pref_auto_pip">自動子母畫面</string>
     <string name="pref_auto_pip_on">離開時切換至子母畫面</string>
     <string name="pref_auto_pip_off">停用自動切換子母畫面</string>
-    <string name="pref_skip_silence">略過無聲</string>
-    <string name="pref_skip_silence_on">跳過音訊串流中的無聲段落</string>
-    <string name="pref_skip_silence_off">播放所有內容</string>
     <string name="pref_repeat_toggle">重複播放控制項</string>
     <string name="pref_repeat_toggle_summary">啟用額外的循環播放控制項 (須重新啟動應用程式)</string>
     <string name="pref_map_dv7">Dolby Vision profile 7 配置</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -54,9 +54,6 @@
     <string name="pref_auto_pip">Auto picture-in-picture</string>
     <string name="pref_auto_pip_on">Switch to PiP when leaving the app</string>
     <string name="pref_auto_pip_off">Do not automatically switch to PiP</string>
-    <string name="pref_skip_silence">Skip silence</string>
-    <string name="pref_skip_silence_on">Skip parts with silence on the audio stream</string>
-    <string name="pref_skip_silence_off">Play content as is</string>
     <string name="pref_repeat_toggle">Repeat toggle</string>
     <string name="pref_repeat_toggle_summary">Extra control to allow indefinitely loop video (requires app restart)</string>
     <string name="pref_disable_volume_brightness_gestures">Turn off volume and brightness swipes</string>

--- a/app/src/main/res/xml/root_preferences.xml
+++ b/app/src/main/res/xml/root_preferences.xml
@@ -53,13 +53,6 @@
             app:title="@string/pref_system_volume" />
 
         <SwitchPreferenceCompat
-            app:key="skipSilence"
-            app:defaultValue="false"
-            app:summaryOn="@string/pref_skip_silence_on"
-            app:summaryOff="@string/pref_skip_silence_off"
-            app:title="@string/pref_skip_silence" />
-
-        <SwitchPreferenceCompat
             app:key="repeatToggle"
             app:defaultValue="false"
             app:summary="@string/pref_repeat_toggle_summary"


### PR DESCRIPTION
Removes the `Skip silence` setting entirely.

It toggled `ExoPlayer.setSkipSilenceEnabled` once, at player build time. Gone with it:

- `skipSilence` preference key and field in `Prefs`
- the `SwitchPreferenceCompat` in `root_preferences.xml`
- `pref_skip_silence` / `_on` / `_off` in the default locale and all 31 translations
- the `skip silence` entry in the player state diagnostics

The stored `skipSilence` boolean is left in SharedPreferences for existing users — an orphan boolean needs no migration.

Verified with `assembleLatestUniversalDebug`.