### PR TITLE
Drop the player task from recents once it is finished

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -57,8 +57,14 @@
             android:name="io.sentry.auto-init"
             android:value="false" />
 
+        <!-- autoRemoveFromRecents: a launcher (Lampa, MX-style api) starts every episode with its own data
+             URI, and leaving one finishes the activity to hand the position back. The emptied task would stay
+             in recents, and since the URI differs the system keeps it beside the next episode's task instead
+             of collapsing them — an episode-per-card pile, each card relaunching a stale link. Dropping the
+             task once its last activity is gone leaves exactly the one card of a player still running. -->
         <activity
             android:name=".PlayerActivity"
+            android:autoRemoveFromRecents="true"
             android:configChanges="keyboard|keyboardHidden|navigation|orientation|screenSize|screenLayout|smallestScreenSize|uiMode|touchscreen"
             android:exported="true"
             android:launchMode="singleTask"


### PR DESCRIPTION
A user reported that the player "opens every episode as a separate instance": the recents list held one card per episode watched, each showing a paused player.

They are not separate players. A launcher-driven session (Lampa and other MX-api callers) starts every episode with its own data URI, and leaving one finishes the activity so the position can be handed back. The emptied task stays in the recents list, and because the base intents differ by URI the system keeps it beside the next episode's task instead of collapsing the two. Tapping such a card relaunches the old episode from a link that has usually expired.

`android:autoRemoveFromRecents="true"` makes a task go away with its last activity, so only a player that is actually running keeps a card.

Checked on an emulator with the launcher flow (own data URI per episode, `return_result`, Back between episodes):

| step | before | after |
| --- | --- | --- |
| 15 s after leaving episode 1 | task still listed in recents | gone |
| 15 s after leaving episode 2 | task still listed in recents | gone |
| player cards left | 1 (Android 14 collapses the earlier ones; older releases do not, hence the pile in the report) | 0 |

Reuse of a running player is untouched: while one is alive, a second launch with a different URI still lands in the same task through `onNewIntent`.