### PR TITLE
Let the held finger steer the speed

### DIFF
--- a/app/src/main/java/com/brouken/player/CustomPlayerView.java
+++ b/app/src/main/java/com/brouken/player/CustomPlayerView.java
@@ -4,6 +4,7 @@ import android.content.Context;
 import android.graphics.Rect;
 import android.media.AudioManager;
 import android.os.Build;
+import android.os.SystemClock;
 import android.util.AttributeSet;
 import android.view.GestureDetector;
 import android.view.Gravity;
@@ -60,11 +61,22 @@ public class CustomPlayerView extends PlayerView implements GestureDetector.OnGe
     private float mScaleFactor = 1.f;
     private float mScaleFactorFit;
 
-    // Hold-to-speed (YouTube-style): while the screen is long-pressed during playback, speed jumps to 2x
-    // and the previous speed is restored on release.
+    // Hold-to-speed: a long press during playback jumps to 2x, and dragging sideways without letting go
+    // moves along one axis - right for more speed, left down to 1x and then on into rewind. The previous
+    // speed is restored on release.
     private static final float SPEED_BOOST = 2.f;
+    private static final float SPEED_MAX = 4.f;
+    private static final float SPEED_REWIND_MIN = 2.f;
+    private static final float SPEED_STEP_DP = 40.f;
+    private static final long REWIND_TICK_MS = 100;
     private boolean speedBoostActive = false;
     private float speedBeforeBoost = 1.f;
+    private float boostAnchorX;
+    private float holdSpeed = SPEED_BOOST;
+    private boolean rewinding;
+    private long rewindPosition;
+    private long rewindLastTime;
+    private final Runnable rewindRunnable = this::rewindTick;
 
     /** True while the hold-to-speed-up gesture is running. A watch-together room does not follow it:
      *  it is a preview held under a finger, not a choice, and the speed goes back on release. */
@@ -149,8 +161,15 @@ public class CustomPlayerView extends PlayerView implements GestureDetector.OnGe
                 seekGestureActive = false;
                 if (speedBoostActive) {
                     speedBoostActive = false;
-                    if (PlayerActivity.player != null)
+                    removeCallbacks(rewindRunnable);
+                    if (PlayerActivity.player != null) {
+                        // A rewind tick is skipped while the previous seek is still in flight, so the
+                        // player can sit behind what the pill promised. Land on the promise.
+                        if (rewinding)
+                            PlayerActivity.player.seekTo(rewindPosition);
                         PlayerActivity.player.setPlaybackSpeed(speedBeforeBoost);
+                    }
+                    rewinding = false;
                     if (getContext() instanceof PlayerActivity)
                         ((PlayerActivity) getContext()).setSpeedBoostIndicatorVisible(false);
                 }
@@ -180,6 +199,13 @@ public class CustomPlayerView extends PlayerView implements GestureDetector.OnGe
                     }
                     break;
                 }
+        }
+
+        // GestureDetector drops every move once it has fired a long press, so the drag of a hold is read
+        // straight from here - which also keeps it clear of the seek and volume/brightness scrolls.
+        if (speedBoostActive && ev.getActionMasked() == MotionEvent.ACTION_MOVE) {
+            updateHoldSpeed(ev.getX());
+            return true;
         }
 
         if (handleTouch)
@@ -237,6 +263,15 @@ public class CustomPlayerView extends PlayerView implements GestureDetector.OnGe
         }
         final Prefs prefs = ((PlayerActivity) getContext()).mPrefs;
         return prefs != null && prefs.disableVolumeBrightnessGestures;
+    }
+
+    // True when the viewer has turned the hold-to-speed gesture off in the settings.
+    private boolean holdSpeedGestureOff() {
+        if (!(getContext() instanceof PlayerActivity)) {
+            return false;
+        }
+        final Prefs prefs = ((PlayerActivity) getContext()).mPrefs;
+        return prefs != null && !prefs.holdSpeed;
     }
 
     // One seek in flight at a time, the same gate the time bar scrubs behind. A swipe fires a seek every
