### PR TITLE
Let the bottom bar count down the time left

### DIFF
--- a/app/src/main/java/com/brouken/player/PlayerActivity.java
+++ b/app/src/main/java/com/brouken/player/PlayerActivity.java
@@ -95,6 +95,7 @@ import androidx.core.graphics.ColorUtils;
 import androidx.documentfile.provider.DocumentFile;
 import androidx.media3.common.AudioAttributes;
 import androidx.media3.common.C;
+import androidx.media3.common.util.Util;
 import androidx.media3.common.ColorInfo;
 import androidx.media3.common.Format;
 import androidx.media3.common.MediaItem;
@@ -177,6 +178,7 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Date;
+import java.util.Formatter;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
@@ -1598,6 +1600,21 @@ public class PlayerActivity extends Activity {
         }
 
         controlView = playerView.findViewById(R.id.exo_controller);
+
+        // The right-hand slot of the bottom bar shows the total duration, or counts down what is left when
+        // the setting says so. PlayerControlView writes that TextView itself, so rewrite it after every
+        // progress tick — updateTimeline() ends with updateProgress(), so its own value never lingers.
+        final TextView durationView = playerView.findViewById(R.id.exo_duration);
+        final StringBuilder timeBuilder = new StringBuilder();
+        final Formatter timeFormatter = new Formatter(timeBuilder, Locale.getDefault());
+        controlView.setProgressUpdateListener((position, bufferedPosition) -> {
+            final long duration = player == null ? C.TIME_UNSET : player.getContentDuration();
+            if (duration == C.TIME_UNSET)
+                return;
+            durationView.setText(mPrefs != null && mPrefs.timeRemaining
+                    ? "-" + Util.getStringForTime(timeBuilder, timeFormatter, Math.max(0, duration - position))
+                    : Util.getStringForTime(timeBuilder, timeFormatter, duration));
+        });
         controlView.setOnApplyWindowInsetsListener((view, windowInsets) -> {
             if (windowInsets != null) {
                 if (Build.VERSION.SDK_INT >= 31) {

--- a/app/src/main/java/com/brouken/player/Prefs.java
+++ b/app/src/main/java/com/brouken/player/Prefs.java
@@ -69,6 +69,7 @@ class Prefs {
     private static final String PREF_KEY_SKIP_UNDO = "skipUndo";
     private static final String PREF_KEY_SKIP_HIDE_LOCKED = "skipHideWhenLocked";
     private static final String PREF_KEY_SHOW_CLOCK = "showClock";
+    private static final String PREF_KEY_TIME_REMAINING = "timeRemaining";
     private static final String PREF_KEY_SHOW_STATS = "showStats";
     private static final String PREF_KEY_SYSTEM_VOLUME = "systemVolume";
     private static final String PREF_KEY_TOGETHER_NICK = "togetherNick";
@@ -154,6 +155,8 @@ class Prefs {
     public boolean skipFetchOnline = true;
     public String skipUndo = SKIP_UNDO_ALL;
     public boolean showClock = false;
+    /** Bottom bar counts down what is left instead of showing the total duration. */
+    public boolean timeRemaining = false;
     public boolean showStats = false;
     public boolean systemVolume = true;
     /** How other people in a watch-together room see this device. Generated once, then editable. */
@@ -276,6 +279,7 @@ class Prefs {
         skipUndo = mSharedPreferences.getString(PREF_KEY_SKIP_UNDO, skipUndo);
         skipHideWhenLocked = mSharedPreferences.getBoolean(PREF_KEY_SKIP_HIDE_LOCKED, skipHideWhenLocked);
         showClock = mSharedPreferences.getBoolean(PREF_KEY_SHOW_CLOCK, showClock);
+        timeRemaining = mSharedPreferences.getBoolean(PREF_KEY_TIME_REMAINING, timeRemaining);
         showStats = mSharedPreferences.getBoolean(PREF_KEY_SHOW_STATS, showStats);
         // Forced on for TV boxes, where the remote routes volume to the panel or receiver over CEC and
         // only the system stream responds — the setting is hidden there too.

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -131,6 +131,9 @@
     <string name="pref_show_clock">Показывать часы</string>
     <string name="pref_show_clock_on">Часы всегда в правом верхнем углу поверх видео</string>
     <string name="pref_show_clock_off">Часы показываются только с элементами управления</string>
+    <string name="pref_time_remaining">Показывать оставшееся время</string>
+    <string name="pref_time_remaining_on">Нижняя панель отсчитывает время до конца</string>
+    <string name="pref_time_remaining_off">Нижняя панель показывает общую длительность</string>
     <string name="pref_system_volume">Системная громкость</string>
     <string name="pref_system_volume_on">Жесты и кнопки громкости меняют громкость медиа на устройстве</string>
     <string name="pref_system_volume_off">Жесты и кнопки громкости меняют только этот плеер и не затрагивают громкость устройства</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -132,6 +132,9 @@
     <string name="pref_show_clock">Показувати годинник</string>
     <string name="pref_show_clock_on">Годинник завжди у верхньому правому куті поверх відео</string>
     <string name="pref_show_clock_off">Годинник показується лише з елементами керування</string>
+    <string name="pref_time_remaining">Показувати час, що залишився</string>
+    <string name="pref_time_remaining_on">Нижня панель відлічує час до кінця</string>
+    <string name="pref_time_remaining_off">Нижня панель показує загальну тривалість</string>
     <string name="pref_system_volume">Системна гучність</string>
     <string name="pref_system_volume_on">Жести та кнопки гучності змінюють гучність медіа на пристрої</string>
     <string name="pref_system_volume_off">Жести та кнопки гучності змінюють лише цей плеєр і не торкаються гучності пристрою</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -133,6 +133,9 @@
     <string name="pref_show_clock">Show clock</string>
     <string name="pref_show_clock_on">Clock stays in the top-right corner over the video</string>
     <string name="pref_show_clock_off">Clock shows only with the player controls</string>
+    <string name="pref_time_remaining">Show remaining time</string>
+    <string name="pref_time_remaining_on">Bottom bar counts down the time left</string>
+    <string name="pref_time_remaining_off">Bottom bar shows the total duration</string>
     <string name="pref_system_volume">System volume</string>
     <string name="pref_system_volume_on">Volume gestures and buttons change the device media volume</string>
     <string name="pref_system_volume_off">Volume gestures and buttons change only this player and leave the device volume alone</string>

--- a/app/src/main/res/xml/root_preferences.xml
+++ b/app/src/main/res/xml/root_preferences.xml
@@ -46,6 +46,13 @@
             app:title="@string/pref_show_clock" />
 
         <SwitchPreferenceCompat
+            app:key="timeRemaining"
+            app:defaultValue="false"
+            app:summaryOn="@string/pref_time_remaining_on"
+            app:summaryOff="@string/pref_time_remaining_off"
+            app:title="@string/pref_time_remaining" />
+
+        <SwitchPreferenceCompat
             app:key="systemVolume"
             app:defaultValue="true"
             app:summaryOn="@string/pref_system_volume_on"


### PR DESCRIPTION
The right-hand slot of the bottom bar always showed the total duration. A new global setting — **Settings → General → Show remaining time**, off by default — turns it into the remaining time (`-1:23:45`) instead.

PlayerControlView owns that TextView, so the text is rewritten after every progress tick. `updateTimeline()` ends with `updateProgress()`, so the value the control view writes itself is never left on screen.

English, Ukrainian and Russian strings included; the rest is left to Weblate.

Closes #115