### PR TITLE
Show the playback dump on the error screen instead of copying it

### DIFF
--- a/app/src/main/java/com/brouken/player/ErrorActivity.java
+++ b/app/src/main/java/com/brouken/player/ErrorActivity.java
@@ -46,6 +46,8 @@ import java.util.TimeZone;
  */
 public class ErrorActivity extends AppCompatActivity {
 
+    /** Optional headline override; defaults to the playback-error title in the layout. */
+    public static final String EXTRA_TITLE = "title";
     /** Optional headline body override; defaults to the playback-error copy in the layout. */
     public static final String EXTRA_MESSAGE = "message";
     /** Short, human-facing text shown in the panel: error code + message. */
@@ -74,6 +76,13 @@ public class ErrorActivity extends AppCompatActivity {
         report = buildReport(Utils.stripUrlQuery(getIntent().getStringExtra(EXTRA_REPORT)));
 
         ((TextView) findViewById(R.id.errorDetails)).setText(summary != null ? summary : "");
+        final String title = getIntent().getStringExtra(EXTRA_TITLE);
+        if (title != null) {
+            ((TextView) findViewById(R.id.errorTitle)).setText(title);
+            // A title override means the screen was opened on purpose, so the error glyph would announce a
+            // failure that did not happen; the logo mark keeps the halo without the alarm.
+            ((ImageView) findViewById(R.id.errorIcon)).setImageResource(R.drawable.ic_logo_mark);
+        }
         final String message = getIntent().getStringExtra(EXTRA_MESSAGE);
         if (message != null) {
             ((TextView) findViewById(R.id.errorMessage)).setText(message);
@@ -86,6 +95,11 @@ public class ErrorActivity extends AppCompatActivity {
         qrImage = findViewById(R.id.qrImage);
 
         findViewById(R.id.btnCopy).setOnClickListener(v -> copy(report));
+        // Nothing on a TV box can empty the clipboard — no keyboard, no text app — so Copy is a dead end
+        // there and only takes a D-pad stop away from Upload, which is how a report actually leaves the box.
+        if (Utils.isTvBox(this)) {
+            findViewById(R.id.btnCopy).setVisibility(View.GONE);
+        }
         findViewById(R.id.btnShare).setOnClickListener(v -> share(report));
         btnUpload.setOnClickListener(v -> upload());
         uploadUrl.setOnClickListener(v -> copy(uploadUrl.getText().toString()));
@@ -126,6 +140,19 @@ public class ErrorActivity extends AppCompatActivity {
                 System.exit(10);
             }
         });
+    }
+
+    /**
+     * The same screen, opened on purpose rather than by a failure — so the playback dump gets the device
+     * header, the QR and the three actions instead of a clipboard a TV box has no way to empty.
+     */
+    public static void showReport(final Context context, final String title, final String message,
+                                  final String summary, final String report) {
+        context.startActivity(new Intent(context, ErrorActivity.class)
+                .putExtra(EXTRA_TITLE, title)
+                .putExtra(EXTRA_MESSAGE, message)
+                .putExtra(EXTRA_SUMMARY, summary)
+                .putExtra(EXTRA_REPORT, report));
     }
 
     // The exception type as the "code" line, plus the deepest cause message — mirrors the playback path.

--- a/app/src/main/java/com/brouken/player/PlayerActivity.java
+++ b/app/src/main/java/com/brouken/player/PlayerActivity.java
@@ -4478,20 +4478,20 @@ public class PlayerActivity extends Activity {
     }
 
     /**
-     * The same dump the error screen carries, to the clipboard — so a report about stuttering or a wrong
-     * decoder reads like one about a crash, and appendPlayerState stays the single source for both.
+     * The same dump the error screen carries, on the error screen itself — so a report about stuttering
+     * or a wrong decoder reads like one about a crash, appendPlayerState stays the single source for
+     * both, and the dump leaves a TV box by QR instead of a clipboard nothing there can paste from.
      */
-    private void copyPlayerState() {
+    private void showPlayerState() {
         final StringBuilder state = new StringBuilder();
         appendPlayerState(state);
         if (state.length() == 0) {
             return;
         }
-        final ClipboardManager clipboard = (ClipboardManager) getSystemService(CLIPBOARD_SERVICE);
-        if (clipboard != null) {
-            clipboard.setPrimaryClip(ClipData.newPlainText("Just+ Player playback", state.toString().trim()));
-            Toast.makeText(this, R.string.error_copied, Toast.LENGTH_SHORT).show();
-        }
+        final Format video = player == null ? null : player.getVideoFormat();
+        ErrorActivity.showReport(this, getString(R.string.stats_report_title),
+                getString(R.string.stats_report_message),
+                video == null ? null : Format.toLogString(video), state.toString().trim());
     }
 
     // Small episode-number chip, inset from the poster's top-start corner so its rounded corners don't
@@ -5672,12 +5672,12 @@ public class PlayerActivity extends Activity {
                     formatSpeed(userSpeed()), false, this::showSpeedDialog));
             items.add(new MenuItem(R.drawable.ic_sleep_24dp, getString(R.string.sleep_timer_title),
                     sleepTimerSummary(), false, this::showSleepTimerMenu));
-            // Rides the stats panel: the details it copies are the ones on screen, and the row would be
+            // Rides the stats panel: the details it reports are the ones on screen, and the row would be
             // noise for everyone who has not asked for them. From the menu rather than a long-press on the
             // panel, so it is reachable with a D-pad and the panel stays free of touch handling.
             if (mPrefs.showStats) {
-                items.add(new MenuItem(R.drawable.ic_content_copy_24dp, getString(R.string.error_copy),
-                        null, false, this::copyPlayerState));
+                items.add(new MenuItem(R.drawable.ic_content_copy_24dp,
+                        getString(R.string.stats_report_title), null, false, this::showPlayerState));
             }
         }
         if (buttonSkipOffset != null && buttonSkipOffset.getVisibility() == View.VISIBLE) {

--- a/app/src/main/res/layout-land/activity_error.xml
+++ b/app/src/main/res/layout-land/activity_error.xml
@@ -33,6 +33,7 @@
                 android:background="@drawable/bg_error_halo">
 
                 <ImageView
+                    android:id="@+id/errorIcon"
                     android:layout_width="38dp"
                     android:layout_height="38dp"
                     android:layout_gravity="center"
@@ -41,6 +42,7 @@
             </FrameLayout>
 
             <TextView
+                android:id="@+id/errorTitle"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="16dp"

--- a/app/src/main/res/layout/activity_error.xml
+++ b/app/src/main/res/layout/activity_error.xml
@@ -17,6 +17,7 @@
         android:background="@drawable/bg_error_halo">
 
         <ImageView
+            android:id="@+id/errorIcon"
             android:layout_width="38dp"
             android:layout_height="38dp"
             android:layout_gravity="center"
@@ -25,6 +26,7 @@
     </FrameLayout>
 
     <TextView
+        android:id="@+id/errorTitle"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginTop="18dp"

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -176,6 +176,8 @@
     <string name="stats_network">Сеть: %1$s</string>
     <string name="stats_stream">Поток: %1$s</string>
     <string name="stats_overall">Всего: %1$s</string>
+    <string name="stats_report_title">Отчёт о воспроизведении</string>
+    <string name="stats_report_message">Отправьте эти подробности воспроизведения, сообщая о проблеме с изображением или звуком.</string>
     <string name="pref_show_stats_on">Буфер, декодеры и пропущенные кадры показываются с элементами управления</string>
     <string name="pref_show_stats_off">Подробности воспроизведения скрыты</string>
     <string name="volume_high_warning">Высокая громкость может повредить слух</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -183,6 +183,8 @@
     <string name="stats_network">Мережа: %1$s</string>
     <string name="stats_stream">Потік: %1$s</string>
     <string name="stats_overall">Загалом: %1$s</string>
+    <string name="stats_report_title">Звіт про відтворення</string>
+    <string name="stats_report_message">Надішліть ці подробиці відтворення, повідомляючи про проблему із зображенням чи звуком.</string>
     <string name="pref_show_stats_on">Буфер, декодери та пропущені кадри показуються з елементами керування</string>
     <string name="pref_show_stats_off">Подробиці відтворення приховані</string>
     <string name="volume_high_warning">Висока гучність може зашкодити слуху</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -199,6 +199,8 @@
     <string name="stats_network">Network: %1$s</string>
     <string name="stats_stream">Stream: %1$s</string>
     <string name="stats_overall">Overall: %1$s</string>
+    <string name="stats_report_title">Playback report</string>
+    <string name="stats_report_message">Send these playback details when reporting a problem with picture or sound.</string>
     <string name="pref_show_stats_on">Buffer, decoders and dropped frames are shown with the player controls</string>
     <string name="pref_show_stats_off">Playback details stay hidden</string>
     <string name="volume_high_warning">High volume may damage your hearing</string>


### PR DESCRIPTION
Closes #102

**More → Copy** put the stats dump on the clipboard and nothing else. On an Android TV box that is a dead end — no keyboard, no text app, nothing to paste into — and the copied text carried none of the device header `ErrorActivity.buildReport()` prepends, so the model, Android version and refresh rate the bug template asks for were missing from exactly the report where frame rate matching is the question.

`ErrorActivity` already solves all of that: the header, Copy / Share / **Upload**, and the QR that gets a report off a box you drive with a remote. It was just unreachable on purpose — `exported="false"`, started only by a crash or a playback error.

## What changed

- `ErrorActivity` takes an `EXTRA_TITLE` override and exposes `showReport()`, so the screen can be opened deliberately.
- `PlayerActivity.copyPlayerState()` → `showPlayerState()`: same `appendPlayerState` source, now shown on that screen. Panel text is the video `Format.toLogString`.
- Headline `TextView` gets `@+id/errorTitle` in both `layout/` and `layout-land/activity_error.xml`.
- With a title override the icon becomes the logo mark instead of the error glyph — the screen is no longer announcing a failure that did not happen.
- **Copy is hidden on TV** (`Utils.isTvBox`), where it never had anywhere to paste to. Applies to the crash screen too, for the same reason.
- New strings in en/uk/ru.

## Trade-off

Opening a full-screen activity backgrounds the player, so playback stops while the report is up. The dump is captured before that, so its content is correct. The alternative — lifting share/upload/QR into an overlay — duplicates a layout that is already shared.

## Verified

Android TV emulator (`tv_720p`, API 36, leanback) and a phone emulator, both variants of the layout:

- TV: Share / Upload / Close, D-pad focus lands on Close, Copy absent.
- Upload produced a QR and a termbin URL whose content starts with the full header — `Display: 1280x720 @213dpi 60.00Hz, tv, landscape` — followed by the same dump the panel used to copy.
- Phone: Copy present, portrait layout intact.
