### PR TITLE
Ask about listing a room where the room is made

### DIFF
--- a/app/src/main/java/com/brouken/player/PlayerActivity.java
+++ b/app/src/main/java/com/brouken/player/PlayerActivity.java
@@ -72,6 +72,7 @@ import android.view.WindowInsets;
 import android.view.WindowInsetsController;
 import android.view.accessibility.CaptioningManager;
 import android.widget.Button;
+import android.widget.CheckBox;
 import android.widget.EditText;
 import android.widget.FrameLayout;
 import android.widget.HorizontalScrollView;
@@ -5636,7 +5637,7 @@ public class PlayerActivity extends Activity {
             items.add(new MenuItem(R.drawable.ic_close_24dp, getString(R.string.together_leave),
                     null, false, this::leaveRoom));
         } else {
-            items.add(new MenuItem(R.drawable.ic_together_24dp, getString(R.string.together_create),
+            items.add(new MenuItem(R.drawable.ic_add_24dp, getString(R.string.together_create),
                     null, false, this::createRoom));
             items.add(new MenuItem(R.drawable.ic_search_24dp, getString(R.string.together_find),
                     null, false, this::findRooms));
@@ -5727,7 +5728,9 @@ public class PlayerActivity extends Activity {
     /**
      * Name the room and settle its password before opening it, which is the plugin's own order of
      * questions. The password is pre-filled from settings so the common case is one confirmation,
-     * while a one-off room can still be given its own — or none.
+     * while a one-off room can still be given its own — or none. Whether the room is listed is asked
+     * here too, and the answer is remembered as the next room's default: it is a decision about the
+     * room being made, not a standing preference worth hunting for in settings.
      */
     private void createRoom() {
         final JSONObject session = sessionDescription();
@@ -5752,20 +5755,28 @@ public class PlayerActivity extends Activity {
         password.setHint(getString(R.string.together_password_hint));
         password.setText(mPrefs.togetherPassword);
 
+        final CheckBox listed = new CheckBox(this);
+        listed.setText(R.string.together_public);
+        listed.setChecked(mPrefs.togetherPublic);
+
         final LinearLayout fields = new LinearLayout(this);
         fields.setOrientation(LinearLayout.VERTICAL);
         final int pad = Utils.dpToPx(16);
         fields.setPadding(pad, 0, pad, 0);
         fields.addView(name);
         fields.addView(password);
+        fields.addView(listed);
 
         new AlertDialog.Builder(this)
                 .setTitle(getString(R.string.together_create_title, code))
                 .setView(fields)
-                .setPositiveButton(android.R.string.ok, (dialog, which) -> openRoom(code,
-                        name.getText().toString().trim(),
-                        password.getText().toString(),
-                        session))
+                .setPositiveButton(android.R.string.ok, (dialog, which) -> {
+                    mPrefs.updateTogetherPublic(listed.isChecked());
+                    openRoom(code,
+                            name.getText().toString().trim(),
+                            password.getText().toString(),
+                            session);
+                })
                 .setNegativeButton(android.R.string.cancel, null)
                 .show();
     }

--- a/app/src/main/java/com/brouken/player/Prefs.java
+++ b/app/src/main/java/com/brouken/player/Prefs.java
@@ -419,6 +419,12 @@ class Prefs {
         sharedPreferencesEditor.apply();
     }
 
+    /** Asked when a room is created, remembered as the next one's default. */
+    public void updateTogetherPublic(final boolean value) {
+        this.togetherPublic = value;
+        mSharedPreferences.edit().putBoolean(PREF_KEY_TOGETHER_PUBLIC, value).apply();
+    }
+
     public void markFirstRun() {
         this.firstRun = false;
         final SharedPreferences.Editor sharedPreferencesEditor = mSharedPreferences.edit();

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -88,9 +88,6 @@
     <string name="pref_together_nick">Имя устройства</string>
     <string name="pref_together_nick_random">Сгенерировать новое имя</string>
     <string name="pref_together_nick_random_summary">Выбрать другое случайное имя для этого устройства</string>
-    <string name="pref_together_public">Показывать комнаты в списке</string>
-    <string name="pref_together_public_on">Комнаты, которые вы создаёте, появляются в списке, а их название, постер и число зрителей можно прочитать, даже не заходя</string>
-    <string name="pref_together_public_off">В комнаты, которые вы создаёте, можно войти только по коду</string>
     <string name="pref_together_relay">Адрес реле</string>
     <string name="pref_together_relay_summary">WebSocket-реле, через которое работают комнаты. Все в комнате должны использовать одно и то же. Пустое поле — по умолчанию.</string>
     <string name="pref_together_relay_default">По умолчанию (%1$s)</string>
@@ -117,6 +114,7 @@
     <string name="together_no_room">Комнаты с таким кодом нет — или нужен пароль</string>
     <string name="together_badge_named">%1$s [%2$s] · %3$d</string>
     <string name="together_create_title">Новая комната %1$s</string>
+    <string name="together_public">Показывать комнату в списке</string>
     <string name="together_room_default_name">Комната %1$s</string>
     <string name="together_badge">Комната %1$s · %2$d</string>
     <string name="together_offline">Комната %1$s · переподключение…</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -89,9 +89,6 @@
     <string name="pref_together_nick">Ім’я пристрою</string>
     <string name="pref_together_nick_random">Згенерувати нове ім’я</string>
     <string name="pref_together_nick_random_summary">Вибрати інше випадкове ім’я для цього пристрою</string>
-    <string name="pref_together_public">Показувати кімнати у списку</string>
-    <string name="pref_together_public_on">Кімнати, які ви створюєте, з’являються у списку, а їхню назву, постер і кількість глядачів можна прочитати, навіть не заходячи</string>
-    <string name="pref_together_public_off">До кімнат, які ви створюєте, можна увійти лише за кодом</string>
     <string name="pref_together_relay">Адреса реле</string>
     <string name="pref_together_relay_summary">WebSocket-реле, через яке працюють кімнати. Усі в кімнаті мусять використовувати те саме. Порожнє поле — типове.</string>
     <string name="pref_together_relay_default">Типове (%1$s)</string>
@@ -118,6 +115,7 @@
     <string name="together_no_room">Кімнати з таким кодом немає — або потрібен пароль</string>
     <string name="together_badge_named">%1$s [%2$s] · %3$d</string>
     <string name="together_create_title">Нова кімната %1$s</string>
+    <string name="together_public">Показувати кімнату у списку</string>
     <string name="together_room_default_name">Кімната %1$s</string>
     <string name="together_badge">Кімната %1$s · %2$d</string>
     <string name="together_offline">Кімната %1$s · перепідключення…</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -90,9 +90,6 @@
     <string name="pref_together_nick">Device name</string>
     <string name="pref_together_nick_random">Generate a new name</string>
     <string name="pref_together_nick_random_summary">Pick another random name for this device</string>
-    <string name="pref_together_public">List rooms publicly</string>
-    <string name="pref_together_public_on">Rooms you create appear in the room list, and their name, poster and viewer count can be read without joining</string>
-    <string name="pref_together_public_off">Rooms you create can only be entered with the code</string>
     <string name="pref_together_relay">Relay address</string>
     <string name="pref_together_relay_summary">WebSocket relay that carries rooms. Everyone in a room must use the same one. Leave empty for the default.</string>
     <string name="pref_together_relay_default">Default (%1$s)</string>
@@ -119,6 +116,7 @@
     <string name="together_no_room">No room with that code — or it needs a password</string>
     <string name="together_badge_named">%1$s [%2$s] · %3$d</string>
     <string name="together_create_title">New room %1$s</string>
+    <string name="together_public">List the room publicly</string>
     <string name="together_room_default_name">Room %1$s</string>
     <string name="together_badge">Room %1$s · %2$d</string>
     <string name="together_offline">Room %1$s · reconnecting…</string>

--- a/app/src/main/res/xml/root_preferences.xml
+++ b/app/src/main/res/xml/root_preferences.xml
@@ -165,13 +165,6 @@
             app:title="@string/pref_together_nick_random"
             app:summary="@string/pref_together_nick_random_summary" />
 
-        <SwitchPreferenceCompat
-            app:key="togetherPublic"
-            app:defaultValue="false"
-            app:summaryOff="@string/pref_together_public_off"
-            app:summaryOn="@string/pref_together_public_on"
-            app:title="@string/pref_together_public" />
-
         <EditTextPreference
             app:key="togetherPassword"
             app:title="@string/pref_together_password"


### PR DESCRIPTION
Two changes to watching together:

- **Listing** — the `List rooms publicly` switch moved out of the advanced settings into the create-room dialog, as a checkbox under the name and the password. The answer is remembered as the next room's default, so nothing is lost for anyone who always wants one or the other.
- **Icon** — `Create a room` now shows the plus glyph instead of the group icon it shared with the feature itself.

The two now-unused summary strings are gone; the label is new in en/uk/ru.