### PR TITLE
Recover the container frame rate reliably, and match the display to it without a second extractor

### DIFF
--- a/app/src/main/java/com/brouken/player/AviMetadataReader.java
+++ b/app/src/main/java/com/brouken/player/AviMetadataReader.java
@@ -43,7 +43,7 @@ final class AviMetadataReader {
                 scanned += size;
             }
         } catch (IOException e) {
-            // Stream ended or the tap was cut off before the header was read.
+            // The header ended before it was fully read.
         }
         return Collections.emptyList();
     }
@@ -75,7 +75,7 @@ final class AviMetadataReader {
             if (skipped > 0) {
                 remaining -= skipped;
             } else {
-                // skip() made no progress — a blocking read forces the pipe forward.
+                // skip() made no progress — read a byte to move on.
                 if (stream.read() < 0) throw new IOException("Truncated AVI header");
                 remaining--;
             }

--- a/app/src/main/java/com/brouken/player/ContainerMetadataReader.java
+++ b/app/src/main/java/com/brouken/player/ContainerMetadataReader.java
@@ -11,18 +11,77 @@ import java.util.List;
 /**
  * Dispatches a container byte stream to the matching parser by signature and returns the track
  * metadata found — names, languages, and the frame rate where the container states one. Reads
- * sequentially and never seeks — it is fed by the bytes the player itself reads (see
- * {@link TrackNameParsingDataSource}), so it only sees metadata that lives near the start of the
- * stream (faststart MP4 with {@code moov} up front, Matroska and AVI headers).
+ * sequentially and never seeks — it is given the front of the stream the player itself read (see
+ * {@link TrackNameParsingDataSource}), so it only sees metadata that lives near the start
+ * (faststart MP4 with {@code moov} up front, Matroska and AVI headers).
  */
 final class ContainerMetadataReader {
 
+    /** 12 bytes covers the longest signature: RIFF, the form size, then 'AVI '. */
+    static final int SIGNATURE_BYTES = 12;
+
+    /**
+     * The containers this dispatches to, with how many leading bytes are worth collecting for each.
+     * Anything not listed here is not parsed at all, so the caller need not keep its bytes.
+     */
+    private enum Container {
+        // Sized from where real headers end, with room to spare. Measured against ffprobe on real rips:
+        // Matroska writes Tracks within the first few kilobytes — 6.5 KB was the worst of eleven files, and
+        // 471 bytes on one carrying a 400 KB attachment, since Attachments follow Tracks — and an AVI opens
+        // on hdrl at 36 bytes. Whatever is not here by then is not coming, and waiting only delays the
+        // answer: the buffer is what bounds the parse, so this is also the ceiling on what it holds.
+        MATROSKA(256 * 1024),
+        AVI(64 * 1024),
+        // A faststart moov is the sample table of the whole file, so it is the one header that gets big.
+        // ponytail: an MP4 whose moov exceeds this loses only its per-track udta/name, which is rare to
+        // begin with — its frame rate and bitrate come from Format either way. Raise it if one turns up.
+        MP4(512 * 1024);
+
+        final int headerBytes;
+
+        Container(int headerBytes) {
+            this.headerBytes = headerBytes;
+        }
+    }
+
     private ContainerMetadataReader() {}
 
+    /** The container the first {@link #SIGNATURE_BYTES} bytes announce, or null for one we do not parse. */
+    private static Container signature(byte[] header) {
+        if (header == null || header.length < SIGNATURE_BYTES) {
+            return null;
+        }
+        // MKV / WebM: EBML header 1A 45 DF A3
+        if ((header[0] & 0xFF) == 0x1A && (header[1] & 0xFF) == 0x45
+                && (header[2] & 0xFF) == 0xDF && (header[3] & 0xFF) == 0xA3) {
+            return Container.MATROSKA;
+        }
+        // MP4: 4-byte box size, then 'ftyp'
+        if ("ftyp".equals(new String(header, 4, 4, StandardCharsets.US_ASCII))) {
+            return Container.MP4;
+        }
+        // AVI: RIFF form 'AVI '
+        if ("RIFF".equals(new String(header, 0, 4, StandardCharsets.US_ASCII))
+                && "AVI ".equals(new String(header, 8, 4, StandardCharsets.US_ASCII))) {
+            return Container.AVI;
+        }
+        return null;
+    }
+
+    /**
+     * Bytes of the front of the stream worth collecting for the matching parser, or 0 for a container
+     * this does not parse — an HLS manifest, an MPEG-TS segment, anything whose header is not at offset
+     * 0. Lets a caller buffering the header stop as soon as it knows there is nothing here to read.
+     */
+    static int headerBudget(byte[] header) {
+        final Container container = signature(header);
+        return container == null ? 0 : container.headerBytes;
+    }
+
     static List<TrackMetadata> parse(InputStream inputStream) {
-        // 12 bytes covers the longest signature: RIFF, the form size, then 'AVI '. Anything shorter
-        // than that is not media, so a stream that cannot supply them is nothing to parse.
-        final byte[] header = new byte[12];
+        // Anything shorter than a signature is not media, so a stream that cannot supply one is
+        // nothing to parse.
+        final byte[] header = new byte[SIGNATURE_BYTES];
         final PushbackInputStream pushbackStream = new PushbackInputStream(inputStream, header.length);
         try {
             new DataInputStream(inputStream).readFully(header);
@@ -31,22 +90,19 @@ final class ContainerMetadataReader {
             return Collections.emptyList();
         }
 
-        try {
-            // MKV / WebM: EBML header 1A 45 DF A3
-            if ((header[0] & 0xFF) == 0x1A && (header[1] & 0xFF) == 0x45
-                    && (header[2] & 0xFF) == 0xDF && (header[3] & 0xFF) == 0xA3) {
-                return MatroskaMetadataReader.parse(pushbackStream);
-            }
-            // MP4: 4-byte box size, then 'ftyp'
-            if ("ftyp".equals(new String(header, 4, 4, StandardCharsets.US_ASCII))) {
-                return Mp4MetadataReader.parse(pushbackStream);
-            }
-            // AVI: RIFF form 'AVI '
-            if ("RIFF".equals(new String(header, 0, 4, StandardCharsets.US_ASCII))
-                    && "AVI ".equals(new String(header, 8, 4, StandardCharsets.US_ASCII))) {
-                return AviMetadataReader.parse(pushbackStream);
-            }
+        final Container container = signature(header);
+        if (container == null) {
             return Collections.emptyList();
+        }
+        try {
+            switch (container) {
+                case MATROSKA:
+                    return MatroskaMetadataReader.parse(pushbackStream);
+                case MP4:
+                    return Mp4MetadataReader.parse(pushbackStream);
+                default:
+                    return AviMetadataReader.parse(pushbackStream);
+            }
         } catch (Exception e) {
             return Collections.emptyList();
         }

--- a/app/src/main/java/com/brouken/player/MatroskaMetadataReader.java
+++ b/app/src/main/java/com/brouken/player/MatroskaMetadataReader.java
@@ -44,10 +44,10 @@ final class MatroskaMetadataReader {
     }
 
     private static void parseSegment(EbmlReader reader, List<TrackMetadata> tracks) {
-        long bytesRead = 0L;
-        final long limit = 512 * 1024; // cap the search for Tracks inside Segment
+        // No cap of its own: the caller hands over a bounded header, and readId consumes at least one byte
+        // per turn, so running out of it is what ends this loop.
         try {
-            while (bytesRead < limit) {
+            while (true) {
                 final long id = reader.readId();
                 final long s = reader.readSize();
                 if (id == 0x1654AE6BL) { // Tracks
@@ -56,7 +56,6 @@ final class MatroskaMetadataReader {
                 } else {
                     reader.skip(s);
                 }
-                bytesRead += s; // rough estimate
             }
         } catch (Exception ignored) {
         }
@@ -69,7 +68,17 @@ final class MatroskaMetadataReader {
                 final long id = reader.readId();
                 final long s = reader.readSize();
                 if (id == 0xAEL) { // TrackEntry
-                    out.add(parseTrackEntry(reader, s));
+                    final TrackMetadata entry = parseTrackEntry(reader, s);
+                    if (entry == null) {
+                        // Cut short inside an entry. Publishing the ones before it would answer the
+                        // caller for good — isMetadataParsed() goes by whether anything was returned —
+                        // so a video entry missing its DefaultDuration would read as "this file states
+                        // no frame rate" for the rest of the session. Say nothing and let a later read
+                        // try again.
+                        out.clear();
+                        return;
+                    }
+                    out.add(entry);
                 } else {
                     reader.skip(s);
                 }
@@ -80,6 +89,7 @@ final class MatroskaMetadataReader {
         }
     }
 
+    /** The entry, or null if the stream ended inside it. */
     private static TrackMetadata parseTrackEntry(EbmlReader reader, long size) {
         int number = 0;
         String name = null;
@@ -118,11 +128,14 @@ final class MatroskaMetadataReader {
                     reader.skip(s);
                 }
             } catch (Exception e) {
-                break;
+                return null;
             }
         }
         return new TrackMetadata(number, name, lang, type, frameRate);
     }
+
+    /** Ceiling for a string element, so a corrupt size cannot turn into a huge allocation. */
+    private static final int MAX_STRING_BYTES = 64 * 1024;
 
     private static final class EbmlReader {
         private final InputStream input;
@@ -202,7 +215,14 @@ final class MatroskaMetadataReader {
             totalBytesRead += skipped;
         }
 
+        /**
+         * Throws rather than return a value cut short — as does {@link #readUInt}. Truncating in silence
+         * published a first-byte-only DefaultDuration as half a billion frames per second.
+         */
         String readString(long size) throws IOException {
+            // A name or a language code is short; anything this long is a corrupt size vint, and
+            // allocating on its word would be an OutOfMemoryError on the player's load thread.
+            if (size < 0 || size > MAX_STRING_BYTES) throw new IOException("Bad string size " + size);
             final byte[] bytes = new byte[(int) size];
             int read = 0;
             while (read < size) {
@@ -211,6 +231,7 @@ final class MatroskaMetadataReader {
                 read += r;
             }
             totalBytesRead += read;
+            if (read < size) throw new EOFException();
             return trimTrailingNul(new String(bytes, 0, read, StandardCharsets.UTF_8));
         }
 
@@ -218,7 +239,8 @@ final class MatroskaMetadataReader {
             long value = 0L;
             for (int i = 0; i < size; i++) {
                 final int b = readByte();
-                if (b != -1) value = (value << 8) | (b & 0xFFL);
+                if (b == -1) throw new EOFException();
+                value = (value << 8) | (b & 0xFFL);
             }
             return value;
         }

--- a/app/src/main/java/com/brouken/player/Mp4MetadataReader.java
+++ b/app/src/main/java/com/brouken/player/Mp4MetadataReader.java
@@ -20,6 +20,9 @@ final class Mp4MetadataReader {
 
     private Mp4MetadataReader() {}
 
+    /** Ceiling for a track name, so a corrupt box size cannot turn into a huge allocation. */
+    private static final int MAX_NAME_BYTES = 64 * 1024;
+
     static List<TrackMetadata> parse(InputStream inputStream) {
         final List<TrackMetadata> tracks = new ArrayList<>();
         final DataInputStream stream = new DataInputStream(inputStream);
@@ -51,9 +54,9 @@ final class Mp4MetadataReader {
                 }
             }
         } catch (EOFException e) {
-            // Stream ended (or the tap was cut off) before moov was fully read — return what we have.
+            // The header ended before moov was fully read — return what we have.
         } catch (IOException e) {
-            // Pipe closed / broken — normal termination of the tap.
+            // Malformed box layout — return what we have.
         }
         return tracks;
     }
@@ -211,6 +214,9 @@ final class Mp4MetadataReader {
             if (actualBoxSize > remaining) break;
 
             if ("name".equals(type)) {
+                // A track name is short; a larger size is a corrupt box, and allocating on its word
+                // would be an OutOfMemoryError on the player's load thread.
+                if (bodySize < 0 || bodySize > MAX_NAME_BYTES) throw new IOException("Bad name size " + bodySize);
                 final byte[] buffer = new byte[(int) bodySize];
                 stream.readFully(buffer);
 
@@ -258,7 +264,7 @@ final class Mp4MetadataReader {
             if (skipped > 0) {
                 remaining -= skipped;
             } else {
-                // skip() made no progress — fall back to a blocking read to force the pipe forward.
+                // skip() made no progress — read a byte to move on.
                 if (stream.read() < 0) throw new EOFException();
                 remaining--;
             }

--- a/app/src/main/java/com/brouken/player/PlayerActivity.java
+++ b/app/src/main/java/com/brouken/player/PlayerActivity.java
@@ -200,6 +200,14 @@ public class PlayerActivity extends Activity {
     // Format.id -> name map that the track list and header read from once tracks are known.
     private final java.util.List<TrackMetadata> containerTracks = new java.util.ArrayList<>();
     private final java.util.Map<String, String> resolvedTrackNames = new java.util.HashMap<>();
+    /**
+     * The media item {@link #containerTracks} was parsed from, keyed like {@link #contentLengths}.
+     * ExoPlayer opens the next item of a playlist while the current one is still playing, so metadata
+     * that is merely "the last parsed" belongs to whichever item won the race — the panel would print
+     * the previous episode's frame rate and the tap would be told there was nothing left to parse.
+     * Read from a load thread, written on the UI thread.
+     */
+    private volatile String containerTracksUri;
     // Streaming manifest type (HLS/DASH/SS) discovered from the real HTTP response of a media item
     // whose request URL had no telling extension. Keyed by the requested URI (== MediaItem URI).
     // Written from a load thread, read on the player thread — hence concurrent.
@@ -209,14 +217,18 @@ public class PlayerActivity extends Activity {
     private final java.util.Map<String, Long> contentLengths = new java.util.concurrent.ConcurrentHashMap<>();
     private final TrackNameParsingDataSource.Listener trackNameListener = new TrackNameParsingDataSource.Listener() {
         @Override
-        public void onMetadataParsed(java.util.List<TrackMetadata> tracks) {
-            // Parser runs on a background thread; hop to the UI thread to touch player/views.
-            runOnUiThread(() -> onContainerMetadata(tracks));
+        public void onMetadataParsed(Uri originalUri, java.util.List<TrackMetadata> tracks) {
+            if (originalUri == null) {
+                return;
+            }
+            // Parses on a load thread; hop to the UI thread to touch player/views.
+            final String key = originalUri.toString();
+            runOnUiThread(() -> onContainerMetadata(key, tracks));
         }
 
         @Override
-        public boolean isMetadataParsed() {
-            return !containerTracks.isEmpty();
+        public boolean isMetadataParsed(Uri originalUri) {
+            return originalUri != null && originalUri.toString().equals(containerTracksUri);
         }
 
         @Override
@@ -4123,11 +4135,19 @@ public class PlayerActivity extends Activity {
     }
 
     /** Called on the UI thread once the container parser has recovered track names. */
-    private void onContainerMetadata(java.util.List<TrackMetadata> tracks) {
+    private void onContainerMetadata(String uri, java.util.List<TrackMetadata> tracks) {
         containerTracks.clear();
         containerTracks.addAll(tracks);
+        containerTracksUri = uri;
         resolveTrackNames();
         updateMediaInfo();
+    }
+
+    /** {@link #containerTracks}, but only when they belong to the item playing now. */
+    private java.util.List<TrackMetadata> currentContainerTracks() {
+        final Uri uri = currentMediaUri();
+        return uri != null && uri.toString().equals(containerTracksUri)
+                ? containerTracks : java.util.Collections.emptyList();
     }
 
     /**
@@ -4137,7 +4157,7 @@ public class PlayerActivity extends Activity {
      */
     private void resolveTrackNames() {
         resolvedTrackNames.clear();
-        if (player == null || containerTracks.isEmpty()) {
+        if (player == null || currentContainerTracks().isEmpty()) {
             return;
         }
         resolveNamesForType(C.TRACK_TYPE_AUDIO, TrackMetadata.Type.AUDIO);
@@ -4146,7 +4166,7 @@ public class PlayerActivity extends Activity {
 
     private void resolveNamesForType(int trackType, TrackMetadata.Type metaType) {
         final java.util.List<TrackMetadata> ordered = new java.util.ArrayList<>();
-        for (TrackMetadata t : containerTracks) {
+        for (TrackMetadata t : currentContainerTracks()) {
             if (t.type == metaType) {
                 ordered.add(t);
             }
@@ -4165,7 +4185,7 @@ public class PlayerActivity extends Activity {
                 if (format.id != null) {
                     final Integer id = tryParseInt(format.id);
                     if (id != null) {
-                        for (TrackMetadata t : containerTracks) {
+                        for (TrackMetadata t : currentContainerTracks()) {
                             if (t.trackId == id && t.name != null && !t.name.isEmpty()) {
                                 name = t.name;
                                 break;
@@ -4419,8 +4439,7 @@ public class PlayerActivity extends Activity {
             text.append('\n').append(video.width).append('×').append(video.height);
             // Media3 fills the rate in from MP4 only; for MKV and AVI it reads the container's own figure
             // for its timing but never publishes it, so the parser we already run picks it up instead.
-            final float frameRate = video.frameRate != Format.NO_VALUE
-                    ? video.frameRate : containerFrameRate();
+            final float frameRate = videoFrameRate();
             if (frameRate > 0) {
                 text.append(String.format(Locale.US, " · %.2f fps", frameRate));
             }
@@ -4456,9 +4475,20 @@ public class PlayerActivity extends Activity {
         fadeChrome(statsView, true);
     }
 
+    /**
+     * The playing video's frame rate: from {@link Format} where Media3 fills it in — MP4, DASH, and HLS
+     * that declares FRAME-RATE — and from the container header otherwise. 0 when neither states one,
+     * which is Matroska and AVI until the header parse lands, and MPEG-TS always.
+     */
+    private float videoFrameRate() {
+        final Format video = player != null ? player.getVideoFormat() : null;
+        return video != null && video.frameRate != Format.NO_VALUE
+                ? video.frameRate : containerFrameRate();
+    }
+
     /** The video track's frame rate as its container states it, or 0 when it does not. */
     private float containerFrameRate() {
-        for (TrackMetadata track : containerTracks) {
+        for (TrackMetadata track : currentContainerTracks()) {
             if (track.type == TrackMetadata.Type.VIDEO && track.frameRate > 0) {
                 return track.frameRate;
             }
@@ -6878,6 +6908,7 @@ public class PlayerActivity extends Activity {
 
         // Fresh media — drop any container track names so the tap re-parses for this item.
         containerTracks.clear();
+        containerTracksUri = null;
         resolvedTrackNames.clear();
 
         // Also drops a deferred error here, not only in releasePlayer: onNewIntent (sharing a video into

--- a/app/src/main/java/com/brouken/player/PlayerActivity.java
+++ b/app/src/main/java/com/brouken/player/PlayerActivity.java
@@ -7880,7 +7880,17 @@ public class PlayerActivity extends Activity {
                             }
                             displayManager.registerDisplayListener(displayListener, null);
                         }
-                        switched = Utils.switchFrameRate(PlayerActivity.this, mPrefs.mediaUri);
+                        // The rate the stats panel prints is the rate the display needs, and by now the app
+                        // usually has it. Measuring it again through a second MediaExtractor costs seconds
+                        // and cannot open HLS at all, which is why online sources never switched.
+                        final float rate = videoFrameRate();
+                        if (rate > 0) {
+                            Utils.handleFrameRate(PlayerActivity.this, rate);
+                            switched = true;
+                        } else {
+                            // Nothing published a rate — a container neither Media3 nor our parser reads.
+                            switched = Utils.switchFrameRate(PlayerActivity.this, currentMediaUri());
+                        }
                     }
                     if (!switched) {
                         if (displayManager != null) {

--- a/app/src/main/java/com/brouken/player/PlayerActivity.java
+++ b/app/src/main/java/com/brouken/player/PlayerActivity.java
@@ -277,6 +277,8 @@ public class PlayerActivity extends Activity {
     // (stuck buffering, a broken next-episode URL, etc.) a friendly LOAD_TIMEOUT message is shown.
     // Such stalls often produce no PlaybackException, so onPlayerError alone would never catch them.
     private static final long VIDEO_LOAD_TIMEOUT_MS = 30_000L;
+    /** How long to wait for a requested display mode to report back before starting playback anyway. */
+    private static final long FRAME_RATE_SWITCH_TIMEOUT_MS = 3_000L;
     // Bytes seen when the watchdog was last armed, so its verdict is "nothing is arriving" rather than
     // "this is taking a while". Filling the first buffer of a large torrent-backed file routinely needs
     // several of these windows — the backend fetches pieces from peers at whatever rate it can, and the
@@ -2179,6 +2181,7 @@ public class PlayerActivity extends Activity {
         play = false;
         // The frame-rate switch registers this listener while waiting to auto-play; with play cleared behind
         // its back it would never unregister itself.
+        playerView.removeCallbacks(frameRateGiveUpRunnable);
         if (displayManager != null && displayListener != null) {
             displayManager.unregisterDisplayListener(displayListener);
         }
@@ -7263,6 +7266,24 @@ public class PlayerActivity extends Activity {
      * and the room's "carry on" then had to drag it back, which cost a second load of the very buffer the
      * hold had just filled.
      */
+    private final Runnable frameRateGiveUpRunnable = this::frameRateSettled;
+
+    /**
+     * Nothing more to wait for from the display: disarm the listener armed for a mode change and spend
+     * the play the loading player is holding. Every path that does not request a new mode ends here, the
+     * ones that give up early included — those used to leave the play pending for good.
+     */
+    private void frameRateSettled() {
+        playerView.removeCallbacks(frameRateGiveUpRunnable);
+        if (displayManager != null && displayListener != null) {
+            displayManager.unregisterDisplayListener(displayListener);
+        }
+        if (play) {
+            play = false;
+            playPending();
+        }
+    }
+
     private void playPending() {
         if (together != null && together.holding()) {
             return;
@@ -7870,11 +7891,7 @@ public class PlayerActivity extends Activity {
 
                                     @Override
                                     public void onDisplayChanged(int displayId) {
-                                        if (play) {
-                                            play = false;
-                                            displayManager.unregisterDisplayListener(this);
-                                            playPending();
-                                        }
+                                        frameRateSettled();
                                     }
                                 };
                             }
@@ -7892,14 +7909,15 @@ public class PlayerActivity extends Activity {
                             switched = Utils.switchFrameRate(PlayerActivity.this, currentMediaUri());
                         }
                     }
-                    if (!switched) {
-                        if (displayManager != null) {
-                            displayManager.unregisterDisplayListener(displayListener);
-                        }
-                        if (play) {
-                            play = false;
-                            playPending();
-                        }
+                    if (switched) {
+                        // A requested mode either comes back as onDisplayChanged or never comes back at
+                        // all: a panel can apply a refresh-rate-only change without reporting one, and a
+                        // request the system declines reports nothing. Without a floor the pending play is
+                        // never spent — on a phone whose display is pinned to 60 Hz the file just sits on
+                        // its first frame, paused, with no spinner and no error.
+                        playerView.postDelayed(frameRateGiveUpRunnable, FRAME_RATE_SWITCH_TIMEOUT_MS);
+                    } else {
+                        frameRateSettled();
                     }
 
                     if (mPrefs.speed <= 0.99f || mPrefs.speed >= 1.01f) {

--- a/app/src/main/java/com/brouken/player/TrackNameParsingDataSource.java
+++ b/app/src/main/java/com/brouken/player/TrackNameParsingDataSource.java
@@ -11,9 +11,9 @@ import androidx.media3.datasource.DataSpec;
 import androidx.media3.datasource.TeeDataSource;
 import androidx.media3.datasource.TransferListener;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.io.PipedInputStream;
-import java.io.PipedOutputStream;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -21,14 +21,22 @@ import java.util.concurrent.atomic.AtomicLong;
 
 /**
  * Wraps an upstream {@link DataSource} and, on the first read of a media item (offset 0), tees the
- * bytes the player reads into a background parser ({@link ContainerMetadataReader}) that recovers
- * per-track container names. Uses only public Media3 API ({@link TeeDataSource} + {@link DataSink}),
- * so it works against the locally-built ExoPlayer AAR without touching its internals.
+ * bytes the player reads into a buffer that {@link ContainerMetadataReader} then parses for per-track
+ * container names and the frame rate. Uses only public Media3 API ({@link TeeDataSource} +
+ * {@link DataSink}), so it works against the locally-built ExoPlayer AAR without touching its
+ * internals.
  *
  * <p>Because it only tees the read that starts at offset 0, it captures metadata that the player
  * reads from the front of the stream (faststart MP4, Matroska headers). A {@code moov} at the end of
  * the file is fetched by the player via a separate seek/reopen and is therefore not seen here — the
  * caller degrades to the language name in that case.
+ *
+ * <p>The header is held and parsed once rather than streamed to a reader running alongside. The
+ * player has to read a file's header past this tee before it can prepare it, so the bytes do arrive —
+ * what used to lose them was the teardown: the reader ran on its own thread behind a pipe that
+ * {@code close()} shut while it was still walking. Holding the bytes instead means the parse happens
+ * when the collecting stops rather than racing it. For Matroska that close is the normal path, not an
+ * edge case: its extractor seeks away to read the cues as soon as it has the tracks.
  */
 final class TrackNameParsingDataSource implements DataSource {
 
@@ -40,10 +48,15 @@ final class TrackNameParsingDataSource implements DataSource {
      */
     static final AtomicLong bytesRead = new AtomicLong();
 
-    /** Receives parsed track metadata (on a background thread) and reports whether it already has it. */
+    /** Receives parsed track metadata (on a load thread) and reports whether it already has it. */
     interface Listener {
-        void onMetadataParsed(List<TrackMetadata> tracks);
-        boolean isMetadataParsed();
+        /**
+         * Called with the tracks read from {@code originalUri}'s header. Keyed by URI because the player
+         * opens the next item of a playlist while the current one is still playing: metadata that is
+         * merely "the most recent" belongs to whichever item won that race.
+         */
+        void onMetadataParsed(Uri originalUri, List<TrackMetadata> tracks);
+        boolean isMetadataParsed(Uri originalUri);
 
         /**
          * Called (on a load thread) with the length the upstream reported for a whole media item, keyed
@@ -70,16 +83,9 @@ final class TrackNameParsingDataSource implements DataSource {
         void onResolverNotReady(Uri originalUri);
     }
 
-    // 64 KB in-RAM pipe — a standard IO chunk; keeps memory bounded and provides backpressure.
-    private static final int PIPE_BUFFER_SIZE = 64 * 1024;
-    // Upper bound on bytes fed to the parser. A large faststart moov can be tens of MB (the sample
-    // tables of a multi-hour 4K file), so this is generous; a non-faststart file bails on the first
-    // mdat instead of streaming this far.
-    private static final int MAX_BYTES_TO_PARSE = 128 * 1024 * 1024;
-
     private final DataSource upstream;
     private final Listener listener;
-    private final PipeSink pipeSink = new PipeSink();
+    private final HeaderSink headerSink = new HeaderSink();
 
     private TeeDataSource teeDataSource;
 
@@ -91,8 +97,8 @@ final class TrackNameParsingDataSource implements DataSource {
     @Override
     public long open(DataSpec dataSpec) throws IOException {
         final long length;
-        if (dataSpec.position == 0 && !listener.isMetadataParsed()) {
-            teeDataSource = new TeeDataSource(upstream, pipeSink);
+        if (dataSpec.position == 0 && !listener.isMetadataParsed(dataSpec.uri)) {
+            teeDataSource = new TeeDataSource(upstream, headerSink);
             length = teeDataSource.open(dataSpec);
         } else {
             teeDataSource = null;
@@ -244,7 +250,9 @@ final class TrackNameParsingDataSource implements DataSource {
                 upstream.close();
             }
         } finally {
-            pipeSink.stopParsing();
+            // TeeDataSource.close() already closed the sink; this covers the no-tee branch and frees the
+            // buffered header either way. Idempotent — the second call finds nothing left to parse.
+            headerSink.close();
             teeDataSource = null;
         }
     }
@@ -259,93 +267,107 @@ final class TrackNameParsingDataSource implements DataSource {
         return upstream.getResponseHeaders();
     }
 
-    private final class PipeSink implements DataSink {
-        private PipedOutputStream pipedOut;
-        private Thread parsingThread;
-        private long totalBytesWritten;
-        private volatile boolean parsingActive;
+    /**
+     * Collects the front of the stream as the player reads it and parses it exactly once.
+     *
+     * <p>Every method here runs on an ExoPlayer load thread, inside {@link DataSource#read} and
+     * {@link DataSource#close}. Anything thrown from there becomes a playback error, and an
+     * {@link Error} — an unbounded allocation from a corrupt header, say — takes the process with it.
+     * Recovering a track name is never worth a failed playback, so both entry points swallow
+     * everything and simply stop collecting. The parser this replaced had the same property by
+     * accident, being on a thread of its own.
+     */
+    private final class HeaderSink implements DataSink {
+        private final byte[] signature = new byte[ContainerMetadataReader.SIGNATURE_BYTES];
+        private int signatureLength;
+        /** The bytes collected so far, or null while there is nothing worth collecting. */
+        private ByteArrayOutputStream header;
+        /** Bytes worth collecting for this container; 0 until the signature has been read. */
+        private int budget;
+        private boolean done;
+        private Uri uri;
 
         @Override
         public void open(DataSpec dataSpec) {
-            if (dataSpec.position != 0 || listener.isMetadataParsed()) {
-                return;
-            }
-            closePipes();
-            totalBytesWritten = 0;
-            parsingActive = true;
-
-            final PipedInputStream pipedIn;
-            try {
-                pipedOut = new PipedOutputStream();
-                pipedIn = new PipedInputStream(pipedOut, PIPE_BUFFER_SIZE);
-            } catch (IOException e) {
-                parsingActive = false;
-                pipedOut = null;
-                return;
-            }
-
-            parsingThread = new Thread(() -> {
-                try {
-                    final List<TrackMetadata> tracks = ContainerMetadataReader.parse(pipedIn);
-                    if (!tracks.isEmpty()) {
-                        listener.onMetadataParsed(tracks);
-                    }
-                } catch (Exception ignored) {
-                    // Pipe closed / interrupted — normal termination.
-                } finally {
-                    parsingActive = false;
-                    try {
-                        pipedIn.close();
-                    } catch (IOException ignored) {
-                    }
-                }
-            }, "TrackNameParser");
-            parsingThread.setDaemon(true);
-            parsingThread.start();
+            // open() already gated on position 0; the sink is unreachable otherwise.
+            uri = dataSpec.uri;
+            signatureLength = 0;
+            header = null;
+            budget = 0;
+            done = listener.isMetadataParsed(uri);
         }
 
         @Override
         public void write(byte[] buffer, int offset, int length) {
-            if (!parsingActive) {
-                return;
-            }
-            if (totalBytesWritten >= MAX_BYTES_TO_PARSE) {
-                stopParsing();
-                return;
-            }
             try {
-                // Blocks once the 64 KB pipe fills until the parser drains it (backpressure).
-                pipedOut.write(buffer, offset, length);
-                totalBytesWritten += length;
-            } catch (IOException e) {
-                // "Pipe closed"/"Pipe broken" — the parser finished.
-                stopParsing();
+                collect(buffer, offset, length);
+            } catch (Throwable t) {
+                discard();
             }
         }
 
         @Override
         public void close() {
-            stopParsing();
+            try {
+                // Less than the budget arrived: a short file, or the player closed the source early —
+                // which is the normal path for Matroska, whose extractor seeks away to read the cues.
+                // What is here is all there will be, so parse it instead of dropping it.
+                parseHeader();
+            } catch (Throwable t) {
+                discard();
+            }
         }
 
-        void stopParsing() {
-            if (parsingActive) {
-                parsingActive = false;
-                if (parsingThread != null) {
-                    parsingThread.interrupt();
+        private void collect(byte[] buffer, int offset, int length) {
+            if (done) {
+                return;
+            }
+            if (budget == 0) {
+                final int taken = Math.min(length, signature.length - signatureLength);
+                System.arraycopy(buffer, offset, signature, signatureLength, taken);
+                signatureLength += taken;
+                if (signatureLength < signature.length) {
+                    return;
+                }
+                budget = ContainerMetadataReader.headerBudget(signature);
+                if (budget == 0) {
+                    // Nothing here any parser reads — an HLS manifest, an MPEG-TS segment. Every segment
+                    // of a streaming playback opens at offset 0, and this is what keeps them free: the
+                    // signature lands in a field, so a stream we do not parse allocates nothing at all.
+                    discard();
+                    return;
+                }
+                header = new ByteArrayOutputStream(Math.min(budget, 64 * 1024));
+                header.write(signature, 0, signature.length);
+                offset += taken;
+                length -= taken;
+                if (length == 0) {
+                    return;
                 }
             }
-            closePipes();
+            header.write(buffer, offset, length);
+            if (header.size() >= budget) {
+                parseHeader();
+            }
         }
 
-        private void closePipes() {
-            if (pipedOut != null) {
-                try {
-                    pipedOut.close();
-                } catch (IOException ignored) {
-                }
-                pipedOut = null;
+        private void parseHeader() {
+            if (done || header == null) {
+                return;
             }
+            final byte[] bytes = header.toByteArray();
+            discard();
+            final List<TrackMetadata> tracks = ContainerMetadataReader.parse(new ByteArrayInputStream(bytes));
+            if (!tracks.isEmpty()) {
+                listener.onMetadataParsed(uri, tracks);
+            }
+        }
+
+        /** Stops collecting and lets the buffer go; nothing more will be parsed for this open. */
+        private void discard() {
+            done = true;
+            header = null;
+            signatureLength = 0;
         }
     }
 

--- a/app/src/main/java/com/brouken/player/Utils.java
+++ b/app/src/main/java/com/brouken/player/Utils.java
@@ -719,11 +719,13 @@ class Utils {
         activity.runOnUiThread(() -> {
             boolean switchingModes = false;
 
-            if (frameRate > 0) {
-                Display display = activity.getWindow().getDecorView().getDisplay();
-                if (display == null) {
-                    return;
-                }
+            // A detached decor view answers null. Falling through to playIfCan rather than returning:
+            // the caller has already told the player a switch is pending, so bailing out here left the
+            // file on its first frame with no spinner and no error. Unreachable until the rate started
+            // coming from Format — before that a stream had no rate at all and never entered this block.
+            final Display display = frameRate > 0
+                    ? activity.getWindow().getDecorView().getDisplay() : null;
+            if (display != null) {
                 Display.Mode[] supportedModes = display.getSupportedModes();
                 Display.Mode activeMode = display.getMode();
 
@@ -752,7 +754,17 @@ class Utils {
                         Display.Mode modeBest = null;
 
                         for (Display.Mode mode : modesHigh) {
-                            if (normRate(mode.getRefreshRate()) % normRate(frameRate) <= 0.0001f) {
+                            // A whole multiple of the content rate, judged on the *relative* error. The
+                            // centi-Hz remainder this replaces could not match 23.976 at all, since
+                            // normRate truncates it to 2397, which divides neither 4795 (47.952 Hz) nor
+                            // 11988 (119.88 Hz). But the tolerance has to stay under the 1/1001 that
+                            // separates an NTSC rate from its integer neighbour, or 120 Hz also "matches"
+                            // 23.976 content and, being the higher rate, beats the 119.88 mode that is the
+                            // exact one. 2e-4 sits between the float noise on these values (~5e-6) and
+                            // that 1e-3 gap.
+                            final float ratio = mode.getRefreshRate() / frameRate;
+                            final int multiple = Math.round(ratio);
+                            if (multiple >= 1 && Math.abs(ratio - multiple) < multiple * 0.0002f) {
                                 if (modeBest == null || normRate(mode.getRefreshRate()) > normRate(modeBest.getRefreshRate())) {
                                     modeBest = mode;
                                 }

--- a/app/src/main/java/com/brouken/player/Utils.java
+++ b/app/src/main/java/com/brouken/player/Utils.java
@@ -796,6 +796,10 @@ class Utils {
     // seconds on a network file, and the user may have left in the meantime (onStop clears it).
     static void playIfCan(final PlayerActivity activity) {
         if (activity.play) {
+            // Spending it, so mark it spent: the caller waiting for a display mode uses this flag to tell
+            // "playback has not started" from "it started without a mode change", and left set it would
+            // let a later display event start playback a second time, on its own.
+            activity.play = false;
             if (PlayerActivity.player != null)
                 PlayerActivity.player.play();
             if (activity.playerView != null)


### PR DESCRIPTION
Closes #113.
Closes #114.

Both issues turned out to have one cause. The frame rate is already in the app twice over —
from `Format` for MP4, DASH and HLS that declares `FRAME-RATE`, from the container header for
Matroska and AVI — and #114 could not stop measuring it a second time until the second half of
that was reliable. So: make the container parse deterministic, then feed the display switch from
the value the stats panel already prints.

### Parse the container header from a buffer, not from a pipe (#113)

The parser was racing the player's teardown. Its input was a 64 KB pipe fed by the tee on the
player's own reads, drained by a thread of its own; `close()` on the data source ended in
`stopParsing()`, which interrupted that thread and closed the pipe, and the thread caught its
own interruption as a normal end. A parse that had not yet walked `Tracks` was discarded in
silence, and since the tee is only armed on a read starting at offset 0 there was no second
attempt. For Matroska that close is the normal path rather than an edge case: the extractor
seeks away to read the cues as soon as it has the tracks.

The player has to read a file's header past the tee before it can prepare it, so the bytes do
arrive — only the parse was being lost. The sink now collects the front of the stream and parses
it once, when it has the container's header or when the source closes. The pipe, the thread and
the race go with it, and the class is 90 lines shorter.

How much to collect comes from the 12-byte signature the dispatcher needed anyway. A container
no parser reads answers zero and the signature never leaves its field, so a streaming playback
— every segment of which opens at offset 0 — allocates nothing.

Moving the parse onto the load thread means it must not be able to cost a playback: what is
thrown inside `DataSource.read()` becomes a playback error, and an `Error` takes the process.
Both entry points now swallow everything and stop collecting, and the two places that sized a
buffer from a length in the file — a Matroska string, an MP4 track name — refuse an implausible
one instead of allocating on its word.

Two further things this exposed:

- A truncated header used to publish a wrong value rather than none. `readUInt` treated
  end-of-stream as a byte to skip, so a `DefaultDuration` cut after its first byte read as half
  a billion fps, and a corrupt length spun the load thread for ~10^12 iterations. Both readers
  now throw, and a `TrackEntry` cut short is dropped rather than returned half-built —
  publishing it would answer the caller for good, since having answered at all is what stops the
  next attempt.
- The metadata was global where it should have been per item. ExoPlayer opens the next item of a
  playlist while the current one is still playing, so "the last thing parsed" belonged to
  whichever item won that race: the panel printed the previous episode's frame rate and the tap
  was told there was nothing left to parse. It is now keyed by URI, the way the content length
  beside it already was.

### Match the display to the frame rate the player already knows (#114)

"Auto frame rate matching" did nothing on online sources. It measured the rate itself, opening a
second `android.media.MediaExtractor` on the same URL and averaging 350 sample timestamps — and
`MediaExtractor` cannot open HLS at all. The `IOException` was printed and swallowed, no mode
was requested, and nothing said so. The boundary was "direct stream vs HLS", not "local vs
network".

The switch now reads the rate the app already has, from one expression instead of two copies of
it: no second connection, no thread, and none of the 5-9 seconds it spent before failing. The
measurement stays as the last resort for what publishes no rate anywhere — MPEG-TS, an MKV
without `DefaultDuration`, HLS without the attribute — and it reads the item that is playing
rather than the one the session opened.

The multiple-of test needed fixing to go with it, because it could never match 23.976.
`normRate` truncates to centi-Hz as an `int`, so `%` was an integer remainder and comparing it
to `0.0001f` meant "equals zero": 23.976 became 2397, which divides neither 4795 (47.952 Hz) nor
11988 (119.88 Hz). Both exact multiples were rejected and the code fell through to the panel's
highest refresh rate, on the most common film rate there is. The replacement compares the ratio
to its nearest whole number relative to that number, not by a flat margin — a flat one is looser
than the 1/1001 that separates an NTSC rate from its integer neighbour, so 24 Hz would also
"match" 23.976 content and, being higher, would beat the exact mode.

### Start playing when a display mode change never reports back

Found while verifying the above, and not covered by either issue. A requested display mode was
waited for unconditionally, and the only thing that spends the play a loading player is holding
is `onDisplayChanged` — so when that never arrives the file sits on its first frame, paused, no
spinner, no error, nothing to retry. Some panels apply a refresh-rate-only change without
reporting one, and a request the system declines reports nothing at all.

Not a corner case: on a phone whose display is pinned to 60 Hz, nothing plays with the setting
on. The wait now has a floor, and every path that does not request a new mode shares one place
that disarms the listener and spends the play, instead of three copies and one early return that
did neither. A mode change that does report back cancels the floor.

`playIfCan` marks the play spent while spending it. Left set, the flag meant a later display
event — an HDR toggle, waking the screen, another app's vote — could start playback a second
time on its own.

### Verification

Parser output against `ffprobe`, on real files rather than synthetic ones:

| File | Parser | ffprobe |
|---|---|---|
| MKV rip, 4 tracks | 60.000 fps, `rus`/`jpn` | `60/1` |
| MKV, generated | 23.976 fps, track name and language read | `24000/1001` |
| MKV with a 400 KB attachment, chapters, tags | 23.976 fps, header ends at 471 B | `24000/1001` |
| AVI | 23.976 / 25.000 fps | `24000/1001`, `25/1` |
| MP4, faststart | no rate, by design | `30000/1001` from `Format` |

The header budgets are sized from those measurements: `Tracks` lands within 6.5 KB on eleven
real rips, and `Attachments` follow `Tracks`, so an attachment does not push it back.

On a device (CPH2447, Android 14), with the panel resting at 120 Hz and modes 60/90/120 at the
current resolution:

| Content | Exact multiple | Mode applied | App's mode vote |
|---|---|---|---|
| 22.5 fps | 90 (x4) | 90 Hz | `90.0` |
| 45 fps | 90 (x2) | 90 Hz | `90.0` |
| 30 fps | 120 (x4), already active | no request | — |
| 23.976 | none | no request | — |

The exact multiple is preferred over the panel's top rate, which is the point of the test that
was fixed. `Format.frameRate` was `-1` for every Matroska and AVI clip and the rate came from
the container header, available by `STATE_READY`, which is when the switch needs it.

Two things this hardware cannot show. It has no NTSC modes (47.952, 119.88), so the tolerance
change is read from the code and from a matrix of real reported refresh rates rather than
observed. And where an exact multiple exists, this panel's answer is the same one Android's own
`Surface.setFrameRate` arbitration would pick, so the two cannot be told apart here — HLS
through a TV box is still the case worth watching.
