### PR TITLE
Show frame rate and bitrate for MKV and AVI in the stats panel

### DIFF
--- a/app/src/main/java/com/brouken/player/AviMetadataReader.java
+++ b/app/src/main/java/com/brouken/player/AviMetadataReader.java
@@ -1,0 +1,84 @@
+package com.brouken.player;
+
+import java.io.DataInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Reads the frame rate out of an AVI's main header. The {@code hdrl} list is the first chunk of the
+ * RIFF-AVI form and {@code avih/dwMicroSecPerFrame} its first field, so this is a handful of bytes
+ * from the very front of the stream — the only thing worth recovering here, since AVI describes its
+ * video with a BITMAPINFOHEADER that carries neither a rate nor a bitrate.
+ *
+ * <p>Returns a single video {@link TrackMetadata} carrying the rate, or nothing when the layout is
+ * not what it expects. Track names are not an AVI thing; {@code strn} is vanishingly rare.
+ */
+final class AviMetadataReader {
+
+    private AviMetadataReader() {}
+
+    /** Bytes of leading chunks (JUNK padding and the like) to look past before giving up on hdrl. */
+    private static final long MAX_BYTES_BEFORE_HDRL = 64 * 1024;
+
+    /** {@code inputStream} positioned at the start of the file; the RIFF/AVI signature is re-read here. */
+    static List<TrackMetadata> parse(InputStream inputStream) {
+        final DataInputStream stream = new DataInputStream(inputStream);
+        try {
+            if (!"RIFF".equals(readFourCc(stream))) return Collections.emptyList();
+            stream.skipBytes(4); // RIFF size
+            if (!"AVI ".equals(readFourCc(stream))) return Collections.emptyList();
+
+            long scanned = 0;
+            while (scanned < MAX_BYTES_BEFORE_HDRL) {
+                final String chunk = readFourCc(stream);
+                // Chunks are padded to an even length.
+                final long size = (readUInt32(stream) + 1) & ~1L;
+                if ("LIST".equals(chunk) && "hdrl".equals(readFourCc(stream))) {
+                    return parseHdrl(stream);
+                }
+                skipFully(stream, "LIST".equals(chunk) ? size - 4 : size);
+                scanned += size;
+            }
+        } catch (IOException e) {
+            // Stream ended or the tap was cut off before the header was read.
+        }
+        return Collections.emptyList();
+    }
+
+    private static List<TrackMetadata> parseHdrl(DataInputStream stream) throws IOException {
+        if (!"avih".equals(readFourCc(stream))) return Collections.emptyList();
+        readUInt32(stream); // avih size
+        final long microSecPerFrame = readUInt32(stream);
+        if (microSecPerFrame <= 0) return Collections.emptyList();
+        return Collections.singletonList(new TrackMetadata(0, null, "und", TrackMetadata.Type.VIDEO,
+                1_000_000f / microSecPerFrame));
+    }
+
+    private static String readFourCc(DataInputStream stream) throws IOException {
+        final byte[] bytes = new byte[4];
+        stream.readFully(bytes);
+        return new String(bytes, StandardCharsets.US_ASCII);
+    }
+
+    /** Little-endian, as everything in RIFF is. */
+    private static long readUInt32(DataInputStream stream) throws IOException {
+        return Integer.reverseBytes(stream.readInt()) & 0xFFFFFFFFL;
+    }
+
+    private static void skipFully(DataInputStream stream, long n) throws IOException {
+        long remaining = n;
+        while (remaining > 0) {
+            final long skipped = stream.skip(remaining);
+            if (skipped > 0) {
+                remaining -= skipped;
+            } else {
+                // skip() made no progress — a blocking read forces the pipe forward.
+                if (stream.read() < 0) throw new IOException("Truncated AVI header");
+                remaining--;
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/brouken/player/ContainerMetadataReader.java
+++ b/app/src/main/java/com/brouken/player/ContainerMetadataReader.java
@@ -1,5 +1,6 @@
 package com.brouken.player;
 
+import java.io.DataInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.PushbackInputStream;
@@ -8,32 +9,24 @@ import java.util.Collections;
 import java.util.List;
 
 /**
- * Dispatches a container byte stream to the matching parser by signature and returns the list of
- * track names/languages found. Reads sequentially and never seeks — it is fed by the bytes the
- * player itself reads (see {@link TrackNameParsingDataSource}), so it only sees track metadata that
- * lives near the start of the stream (faststart MP4 with {@code moov} up front, Matroska headers).
+ * Dispatches a container byte stream to the matching parser by signature and returns the track
+ * metadata found — names, languages, and the frame rate where the container states one. Reads
+ * sequentially and never seeks — it is fed by the bytes the player itself reads (see
+ * {@link TrackNameParsingDataSource}), so it only sees metadata that lives near the start of the
+ * stream (faststart MP4 with {@code moov} up front, Matroska and AVI headers).
  */
 final class ContainerMetadataReader {
 
     private ContainerMetadataReader() {}
 
     static List<TrackMetadata> parse(InputStream inputStream) {
-        // 8 bytes is enough for both the MKV EBML id and the MP4 ftyp signature.
-        final byte[] header = new byte[8];
-        final int bytesRead;
+        // 12 bytes covers the longest signature: RIFF, the form size, then 'AVI '. Anything shorter
+        // than that is not media, so a stream that cannot supply them is nothing to parse.
+        final byte[] header = new byte[12];
+        final PushbackInputStream pushbackStream = new PushbackInputStream(inputStream, header.length);
         try {
-            bytesRead = inputStream.read(header);
-        } catch (IOException e) {
-            return Collections.emptyList();
-        }
-
-        if (bytesRead < 4) {
-            return Collections.emptyList();
-        }
-
-        final PushbackInputStream pushbackStream = new PushbackInputStream(inputStream, 8);
-        try {
-            pushbackStream.unread(header, 0, bytesRead);
+            new DataInputStream(inputStream).readFully(header);
+            pushbackStream.unread(header);
         } catch (IOException e) {
             return Collections.emptyList();
         }
@@ -45,8 +38,13 @@ final class ContainerMetadataReader {
                 return MatroskaMetadataReader.parse(pushbackStream);
             }
             // MP4: 4-byte box size, then 'ftyp'
-            if (bytesRead >= 8 && "ftyp".equals(new String(header, 4, 4, StandardCharsets.US_ASCII))) {
+            if ("ftyp".equals(new String(header, 4, 4, StandardCharsets.US_ASCII))) {
                 return Mp4MetadataReader.parse(pushbackStream);
+            }
+            // AVI: RIFF form 'AVI '
+            if ("RIFF".equals(new String(header, 0, 4, StandardCharsets.US_ASCII))
+                    && "AVI ".equals(new String(header, 8, 4, StandardCharsets.US_ASCII))) {
+                return AviMetadataReader.parse(pushbackStream);
             }
             return Collections.emptyList();
         } catch (Exception e) {

--- a/app/src/main/java/com/brouken/player/MatroskaMetadataReader.java
+++ b/app/src/main/java/com/brouken/player/MatroskaMetadataReader.java
@@ -151,8 +151,28 @@ final class MatroskaMetadataReader {
             return value;
         }
 
+        /**
+         * An element ID as it is written on disk, marker bits included — that is how the spec quotes
+         * them (and how the constants above read). Sizes drop the marker; IDs must not, or nothing
+         * ever matches.
+         */
         long readId() throws IOException {
-            return readVInt();
+            final int first = readByte();
+            if (first == -1) throw new EOFException();
+            int mask = 0x80;
+            int length = 1;
+            while ((first & mask) == 0) {
+                mask >>= 1;
+                length++;
+                if (length > 4) throw new IOException("Invalid EBML id");
+            }
+            long value = first & 0xFFL;
+            for (int i = 1; i < length; i++) {
+                final int b = readByte();
+                if (b == -1) throw new EOFException();
+                value = (value << 8) | (b & 0xFFL);
+            }
+            return value;
         }
 
         long readSize() throws IOException {

--- a/app/src/main/java/com/brouken/player/MatroskaMetadataReader.java
+++ b/app/src/main/java/com/brouken/player/MatroskaMetadataReader.java
@@ -9,8 +9,8 @@ import java.util.List;
 
 /**
  * Minimal EBML/Matroska parser that walks {@code Segment → Tracks → TrackEntry} to recover each
- * track's number, {@code Name}, {@code Language} and type. Reads a forward-only stream fed by the
- * player's own reads.
+ * track's number, {@code Name}, {@code Language}, type and frame rate ({@code DefaultDuration}).
+ * Reads a forward-only stream fed by the player's own reads.
  */
 final class MatroskaMetadataReader {
 
@@ -85,6 +85,7 @@ final class MatroskaMetadataReader {
         String name = null;
         String lang = "und";
         TrackMetadata.Type type = TrackMetadata.Type.UNKNOWN;
+        float frameRate = 0f;
 
         final long startPos = reader.totalBytesRead;
 
@@ -100,6 +101,11 @@ final class MatroskaMetadataReader {
                     name = reader.readString(s);
                 } else if (id == 0x22B59CL) { // Language
                     lang = reader.readString(s);
+                } else if (id == 0x23E383L) { // DefaultDuration, nanoseconds per frame
+                    final long durationNs = reader.readUInt(s);
+                    if (durationNs > 0) {
+                        frameRate = 1_000_000_000f / durationNs;
+                    }
                 } else if (id == 0x83L) { // TrackType
                     final int mkvType = (int) reader.readUInt(s);
                     switch (mkvType) {
@@ -115,7 +121,7 @@ final class MatroskaMetadataReader {
                 break;
             }
         }
-        return new TrackMetadata(number, name, lang, type);
+        return new TrackMetadata(number, name, lang, type, frameRate);
     }
 
     private static final class EbmlReader {

--- a/app/src/main/java/com/brouken/player/Mp4MetadataReader.java
+++ b/app/src/main/java/com/brouken/player/Mp4MetadataReader.java
@@ -114,7 +114,8 @@ final class Mp4MetadataReader {
             }
             remaining -= actualBoxSize;
         }
-        return trackId != -1 ? new TrackMetadata(trackId, trackName, language, type) : null;
+        // No frame rate: Media3 already fills it in from MP4 (stts), so there is nothing to recover.
+        return trackId != -1 ? new TrackMetadata(trackId, trackName, language, type, 0f) : null;
     }
 
     private static TrackMetadata.Type handlerToType(String hdlrType) {

--- a/app/src/main/java/com/brouken/player/PlayerActivity.java
+++ b/app/src/main/java/com/brouken/player/PlayerActivity.java
@@ -204,6 +204,9 @@ public class PlayerActivity extends Activity {
     // whose request URL had no telling extension. Keyed by the requested URI (== MediaItem URI).
     // Written from a load thread, read on the player thread — hence concurrent.
     private final java.util.Map<String, String> resolvedMediaTypes = new java.util.concurrent.ConcurrentHashMap<>();
+    // Byte length of each media item as its data source reported it, keyed the same way. Feeds the
+    // stats panel's average bitrate for the containers that state no bitrate at all.
+    private final java.util.Map<String, Long> contentLengths = new java.util.concurrent.ConcurrentHashMap<>();
     private final TrackNameParsingDataSource.Listener trackNameListener = new TrackNameParsingDataSource.Listener() {
         @Override
         public void onMetadataParsed(java.util.List<TrackMetadata> tracks) {
@@ -214,6 +217,13 @@ public class PlayerActivity extends Activity {
         @Override
         public boolean isMetadataParsed() {
             return !containerTracks.isEmpty();
+        }
+
+        @Override
+        public void onContentLength(Uri originalUri, long length) {
+            if (originalUri != null) {
+                contentLengths.put(originalUri.toString(), length);
+            }
         }
 
         @Override
@@ -4354,14 +4364,26 @@ public class PlayerActivity extends Activity {
         final Format video = player.getVideoFormat();
         if (video != null) {
             text.append('\n').append(video.width).append('×').append(video.height);
-            if (video.frameRate != Format.NO_VALUE) {
-                text.append(String.format(Locale.US, " · %.2f fps", video.frameRate));
+            // Media3 fills the rate in from MP4 only; for MKV and AVI it reads the container's own figure
+            // for its timing but never publishes it, so the parser we already run picks it up instead.
+            final float frameRate = video.frameRate != Format.NO_VALUE
+                    ? video.frameRate : containerFrameRate();
+            if (frameRate > 0) {
+                text.append(String.format(Locale.US, " · %.2f fps", frameRate));
             }
             // Its own line rather than a third field: the panel has to stay narrower than the gap to the
             // centred transport buttons, and every line here is kept short enough to never wrap.
             if (video.bitrate != Format.NO_VALUE) {
                 text.append('\n').append(getString(R.string.stats_stream,
                         getString(R.string.quality_bitrate, video.bitrate / 1_000_000f)));
+            } else {
+                // Matroska and AVI carry no bitrate to read, so the whole file over its duration is all
+                // there is. Labelled apart from Stream: it counts audio and subtitles in too.
+                final float overall = overallBitrate();
+                if (overall > 0) {
+                    text.append('\n').append(getString(R.string.stats_overall,
+                            getString(R.string.quality_bitrate, overall)));
+                }
             }
         }
         // The mime says "hevc"; only the decoder name says whether that went to the vendor's hardware
@@ -4379,6 +4401,27 @@ public class PlayerActivity extends Activity {
         }
         statsView.setText(text);
         statsView.setVisibility(View.VISIBLE);
+    }
+
+    /** The video track's frame rate as its container states it, or 0 when it does not. */
+    private float containerFrameRate() {
+        for (TrackMetadata track : containerTracks) {
+            if (track.type == TrackMetadata.Type.VIDEO && track.frameRate > 0) {
+                return track.frameRate;
+            }
+        }
+        return 0f;
+    }
+
+    /** The whole file's average bitrate in Mbit/s, or 0 while either its length or duration is unknown. */
+    private float overallBitrate() {
+        final long durationMs = player.getDuration();
+        if (durationMs <= 0 || mPrefs.mediaUri == null) {
+            return 0f;
+        }
+        final Long length = contentLengths.get(mPrefs.mediaUri.toString());
+        // bytes * 8 bits / (ms / 1000) / 1e6 Mbit == bytes / (ms * 125)
+        return length == null ? 0f : length / (durationMs * 125f);
     }
 
     /**

--- a/app/src/main/java/com/brouken/player/TrackMetadata.java
+++ b/app/src/main/java/com/brouken/player/TrackMetadata.java
@@ -12,11 +12,18 @@ class TrackMetadata {
     final String name;
     final String language;
     final Type type;
+    /**
+     * Frames per second as the container header states it (Matroska {@code DefaultDuration}, AVI
+     * {@code avih/dwMicroSecPerFrame}), or 0 when the container does not say. Media3 uses both values
+     * for its own timing but never puts them in {@link androidx.media3.common.Format}.
+     */
+    final float frameRate;
 
-    TrackMetadata(int trackId, String name, String language, Type type) {
+    TrackMetadata(int trackId, String name, String language, Type type, float frameRate) {
         this.trackId = trackId;
         this.name = name;
         this.language = language;
         this.type = type;
+        this.frameRate = frameRate;
     }
 }

--- a/app/src/main/java/com/brouken/player/TrackNameParsingDataSource.java
+++ b/app/src/main/java/com/brouken/player/TrackNameParsingDataSource.java
@@ -2,6 +2,7 @@ package com.brouken.player;
 
 import android.net.Uri;
 
+import androidx.media3.common.C;
 import androidx.media3.common.MimeTypes;
 import androidx.media3.common.ParserException;
 import androidx.media3.datasource.DataSink;
@@ -43,6 +44,13 @@ final class TrackNameParsingDataSource implements DataSource {
     interface Listener {
         void onMetadataParsed(List<TrackMetadata> tracks);
         boolean isMetadataParsed();
+
+        /**
+         * Called (on a load thread) with the length the upstream reported for a whole media item, keyed
+         * by the URI that was requested (matches the MediaItem URI). Matroska and AVI state no bitrate
+         * anywhere, so length over duration is the only figure available for them.
+         */
+        void onContentLength(Uri originalUri, long length);
 
         /**
          * Called (on a load thread) when the real HTTP response for a media item reveals a streaming
@@ -95,6 +103,11 @@ final class TrackNameParsingDataSource implements DataSource {
         // extensionless resolver that returns HLS), report it so the player can re-prepare as HLS.
         if (dataSpec.position == 0 && dataSpec.uri != null) {
             reportResolvedMediaType(dataSpec.uri);
+            // An unbounded read from the start answers with the whole thing: the stats panel turns that
+            // into an average bitrate for the containers that state none (see Listener#onContentLength).
+            if (dataSpec.length == C.LENGTH_UNSET && length > 0) {
+                listener.onContentLength(dataSpec.uri, length);
+            }
             // A media request answered with a JSON body is a stream-resolver control response (the
             // Lampac "not ready" handshake), never playable media. The resolver sends these headers
             // immediately but then long-polls the body until a read timeout — so fail now, from the

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -175,6 +175,7 @@
     <string name="stats_dropped">Пропущенные кадры: %1$d</string>
     <string name="stats_network">Сеть: %1$s</string>
     <string name="stats_stream">Поток: %1$s</string>
+    <string name="stats_overall">Всего: %1$s</string>
     <string name="pref_show_stats_on">Буфер, декодеры и пропущенные кадры показываются с элементами управления</string>
     <string name="pref_show_stats_off">Подробности воспроизведения скрыты</string>
     <string name="volume_high_warning">Высокая громкость может повредить слух</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -182,6 +182,7 @@
     <string name="stats_dropped">Пропущені кадри: %1$d</string>
     <string name="stats_network">Мережа: %1$s</string>
     <string name="stats_stream">Потік: %1$s</string>
+    <string name="stats_overall">Загалом: %1$s</string>
     <string name="pref_show_stats_on">Буфер, декодери та пропущені кадри показуються з елементами керування</string>
     <string name="pref_show_stats_off">Подробиці відтворення приховані</string>
     <string name="volume_high_warning">Висока гучність може зашкодити слуху</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -198,6 +198,7 @@
     <string name="stats_dropped">Dropped frames: %1$d</string>
     <string name="stats_network">Network: %1$s</string>
     <string name="stats_stream">Stream: %1$s</string>
+    <string name="stats_overall">Overall: %1$s</string>
     <string name="pref_show_stats_on">Buffer, decoders and dropped frames are shown with the player controls</string>
     <string name="pref_show_stats_off">Playback details stay hidden</string>
     <string name="volume_high_warning">High volume may damage your hearing</string>


### PR DESCRIPTION
Closes #104.

The stats panel printed the resolution and stopped on MKV and AVI: Media3 only puts a frame rate in `Format` for MP4, and neither of these containers states a bitrate anywhere at all.

**Element ids in the EBML reader.** `MatroskaMetadataReader` stripped the length marker off every id it read, while the constants it compares against are quoted as the spec writes them, with the marker. Nothing ever matched — the parser bailed on the EBML header check, so every MKV came back with no track metadata whatsoever and the track list silently fell back to the language name. Ids are now read as the bytes on disk.

**Frame rate from the header.** Both containers state it, and Media3 reads it for its own timing without publishing it — Matroska in `TrackEntry/DefaultDuration`, AVI in `avih/dwMicroSecPerFrame`. The container parser already walks past both, so it carries the rate along with the names and `updateStats()` uses it when `Format` has none. AVI gets a small reader of its own (`hdrl → avih`) and a signature branch; the dispatcher's header grew from 8 to 12 bytes and is now read with `readFully` rather than a single `read()`.

**Bitrate.** There is nothing to read, so the figure is the length the data source already learns when it opens the item, over the duration. That is the whole file's average, audio and subtitles included, so it goes on its own `Overall:` line instead of pretending to be the video track's `Stream:` figure.

Verified against ffprobe on real files:

| File | Parser | ffprobe |
|---|---|---|
| AVI rip (mpeg4) | 25.000 fps | `25/1` |
| MKV remux, 4 tracks | 60.000 fps, `rus`/`jpn` | `60/1` |
| MKV screen recording (VFR) | no rate | `avg 91/6`, video track has no `DefaultDuration` |
| Same AVI, bitrate | 1.785 Mbit/s | `bit_rate` 1.785 |

An audio track's own `DefaultDuration` (23.22 ms per AAC frame, which would read as "43 fps") is not mistaken for a video rate. The MP4 path is unchanged: a faststart file still parses, a non-faststart one still bails.
