### PR TITLE
Drop the captioning shortcut where there is nothing to open

### DIFF
--- a/app/src/main/java/com/brouken/player/SettingsActivity.java
+++ b/app/src/main/java/com/brouken/player/SettingsActivity.java
@@ -171,6 +171,15 @@ public class SettingsActivity extends AppCompatActivity {
                 });
             }
 
+            // Fire OS and some TV boxes ship no system captioning screen, and the preference
+            // launches its intent itself — an unhandled one takes the app down.
+            Preference preferenceCaptioning = findPreference("captioningPreferences");
+            if (preferenceCaptioning != null && (preferenceCaptioning.getIntent() == null
+                    || preferenceCaptioning.getIntent().resolveActivity(
+                            getContext().getPackageManager()) == null)) {
+                preferenceCaptioning.setVisible(false);
+            }
+
             Preference preferenceSystemVolume = findPreference("systemVolume");
             if (preferenceSystemVolume != null && Utils.isTvBox(getContext())) {
                 // TV remotes route volume to the panel or receiver over CEC, where only the system

--- a/app/src/main/res/xml/root_preferences.xml
+++ b/app/src/main/res/xml/root_preferences.xml
@@ -145,6 +145,7 @@
             app:title="@string/pref_subtitle_style_bold" />
 
         <Preference
+            app:key="captioningPreferences"
             app:title="@string/pref_captioning_preferences">
             <intent android:action="android.settings.CAPTIONING_SETTINGS" />
         </Preference>


### PR DESCRIPTION
Fire OS and some TV boxes ship no activity for `android.settings.CAPTIONING_SETTINGS`. The preference launches its intent itself, outside any code of ours, so on those devices tapping "Captioning preferences" in Settings threw an uncaught `ActivityNotFoundException` (seen on an Amazon Fire TV Stick, Fire OS / Android 7.1.2).

The item is now hidden when the intent resolves to nothing, using the same check the player already does for the same intent behind a long press on the subtitle button.