### PR TITLE
Require a password before a room can be listed publicly

### DIFF
--- a/app/src/main/java/com/brouken/player/PlayerActivity.java
+++ b/app/src/main/java/com/brouken/player/PlayerActivity.java
@@ -47,10 +47,12 @@ import android.os.Parcelable;
 import android.os.SystemClock;
 import android.provider.DocumentsContract;
 import android.provider.Settings;
+import android.text.Editable;
 import android.text.InputType;
 import android.text.SpannableString;
 import android.text.Spanned;
 import android.text.TextUtils;
+import android.text.TextWatcher;
 import android.text.format.DateFormat;
 import android.text.style.ForegroundColorSpan;
 import android.text.style.RelativeSizeSpan;
@@ -5759,6 +5761,16 @@ public class PlayerActivity extends Activity {
         listed.setText(R.string.together_public);
         listed.setChecked(mPrefs.togetherPublic);
 
+        // A listed room without a password is open to whoever reads the list. Said as a quiet line under
+        // the tick that put it there, not as an error after the fact: the accent here is already the brand
+        // coral, and a red field on top of it reads as alarm rather than as the one thing left to fill in.
+        final TextView note = new TextView(this);
+        note.setText(R.string.together_public_needs_password);
+        note.setTextSize(TypedValue.COMPLEX_UNIT_SP, 13);
+        note.setTextColor(ContextCompat.getColor(this, R.color.error_ink_muted));
+        note.setPadding(0, 0, 0, Utils.dpToPx(4));
+        note.setVisibility(View.GONE);
+
         final LinearLayout fields = new LinearLayout(this);
         fields.setOrientation(LinearLayout.VERTICAL);
         final int pad = Utils.dpToPx(16);
@@ -5766,11 +5778,12 @@ public class PlayerActivity extends Activity {
         fields.addView(name);
         fields.addView(password);
         fields.addView(listed);
+        fields.addView(note);
 
-        new AlertDialog.Builder(this)
+        final AlertDialog dialog = new AlertDialog.Builder(this)
                 .setTitle(getString(R.string.together_create_title, code))
                 .setView(fields)
-                .setPositiveButton(android.R.string.ok, (dialog, which) -> {
+                .setPositiveButton(android.R.string.ok, (d, which) -> {
                     mPrefs.updateTogetherPublic(listed.isChecked());
                     openRoom(code,
                             name.getText().toString().trim(),
@@ -5778,7 +5791,31 @@ public class PlayerActivity extends Activity {
                             session);
                 })
                 .setNegativeButton(android.R.string.cancel, null)
-                .show();
+                .create();
+        // OK carries the refusal — greyed out while the pair is impossible, live from both the tick and
+        // the field. Wired on show: the buttons do not exist before that.
+        dialog.setOnShowListener(d -> {
+            final Runnable sync = () -> {
+                final boolean open = listed.isChecked() && password.getText().length() == 0;
+                note.setVisibility(open ? View.VISIBLE : View.GONE);
+                dialog.getButton(AlertDialog.BUTTON_POSITIVE).setEnabled(!open);
+            };
+            listed.setOnCheckedChangeListener((button, checked) -> sync.run());
+            password.addTextChangedListener(new TextWatcher() {
+                @Override
+                public void beforeTextChanged(CharSequence s, int start, int count, int after) {}
+
+                @Override
+                public void onTextChanged(CharSequence s, int start, int before, int count) {}
+
+                @Override
+                public void afterTextChanged(Editable s) {
+                    sync.run();
+                }
+            });
+            sync.run();
+        });
+        dialog.show();
     }
 
     private void openRoom(final String code, final String name, final String password,

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -115,6 +115,7 @@
     <string name="together_badge_named">%1$s [%2$s] · %3$d</string>
     <string name="together_create_title">Новая комната %1$s</string>
     <string name="together_public">Показывать комнату в списке</string>
+    <string name="together_public_needs_password">Публичная комната должна быть с паролем</string>
     <string name="together_room_default_name">Комната %1$s</string>
     <string name="together_badge">Комната %1$s · %2$d</string>
     <string name="together_offline">Комната %1$s · переподключение…</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -116,6 +116,7 @@
     <string name="together_badge_named">%1$s [%2$s] · %3$d</string>
     <string name="together_create_title">Нова кімната %1$s</string>
     <string name="together_public">Показувати кімнату у списку</string>
+    <string name="together_public_needs_password">Публічна кімната має бути із паролем</string>
     <string name="together_room_default_name">Кімната %1$s</string>
     <string name="together_badge">Кімната %1$s · %2$d</string>
     <string name="together_offline">Кімната %1$s · перепідключення…</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -117,6 +117,7 @@
     <string name="together_badge_named">%1$s [%2$s] · %3$d</string>
     <string name="together_create_title">New room %1$s</string>
     <string name="together_public">List the room publicly</string>
+    <string name="together_public_needs_password">A public room needs a password</string>
     <string name="together_room_default_name">Room %1$s</string>
     <string name="together_badge">Room %1$s · %2$d</string>
     <string name="together_offline">Room %1$s · reconnecting…</string>


### PR DESCRIPTION
A room advertised in the public lobby list with no password is open to whoever reads that list. The create dialog no longer allows that pair.

- **OK is disabled** while "List the room publicly" is ticked and the password field is empty; it comes back as soon as a password is typed or the tick is cleared. The state is kept in sync from both controls.
- A **muted caption** appears under the tick: "A public room needs a password" (en/uk/ru).

No field error and no red: the dialog's accent is already the brand coral, so a red-tinted field on top of it read as alarm rather than as the one thing left to fill in.

`createRoom()` -> `openRoom()` -> `TogetherManager.create()` is the only creation path, so there is no way around the check.