@@ -373,13 +408,88 @@ public class CustomPlayerView extends PlayerView implements GestureDetector.OnGe
             return;
         if (!PlayerActivity.haveMedia || PlayerActivity.player == null || !PlayerActivity.player.isPlaying())
             return;
+        if (holdSpeedGestureOff())
+            return;
         speedBeforeBoost = PlayerActivity.player.getPlaybackParameters().speed;
         speedBoostActive = true;
         isHandledLongPress = true;
+        boostAnchorX = motionEvent.getX();
+        holdSpeed = SPEED_BOOST;
+        rewinding = false;
         PlayerActivity.player.setPlaybackSpeed(SPEED_BOOST);
         hideController();
+        showHoldSpeed();
+    }
+
+    // The hold axis: where the press landed is 2x, and every SPEED_STEP_DP to the right adds 1x. To the
+    // left it counts down to 1x and then flips into rewind, which starts at 2x and grows the same way.
+    // The flip has a little hysteresis, so a finger resting on the boundary cannot thrash the player
+    // between paused rewind and playback.
+    private void updateHoldSpeed(final float x) {
+        if (PlayerActivity.player == null)
+            return;
+        final float value = SPEED_BOOST + Utils.pxToDp(x - boostAnchorX) / SPEED_STEP_DP;
+        final boolean rewind = rewinding ? value < 1.1f : value < 1.f;
+        final float speed = Math.min(SPEED_MAX,
+                rewind ? SPEED_REWIND_MIN + (1.f - value) : Math.max(1.f, value));
+        // A tenth is what the pill shows; anything finer would only churn the player.
+        final float rounded = Math.round(speed * 10.f) / 10.f;
+        if (rewind == rewinding && rounded == holdSpeed)
+            return;
+        holdSpeed = rounded;
+        if (rewind != rewinding) {
+            rewinding = rewind;
+            if (rewind)
+                startRewind();
+            else
+                stopRewind();
+        }
+        if (!rewinding)
+            PlayerActivity.player.setPlaybackSpeed(holdSpeed);
+        showHoldSpeed();
+    }
+
+    private void showHoldSpeed() {
         if (getContext() instanceof PlayerActivity)
-            ((PlayerActivity) getContext()).setSpeedBoostIndicatorVisible(true);
+            ((PlayerActivity) getContext()).setSpeedBoostIndicator(holdSpeed, rewinding);
+    }
+
+    // Nothing decodes backwards, so rewind is the swipe-seek gesture on a timer: the player is paused and
+    // walked back at the held rate, one seek at a time behind the same in-flight gate.
+    private void startRewind() {
+        seekGestureActive = true;
+        if (PlayerActivity.player.isPlaying()) {
+            restorePlayState = true;
+            PlayerActivity.player.pause();
+        }
+        PlayerActivity.player.setPlaybackSpeed(speedBeforeBoost);
+        PlayerActivity.player.setSeekParameters(SeekParameters.PREVIOUS_SYNC);
+        rewindPosition = PlayerActivity.player.getCurrentPosition();
+        rewindLastTime = SystemClock.uptimeMillis();
+        if (!isControllerFullyVisible()) {
+            seekProgress = true;
+            showProgress();
+        }
+        post(rewindRunnable);
+    }
+
+    private void stopRewind() {
+        removeCallbacks(rewindRunnable);
+        PlayerActivity.player.seekTo(rewindPosition);
+        if (restorePlayState) {
+            restorePlayState = false;
+            PlayerActivity.player.play();
+        }
+    }
+
+    private void rewindTick() {
+        if (!speedBoostActive || !rewinding || PlayerActivity.player == null)
+            return;
+        final long now = SystemClock.uptimeMillis();
+        rewindPosition = Math.max(0, rewindPosition - (long) ((now - rewindLastTime) * holdSpeed));
+        rewindLastTime = now;
+        seekGesture(rewindPosition);
+        postDelayed(rewindRunnable, REWIND_TICK_MS);
     }
 
     // Toggles the touch lock (triggered by the lock button). While locked the controller stays hidden

