### PR TITLE
Let the D-pad cross unfocusable rows in settings

### DIFF
--- a/app/src/main/java/com/brouken/player/SettingsActivity.java
+++ b/app/src/main/java/com/brouken/player/SettingsActivity.java
@@ -20,6 +20,7 @@ import androidx.preference.Preference;
 import androidx.preference.PreferenceCategory;
 import androidx.preference.PreferenceFragmentCompat;
 import androidx.preference.SwitchPreferenceCompat;
+import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 
 import com.brouken.player.together.AliasGenerator;
@@ -271,6 +272,21 @@ public class SettingsActivity extends AppCompatActivity {
                     });
                 }
             }
+        }
+
+        // A D-pad can only reach a row that is laid out, and when focus search fails
+        // LinearLayoutManager extends the layout by a third of a screen and looks again — which is
+        // not past a run of unfocusable rows: the group a switched-off "dependency" disables, or the
+        // warning text in "Dangerous". Lay out two screens extra so the next focusable row is there.
+        @Override
+        public RecyclerView.LayoutManager onCreateLayoutManager() {
+            return new LinearLayoutManager(getContext()) {
+                @Override
+                protected void calculateExtraLayoutSpace(@NonNull RecyclerView.State state,
+                                                         @NonNull int[] extraLayoutSpace) {
+                    extraLayoutSpace[0] = extraLayoutSpace[1] = getHeight() * 2;
+                }
+            };
         }
 
         @Override


### PR DESCRIPTION
On an Android TV box (reported on a Google TV Streamer 4K) the D-pad stopped moving down in the app settings at a certain row: a single press did nothing at all — the highlight stayed put — and only holding the button crawled past.

With **Skip segments** switched off, the five preferences that declare `app:dependency="skipEnabled"` are disabled, and a disabled view cannot take focus. Focus therefore sat on the switch with a ~400dp wall of unfocusable rows below it. When focus search finds no focusable child among the rows currently laid out, `LinearLayoutManager.onFocusSearchFailed()` extends the layout by only a third of a screen (~180dp on a TV) before looking again — not across the wall — so the key press did nothing. The rows that failed attempt laid out stay attached, which is why each further press reached a little further.

`onCreateLayoutManager()` now returns a `LinearLayoutManager` that lays out two screens extra in both directions, so the next focusable row is always there to be found. Nothing in `root_preferences.xml` changes: greying out dependent preferences is correct, only the focus traversal was broken.

The same wall, lower, stood in front of the warning text in "Dangerous", "Current version" under "Updates", and any preference an SDK check disables (`autoPiP` on a box without PiP).

### Verification

TV emulator (`tv_test`), "Skip segments" off, single `DPAD_DOWN` presses, focus read from `uiautomator dump`:

| | before | after |
|---|---|---|
| three single presses of down | focus stays on "Enabled" all three times | one press → "Embedded styles" |
| one press of up from there | — | back to "Enabled" |

The whole list also walks top to bottom one row per press, stepping over the disabled "Auto PiP" row, the "Dangerous" warning and "Current version".