### PR TITLE
Seek once per landed seek while swiping the picture

### DIFF
--- a/app/src/main/java/com/brouken/player/CustomPlayerView.java
+++ b/app/src/main/java/com/brouken/player/CustomPlayerView.java
@@ -156,6 +156,10 @@ public class CustomPlayerView extends PlayerView implements GestureDetector.OnGe
                 }
                 if (handleTouch) {
                     if (gestureOrientation == Orientation.HORIZONTAL) {
+                        // The drag itself only seeks when the previous seek has landed, so the last steps
+                        // of a fast swipe are usually skipped. Land on what the label promised.
+                        if (PlayerActivity.haveMedia && PlayerActivity.player != null)
+                            PlayerActivity.player.seekTo(seekStart + seekChange);
                         setCustomErrorMessage(null);
                     } else {
                         postDelayed(textClearRunnable, isHandledLongPress ? MESSAGE_TIMEOUT_LONG : MESSAGE_TIMEOUT_TOUCH);
@@ -235,6 +239,21 @@ public class CustomPlayerView extends PlayerView implements GestureDetector.OnGe
         return prefs != null && prefs.disableVolumeBrightnessGestures;
     }
 
+    // One seek in flight at a time, the same gate the time bar scrubs behind. A swipe fires a seek every
+    // 8dp, and a backward one cannot be served from the buffer already read past — it reopens the source
+    // and refills — so unthrottled they pile up on the playback thread and the position lurches along
+    // behind the finger instead of following it. Forward seeks land in buffered data, which is why only
+    // rewinding looked broken. The release in onTouchEvent seeks to wherever the drag actually ended.
+    private void seekGesture(final long position) {
+        if (!(getContext() instanceof PlayerActivity))
+            return;
+        final PlayerActivity activity = (PlayerActivity) getContext();
+        if (!activity.frameRendered)
+            return;
+        activity.frameRendered = false;
+        PlayerActivity.player.seekTo(position);
+    }
+
     @Override
     public boolean onScroll(MotionEvent motionEvent, MotionEvent motionEvent1, float distanceX, float distanceY) {
         // No player check here: brightness and volume must stay reachable even when playback has died
@@ -288,18 +307,18 @@ public class CustomPlayerView extends PlayerView implements GestureDetector.OnGe
                             PlayerActivity.player.setSeekParameters(SeekParameters.PREVIOUS_SYNC);
                             seekChange -= SEEK_STEP * distanceDiff;
                             position = seekStart + seekChange;
-                            PlayerActivity.player.seekTo(position);
+                            seekGesture(position);
                         }
                     } else {
                         PlayerActivity.player.setSeekParameters(SeekParameters.NEXT_SYNC);
                         if (seekMax == C.TIME_UNSET) {
                             seekChange += SEEK_STEP * distanceDiff;
                             position = seekStart + seekChange;
-                            PlayerActivity.player.seekTo(position);
+                            seekGesture(position);
                         } else if (seekStart + seekChange + SEEK_STEP < seekMax) {
                             seekChange += SEEK_STEP  * distanceDiff;
                             position = seekStart + seekChange;
-                            PlayerActivity.player.seekTo(position);
+                            seekGesture(position);
                         }
                     }
                     String message = Utils.formatMilisSign(seekChange);

--- a/app/src/main/java/com/brouken/player/PlayerActivity.java
+++ b/app/src/main/java/com/brouken/player/PlayerActivity.java
@@ -7497,6 +7497,10 @@ public class PlayerActivity extends Activity {
         @Override
         public void onRenderedFirstFrame() {
             resumeFrameRendered = true;
+            // Fires again after every seek's flush, which is the only signal a seek that never left
+            // STATE_READY gives. Without it the one-seek-at-a-time gate the scrubbing and swipe-seek
+            // paths share can latch shut mid-drag.
+            frameRendered = true;
         }
 
         @Override


### PR DESCRIPTION
Swiping the picture sideways to seek was smooth forward and jerky backward on a tablet: the scrubber lurched along behind the finger instead of tracking it.

**Cause.** The gesture fired a `seekTo` every 8dp of travel, dozens a second, with nothing waiting for the previous one to land. Forward that is cheap — `NEXT_SYNC` resolves inside data the buffer has already read. Backward it is not — `PREVIOUS_SYNC` always targets a point behind the read position, so each seek discards the buffer and reopens the source. Unthrottled, they piled up on the playback thread.

**Fix.** Gate the gesture behind the same one-seek-at-a-time `frameRendered` flag the time bar has scrubbed behind since "Faster seek", and seek to the drag's real end on release — the skipped steps would otherwise leave playback short of the offset the label promised.

Setting that flag on `STATE_READY` alone was enough for the time bar, whose `CLOSEST_SYNC` seeks reliably drop out of `READY`. A forward gesture seek need not, so it is also set on `onRenderedFirstFrame`, which fires after every seek's flush; without it the gate could latch shut for the rest of a drag.

Tested on a tablet: backward swipe-seek now tracks the finger, forward is unchanged.