--- a/app/src/main/java/com/brouken/player/PlayerActivity.java
+++ b/app/src/main/java/com/brouken/player/PlayerActivity.java
@@ -798,8 +798,10 @@ public class PlayerActivity extends Activity {
     private Drawable skipIconKeep;
     private Drawable skipIconBack;
     private GradientDrawable skipPillGroove;
-    // Top-center pill shown while hold-to-speed (2x) is active. Non-clickable so it never intercepts the hold.
+    // Top-center pill shown while hold-to-speed is active. Non-clickable so it never intercepts the hold.
     TextView speedBoostIndicator;
+    private Drawable speedBoostIconForward;
+    private Drawable speedBoostIconRewind;
     final Runnable skipPillHider = new Runnable() {
         @Override
         public void run() {
@@ -1443,10 +1445,10 @@ public class PlayerActivity extends Activity {
         buttonSkip.setVisibility(View.GONE);
         coordinatorLayout.addView(buttonSkip);
 
-        // Hold-to-speed (2x) indicator: the same rounded dark pill as the skip pill (fast-forward icon +
-        // label), floating top-centre. Non-clickable so it never intercepts the hold.
+        // Hold-to-speed indicator: the same rounded dark pill as the skip pill (rate + direction arrows),
+        // floating top-centre. Non-clickable so it never intercepts the hold.
         speedBoostIndicator = new TextView(this);
-        speedBoostIndicator.setText("2×");
+        speedBoostIndicator.setText("2.0×");
         speedBoostIndicator.setAllCaps(false);
         speedBoostIndicator.setTextColor(Color.WHITE);
         speedBoostIndicator.setTextSize(TypedValue.COMPLEX_UNIT_SP, ui.textSkip());
@@ -1456,14 +1458,16 @@ public class PlayerActivity extends Activity {
         speedBoostIndicator.setClickable(false);
         speedBoostIndicator.setFocusable(false);
 
-        final Drawable speedBoostIcon = ContextCompat.getDrawable(this, R.drawable.exo_icon_fastforward);
-        if (speedBoostIcon != null) {
-            final int speedBoostIconSize = Utils.dpToPx(18);
-            speedBoostIcon.setBounds(0, 0, speedBoostIconSize, speedBoostIconSize);
-            speedBoostIndicator.setCompoundDrawablesRelative(speedBoostIcon, null, null, null);
-            speedBoostIndicator.setCompoundDrawablePadding(Utils.dpToPx(6));
-            speedBoostIndicator.setCompoundDrawableTintList(ColorStateList.valueOf(brandColor()));
-        }
+        speedBoostIconForward = ContextCompat.getDrawable(this, R.drawable.exo_icon_fastforward);
+        speedBoostIconRewind = ContextCompat.getDrawable(this, R.drawable.exo_icon_rewind);
+        final int speedBoostIconSize = Utils.dpToPx(18);
+        if (speedBoostIconForward != null)
+            speedBoostIconForward.setBounds(0, 0, speedBoostIconSize, speedBoostIconSize);
+        if (speedBoostIconRewind != null)
+            speedBoostIconRewind.setBounds(0, 0, speedBoostIconSize, speedBoostIconSize);
+        speedBoostIndicator.setCompoundDrawablesRelative(null, null, speedBoostIconForward, null);
+        speedBoostIndicator.setCompoundDrawablePadding(Utils.dpToPx(6));
+        speedBoostIndicator.setCompoundDrawableTintList(ColorStateList.valueOf(brandColor()));
 
         final GradientDrawable speedBoostBackground = new GradientDrawable();
         speedBoostBackground.setColor(Color.argb(0xF0, 0x16, 0x16, 0x16));
@@ -9865,6 +9869,17 @@ public class PlayerActivity extends Activity {
         if (mode.ratio > 0)
             return Math.abs(mode.ratio - currentAspectRatio) < 0.001f;
         return currentAspectRatio == 0 && playerView.getResizeMode() == mode.resizeMode;
+    }
+
+    // The arrows sit on the side the picture is travelling: after the rate going forward, before it
+    // going back.
+    public void setSpeedBoostIndicator(float speed, boolean rewind) {
+        if (speedBoostIndicator == null)
+            return;
+        speedBoostIndicator.setText(String.format(Locale.US, "%.1f×", speed));
+        speedBoostIndicator.setCompoundDrawablesRelative(rewind ? speedBoostIconRewind : null, null,
+                rewind ? null : speedBoostIconForward, null);
+        setSpeedBoostIndicatorVisible(true);
     }
 
     public void setSpeedBoostIndicatorVisible(boolean visible) {

--- a/app/src/main/java/com/brouken/player/Prefs.java
+++ b/app/src/main/java/com/brouken/player/Prefs.java
@@ -51,6 +51,7 @@ class Prefs {
     private static final String PREF_KEY_RESTORE_AUTO_ROTATE = "restoreAutoRotate";
     private static final String PREF_KEY_AUTO_PIP = "autoPiP";
     private static final String PREF_KEY_DISABLE_VOLUME_BRIGHTNESS_GESTURES = "disableVolumeBrightnessGestures";
+    private static final String PREF_KEY_HOLD_SPEED = "holdSpeed";
     private static final String PREF_KEY_TUNNELING = "tunneling";
     private static final String PREF_KEY_FRAMERATE_MATCHING = "frameRateMatching";
     private static final String PREF_KEY_ALLOW_SYSTEM_FRAMERATE = "allowSystemFrameRate";
@@ -135,6 +136,8 @@ class Prefs {
     public boolean autoPiP = false;
     // Off means the vertical swipes work as they always have; on takes them away entirely.
     public boolean disableVolumeBrightnessGestures = false;
+    // Off takes the whole hold gesture away: a long press on the picture then does nothing at all.
+    public boolean holdSpeed = true;
 
     public boolean tunneling = false;
     public boolean frameRateMatching = false;
@@ -262,6 +265,7 @@ class Prefs {
         autoPiP = mSharedPreferences.getBoolean(PREF_KEY_AUTO_PIP, autoPiP);
         disableVolumeBrightnessGestures = mSharedPreferences.getBoolean(
                 PREF_KEY_DISABLE_VOLUME_BRIGHTNESS_GESTURES, disableVolumeBrightnessGestures);
+        holdSpeed = mSharedPreferences.getBoolean(PREF_KEY_HOLD_SPEED, holdSpeed);
         tunneling = mSharedPreferences.getBoolean(PREF_KEY_TUNNELING, tunneling);
         frameRateMatching = mSharedPreferences.getBoolean(PREF_KEY_FRAMERATE_MATCHING, frameRateMatching);
         allowSystemFrameRate = mSharedPreferences.getBoolean(PREF_KEY_ALLOW_SYSTEM_FRAMERATE, !Utils.isTvBox(mContext));

--- a/app/src/main/java/com/brouken/player/SettingsActivity.java
+++ b/app/src/main/java/com/brouken/player/SettingsActivity.java
@@ -192,6 +192,11 @@ public class SettingsActivity extends AppCompatActivity {
                 // A remote has no swipes to give up, so there is nothing here to turn off.
                 preferenceDisableGestures.setVisible(false);
             }
+            Preference preferenceHoldSpeed = findPreference("holdSpeed");
+            if (preferenceHoldSpeed != null && Utils.isTvBox(getContext())) {
+                // Same reason: there is no finger to hold on the picture.
+                preferenceHoldSpeed.setVisible(false);
+            }
             ListPreference listPreferenceFileAccess = findPreference("fileAccess");
             if (listPreferenceFileAccess != null) {
                 List<String> entries = new ArrayList<>(Arrays.asList(getResources().getStringArray(R.array.file_access_entries)));

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -57,6 +57,9 @@
     <string name="pref_disable_volume_brightness_gestures">Отключить жесты громкости и яркости</string>
     <string name="pref_disable_volume_brightness_gestures_on">Свайпы вверх и вниз ничего не делают; перемотка, масштаб и кнопки громкости работают</string>
     <string name="pref_disable_volume_brightness_gestures_off">Проведите вверх или вниз, чтобы изменить яркость в левой части экрана и громкость в правой</string>
+    <string name="pref_hold_speed">Удержание для ускорения</string>
+    <string name="pref_hold_speed_on">Держите палец на видео для 2×, затем тяните вбок, чтобы менять скорость или перематывать назад</string>
+    <string name="pref_hold_speed_off">Удержание пальца на видео ничего не делает</string>
     <string name="pref_skip_header">Пропуск сегментов</string>
     <string name="pref_skip_enabled">Включено</string>
     <string name="pref_skip_enabled_on">Пропускать заставки и рекламные сегменты от запускающего приложения</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -58,6 +58,9 @@
     <string name="pref_disable_volume_brightness_gestures">Вимкнути жести гучності та яскравості</string>
     <string name="pref_disable_volume_brightness_gestures_on">Проведення вгору та вниз нічого не робить; перемотування, масштаб і кнопки гучності працюють</string>
     <string name="pref_disable_volume_brightness_gestures_off">Проведіть вгору або вниз, щоб змінити яскравість у лівій частині екрана та гучність у правій</string>
+    <string name="pref_hold_speed">Утримання для прискорення</string>
+    <string name="pref_hold_speed_on">Тримайте палець на відео для 2×, потім тягніть убік, щоб змінити швидкість або відмотати назад</string>
+    <string name="pref_hold_speed_off">Утримання пальця на відео нічого не робить</string>
     <string name="pref_skip_header">Пропуск сегментів</string>
     <string name="pref_skip_enabled">Увімкнено</string>
     <string name="pref_skip_enabled_on">Пропускати заставки та рекламні сегменти від застосунку</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -59,6 +59,9 @@
     <string name="pref_disable_volume_brightness_gestures">Turn off volume and brightness swipes</string>
     <string name="pref_disable_volume_brightness_gestures_on">Swiping up and down does nothing; seeking, zoom and the volume buttons still work</string>
     <string name="pref_disable_volume_brightness_gestures_off">Swipe up and down to change brightness on the left of the screen and volume on the right</string>
+    <string name="pref_hold_speed">Hold to speed up</string>
+    <string name="pref_hold_speed_on">Hold a finger on the video for 2×, then drag sideways to change the speed or rewind</string>
+    <string name="pref_hold_speed_off">Holding a finger on the video does nothing</string>
     <string name="pref_skip_header">Skip segments</string>
     <string name="pref_skip_enabled">Enabled</string>
     <string name="pref_skip_enabled_on">Skip intros and ad segments provided by the launching app</string>

--- a/app/src/main/res/xml/root_preferences.xml
+++ b/app/src/main/res/xml/root_preferences.xml
@@ -73,6 +73,13 @@
             app:title="@string/pref_disable_volume_brightness_gestures" />
 
         <SwitchPreferenceCompat
+            app:key="holdSpeed"
+            app:defaultValue="true"
+            app:summaryOn="@string/pref_hold_speed_on"
+            app:summaryOff="@string/pref_hold_speed_off"
+            app:title="@string/pref_hold_speed" />
+
+        <SwitchPreferenceCompat
             app:key="showStats"
             app:defaultValue="false"
             app:summaryOn="@string/pref_show_stats_on"


### PR DESCRIPTION
A long press on the picture still jumps to 2x, but the point it landed on is now the middle of an axis:

- every 40dp to the right adds 1.0x, up to 4.0x;
- to the left the rate counts down to 1.0x and then flips into rewind, which starts at 2.0x and grows the same way (a little hysteresis at the flip keeps a finger resting on the boundary from thrashing play/pause);
- releasing restores the speed that was in force before the hold and keeps the position the finger arrived at.

Nothing decodes backwards, so rewind pauses the player and walks it back at the held rate: one `PREVIOUS_SYNC` seek per 100 ms tick, issued only when the previous one has landed — the same in-flight gate the swipe-seek scrubs behind — and the progress bar is shown so the drag is not blind. The top pill reports the current rate and puts its arrows on the side the picture is travelling.

`GestureDetector` drops every move once it has fired a long press, so the drag is read straight from `onTouchEvent`; the seek and volume/brightness scrolls are untouched.

The whole gesture also gets a switch in the settings — on by default, hidden on TV — for anyone who would rather a long press did nothing at all.
