### PR TITLE
Shift subtitles against the picture, and show a found one without a restart

### DIFF
--- a/app/src/main/java/com/brouken/player/PlayerActivity.java
+++ b/app/src/main/java/com/brouken/player/PlayerActivity.java
@@ -43,6 +43,7 @@ import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
 import android.os.Handler;
+import android.os.Looper;
 import android.os.Parcelable;
 import android.os.SystemClock;
 import android.provider.DocumentsContract;
@@ -132,6 +133,7 @@ import androidx.media3.exoplayer.audio.ForwardingAudioSink;
 import androidx.media3.exoplayer.mediacodec.MediaCodecSelector;
 import androidx.media3.exoplayer.mediacodec.MediaCodecUtil;
 import androidx.media3.exoplayer.source.DefaultMediaSourceFactory;
+import androidx.media3.exoplayer.text.TextOutput;
 import androidx.media3.exoplayer.trackselection.DefaultTrackSelector;
 import androidx.media3.extractor.DefaultExtractorsFactory;
 import androidx.media3.extractor.text.DefaultSubtitleParserFactory;
@@ -519,6 +521,7 @@ public class PlayerActivity extends Activity {
     private android.app.Dialog qualityDialog;
     private android.app.Dialog playlistDialog;
     private android.app.Dialog skipOffsetDialog;
+    private android.app.Dialog subtitleOffsetDialog;
     private android.app.Dialog sleepTimerDialog;
     private android.app.Dialog menuDialog;
     // While a picker panel is open the app must stay out of immersive/fullscreen, otherwise OxygenOS/ColorOS
@@ -742,8 +745,17 @@ public class PlayerActivity extends Activity {
     // True once any skip segment has appeared this session; keeps the offset button available
     // afterwards even on an item that itself has no segments.
     private boolean skipSeenThisSession;
-    private static final double SKIP_OFFSET_MAX_SEC = 30;   // ± range of the offset slider
-    private static final double SKIP_OFFSET_STEP_SEC = 0.25; // fine step (± buttons / D-pad)
+    // Shared by the skip and the subtitle offset panel — one shape, one range.
+    private static final double OFFSET_MAX_SEC = 30;   // ± range of the offset slider
+    private static final double OFFSET_STEP_SEC = 0.25; // fine step (± buttons / D-pad)
+    // Subtitle timing offset (seconds, positive = subtitles later) — session-only like the skip offset
+    // above. Applied by SubtitleOffsetRenderer, which is rebuilt with the player and re-seeded from here.
+    private double subtitleOffsetSec = 0;
+    private SubtitleOffset subtitleOffset;
+    // The external subtitle file taken over from the renderer, and which URI it was read from. Parsed
+    // once per track choice on a worker; kept across player rebuilds, dropped with the media session.
+    private SubtitleTimeline subtitleTimeline;
+    private Uri subtitleTimelineUri;
     // Set before a reinitialisation that must not auto-play — a SOURCE switch, or any rebuild caused by
     // returning to the foreground (initializePlayer otherwise force-plays under apiAccess or at position
     // zero). Consumed once inside initializePlayer.
@@ -2947,6 +2959,16 @@ public class PlayerActivity extends Activity {
             skipOffsetDialog.dismiss();
         }
         updateSkipOffsetButton();
+        // Same for the subtitle offset: it was tuned against one file's timing and means nothing to the next.
+        applySubtitleOffset(0);
+        subtitleTimeline = null;
+        subtitleTimelineUri = null;
+        if (subtitleOffset != null) {
+            subtitleOffset.setTimeline(null);
+        }
+        if (subtitleOffsetDialog != null && subtitleOffsetDialog.isShowing()) {
+            subtitleOffsetDialog.dismiss();
+        }
         if (timeBar != null) {
             timeBar.clearSkipHighlights();
         }
@@ -3043,9 +3065,31 @@ public class PlayerActivity extends Activity {
         skipOffsetDialog = OffsetPanel.create(this, ui, coordinatorLayout,
                 brandColor(),   // coral, matches the skip timeline highlight
                 getString(R.string.skip_offset_title),
-                SKIP_OFFSET_MAX_SEC, SKIP_OFFSET_STEP_SEC, skipOffsetSec,
+                OFFSET_MAX_SEC, OFFSET_STEP_SEC, skipOffsetSec,
                 this::applySkipOffset);
         showPickerDialog(skipOffsetDialog);
+    }
+
+    /** Apply a new subtitle offset to the live text renderer (no reload, no reselection). */
+    private void applySubtitleOffset(double sec) {
+        subtitleOffsetSec = sec;
+        if (subtitleOffset != null) {
+            subtitleOffset.setOffsetSec(sec);
+        }
+    }
+
+    /** Session-only subtitle-offset panel — the same {@link OffsetPanel}, bound to the text renderer. */
+    private void showSubtitleOffsetDialog() {
+        if (player == null) {
+            return;
+        }
+        if (subtitleOffsetDialog != null) {
+            subtitleOffsetDialog.dismiss();
+        }
+        subtitleOffsetDialog = OffsetPanel.create(this, ui, coordinatorLayout, brandColor(),
+                getString(R.string.subtitle_offset_title),
+                OFFSET_MAX_SEC, OFFSET_STEP_SEC, subtitleOffsetSec, this::applySubtitleOffset);
+        showPickerDialog(subtitleOffsetDialog);
     }
 
     // Online skip-segment lookup (FIND_INTO.MD): when the current item has no intent-provided segments,
@@ -5805,6 +5849,95 @@ public class PlayerActivity extends Activity {
         showSideMenu(getString(R.string.subtitle_title), items);
     }
 
+    /**
+     * Hands the selected subtitle over to {@link SubtitleTimeline} when it is a file the app sideloaded,
+     * and back to the renderer when it is not (an embedded track, or subtitles off). Runs on every track
+     * change, so it has to be cheap when nothing moved — the file is read once per choice, on a worker.
+     */
+    private void updateSubtitleTimeline(Tracks tracks) {
+        final MediaItem.SubtitleConfiguration selected = selectedSideloadedSubtitle(tracks);
+        if (selected == null) {
+            subtitleTimeline = null;
+            subtitleTimelineUri = null;
+            if (subtitleOffset != null) {
+                subtitleOffset.setTimeline(null);
+            }
+            return;
+        }
+        if (selected.uri.equals(subtitleTimelineUri)) {
+            // Already read, or being read. A player rebuild brings a new SubtitleOffset, so re-hand it.
+            if (subtitleOffset != null && subtitleTimeline != null) {
+                subtitleOffset.setTimeline(subtitleTimeline);
+            }
+            return;
+        }
+        subtitleTimelineUri = selected.uri;
+        subtitleTimeline = null;
+        if (subtitleOffset != null) {
+            subtitleOffset.setTimeline(null);
+        }
+        final Uri uri = selected.uri;
+        final String mimeType = selected.mimeType;
+        final Thread worker = new Thread(() -> {
+            final SubtitleTimeline loaded = SubtitleTimeline.load(this, uri, mimeType);
+            runOnUiThread(() -> {
+                // Another track (or another media) was chosen while this was being read.
+                if (!uri.equals(subtitleTimelineUri)) {
+                    return;
+                }
+                subtitleTimeline = loaded;
+                if (subtitleOffset != null) {
+                    subtitleOffset.setTimeline(loaded);
+                }
+            });
+        }, "SubtitleTimeline");
+        worker.setDaemon(true);
+        worker.start();
+    }
+
+    /** The sideloaded subtitle currently selected, matched by the URI its track carries as its id. */
+    private MediaItem.SubtitleConfiguration selectedSideloadedSubtitle(Tracks tracks) {
+        if (player == null) {
+            return null;
+        }
+        final MediaItem item = player.getCurrentMediaItem();
+        if (item == null || item.localConfiguration == null
+                || item.localConfiguration.subtitleConfigurations.isEmpty()) {
+            return null;
+        }
+        for (final Tracks.Group group : tracks.getGroups()) {
+            if (group.getType() != C.TRACK_TYPE_TEXT) {
+                continue;
+            }
+            for (int i = 0; i < group.length; i++) {
+                if (!group.isTrackSelected(i)) {
+                    continue;
+                }
+                final String id = group.getTrackFormat(i).id;
+                for (final MediaItem.SubtitleConfiguration config : item.localConfiguration.subtitleConfigurations) {
+                    if (config.mimeType != null && carriesUri(id, config.uri)) {
+                        return config;
+                    }
+                }
+                return null; // selected, but embedded — the renderer keeps it
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Whether a track id is the one the app gave this sideloaded subtitle. The id it set is the URI
+     * (SubtitleUtils.buildSubtitle), but Media3 hands the track out prefixed with the index its source
+     * has in the merge — "1:file:///…" — so the URI is the tail of the id, not all of it.
+     */
+    private static boolean carriesUri(String formatId, Uri uri) {
+        if (formatId == null) {
+            return false;
+        }
+        final String text = uri.toString();
+        return formatId.equals(text) || formatId.endsWith(":" + text);
+    }
+
     private void disableSubtitles() {
         if (player == null) {
             return;
@@ -6059,7 +6192,16 @@ public class PlayerActivity extends Activity {
             }
         }
         if (buttonSkipOffset != null && buttonSkipOffset.getVisibility() == View.VISIBLE) {
-            items.add(new MenuItem(R.drawable.ic_skip_offset_24dp, getString(R.string.button_skip_offset), null, false, this::showSkipOffsetDialog));
+            items.add(new MenuItem(R.drawable.ic_skip_offset_24dp, getString(R.string.button_skip_offset),
+                    skipOffsetSec == 0 ? null : OffsetPanel.format(skipOffsetSec),
+                    false, this::showSkipOffsetDialog));
+        }
+        // Right below its twin. Only with subtitles on: there is nothing to shift otherwise.
+        if (player != null && player.getCurrentTracks().isTypeSelected(C.TRACK_TYPE_TEXT)) {
+            items.add(new MenuItem(R.drawable.ic_subtitle_offset_24dp,
+                    getString(R.string.subtitle_offset_title),
+                    subtitleOffsetSec == 0 ? null : OffsetPanel.format(subtitleOffsetSec),
+                    false, this::showSubtitleOffsetDialog));
         }
         // Only for network media: a room syncs one shared URL, and there is nothing to share about a
         // file that lives on this device alone.
@@ -7354,6 +7496,34 @@ public class PlayerActivity extends Activity {
                 audioSink = new AudioPassthroughDenylistSink(sink, revokedAudioMimes);
                 return audioSink;
             }
+
+            @Override
+            protected void buildTextRenderers(Context context, TextOutput output, Looper outputLooper,
+                                              int extensionRendererMode, ArrayList<Renderer> out) {
+                // The subtitle offset wraps the text renderer on both sides — its cue output and its
+                // clock (see SubtitleOffset). The list the base class appends to already holds the
+                // video/audio renderers, hence the index.
+                final SubtitleOffset offset = new SubtitleOffset(output, outputLooper,
+                        new SubtitleOffset.Position() {
+                            @Override
+                            public long currentMs() {
+                                return player == null ? C.TIME_UNSET : player.getCurrentPosition();
+                            }
+
+                            @Override
+                            public boolean playing() {
+                                return player != null && player.isPlaying();
+                            }
+                        });
+                offset.setOffsetSec(subtitleOffsetSec);
+                offset.setTimeline(subtitleTimeline);
+                subtitleOffset = offset;
+                final int first = out.size();
+                super.buildTextRenderers(context, offset, outputLooper, extensionRendererMode, out);
+                for (int i = first; i < out.size(); i++) {
+                    out.set(i, offset.wrap(out.get(i)));
+                }
+            }
         };
         @SuppressLint("WrongConstant") DefaultRenderersFactory renderersFactory = baseRenderersFactory
                 .setExtensionRendererMode(mPrefs.decoderPriority)
@@ -7883,6 +8053,10 @@ public class PlayerActivity extends Activity {
             skipOffsetDialog.dismiss();
             skipOffsetDialog = null;
         }
+        if (subtitleOffsetDialog != null) {
+            subtitleOffsetDialog.dismiss();
+            subtitleOffsetDialog = null;
+        }
         // Only the panel goes: this runs on a quality switch too, and an armed timer has to ride across that.
         if (sleepTimerDialog != null) {
             sleepTimerDialog.dismiss();
@@ -7955,6 +8129,10 @@ public class PlayerActivity extends Activity {
             // each skipped silence, and on internal live-window updates.
             if (oldPosition.mediaItemIndex != newPosition.mediaItemIndex) {
                 playerStartPositionMs = currentPeriodPositionMs();
+            }
+            // A delayed cue still waiting to be shown belongs to the moment it was read at, not to this one.
+            if (subtitleOffset != null) {
+                subtitleOffset.clear();
             }
             // The seek flushed the audio output, so the bitstream may need re-locking (see
             // audioRestartPending). Latched, not run here. Within one item only.
@@ -8084,6 +8262,7 @@ public class PlayerActivity extends Activity {
             if (playerView != null) {
                 playerView.post(PlayerActivity.this::updateSubtitleButton);
             }
+            updateSubtitleTimeline(tracks);
             // The track list is what decides whether anything is missing, so this is the first moment
             // the question can be asked at all.
             maybeSearchSubtitlesOnline(tracks);
@@ -8127,6 +8306,10 @@ public class PlayerActivity extends Activity {
         // playWhenReady survives both, and a latch armed there would be spent on whatever output comes next.
         @Override
         public void onIsPlayingChanged(boolean isPlaying) {
+            // Subtitles are painted off the media position, which only moves while this is true.
+            if (subtitleOffset != null) {
+                subtitleOffset.wake();
+            }
             if (isPlaying) {
                 playerView.removeCallbacks(rebufferArmRunnable);
                 audioRestartSettling = false;
@@ -9261,7 +9444,7 @@ public class PlayerActivity extends Activity {
 
     private void dismissOpenPickers() {
         final android.app.Dialog[] pickers = { qualityDialog, playlistDialog, skipOffsetDialog,
-                sleepTimerDialog, menuDialog };
+                subtitleOffsetDialog, sleepTimerDialog, menuDialog };
         for (final android.app.Dialog d : pickers) {
             if (d != null && d.isShowing()) {
                 d.dismiss();

--- a/app/src/main/java/com/brouken/player/PlayerActivity.java
+++ b/app/src/main/java/com/brouken/player/PlayerActivity.java
@@ -756,6 +756,13 @@ public class PlayerActivity extends Activity {
     // once per track choice on a worker; kept across player rebuilds, dropped with the media session.
     private SubtitleTimeline subtitleTimeline;
     private Uri subtitleTimelineUri;
+    // A subtitle shown without a track of its own, painted from the file by SubtitleOffset: attaching it
+    // as a track means re-preparing the player, which on an HTTP stream costs a re-open of the media and
+    // seconds of re-buffering — for a file the app found by itself, unasked, mid-playback.
+    // ponytail: switch a painted subtitle off and a later search that hits the disk cache can paint it
+    // again. Remembering "the viewer said no to this file" needs a second field; not worth it until
+    // someone hits it (subtitleSearchStarted and the miss TTL cover it in practice).
+    private Uri paintedSubtitleUri;
     // Set before a reinitialisation that must not auto-play — a SOURCE switch, or any rebuild caused by
     // returning to the foreground (initializePlayer otherwise force-plays under apiAccess or at position
     // zero). Consumed once inside initializePlayer.
@@ -2961,11 +2968,7 @@ public class PlayerActivity extends Activity {
         updateSkipOffsetButton();
         // Same for the subtitle offset: it was tuned against one file's timing and means nothing to the next.
         applySubtitleOffset(0);
-        subtitleTimeline = null;
-        subtitleTimelineUri = null;
-        if (subtitleOffset != null) {
-            subtitleOffset.setTimeline(null);
-        }
+        clearSubtitleTimeline();
         if (subtitleOffsetDialog != null && subtitleOffsetDialog.isShowing()) {
             subtitleOffsetDialog.dismiss();
         }
@@ -5409,17 +5412,17 @@ public class PlayerActivity extends Activity {
     // Media3 keeps the subtitle button visible-but-disabled while loading; we instead hide it entirely
     // until the media actually exposes subtitle tracks, matching the audio/quality buttons.
     /**
-     * Sideloads an external subtitle onto the item playing now, keeping the playlist and the position.
+     * Shows an external subtitle on the item playing now, without interrupting it. The file is parsed
+     * into a {@link SubtitleTimeline} and painted by {@link SubtitleOffset} straight to the player's text
+     * output — which is where a selected sideloaded subtitle already ends up for the offset to work — so
+     * the player never re-prepares: no re-open, no re-buffer, no gap in the sound, no reset progress bar.
+     * The track itself turns up on the next player rebuild, from {@code mPrefs.subtitleUri} (see
+     * {@link #rememberedSubtitle()}), so this state heals by itself.
      *
-     * <p>The timeline is rebuilt rather than the item replaced. With the media URI unchanged
-     * {@code replaceMediaItem} updates the item in place and never re-instantiates the source, so an
-     * added subtitle configuration is accepted and then silently ignored — the player reports no new
-     * text track at all. It is the same trap {@link #recoverFromContainerError()} documents for the mime
-     * type. {@code setMediaItems} with the whole list is what re-creates the merged source, and unlike
-     * {@code setMediaItem} it keeps the other episodes, their arrows and their remembered positions.
+     * <p>It also breaks a loop at its root: painting raises no track change, so the finder is not sent
+     * looking again by the very subtitle it just found.
      *
-     * <p>Doing nothing when the subtitle is already attached is what stops this from looping: the
-     * re-prepare produces another track change, which sends the finder looking again.
+     * @return whether this was a new subtitle, i.e. whether it is worth telling the viewer about
      */
     boolean addSubtitleTrack(Uri subtitleUri) {
         if (player == null || subtitleUri == null) {
@@ -5430,14 +5433,88 @@ public class PlayerActivity extends Activity {
         if (index < 0 || index >= count) {
             return false;
         }
+        // Already on screen: no second read of the file, and no second toast for it — a re-search that
+        // hits the cache asks for the same one again.
+        if (subtitleUri.equals(paintedSubtitleUri)) {
+            return false;
+        }
         final MediaItem current = player.getMediaItemAt(index);
         if (current.localConfiguration != null) {
             for (MediaItem.SubtitleConfiguration existing : current.localConfiguration.subtitleConfigurations) {
                 if (existing.uri.equals(subtitleUri)) {
-                    return false;
+                    return false; // a real track carries it: the renderer and the picker have it already
                 }
             }
-        } else {
+        }
+        paintSubtitle(subtitleUri);
+        return true;
+    }
+
+    /** Reads the file on a worker and hands it to {@link SubtitleOffset}; re-prepares only if it cannot. */
+    private void paintSubtitle(Uri uri) {
+        paintedSubtitleUri = uri;
+        subtitleTimelineUri = uri;
+        subtitleTimeline = null;
+        if (subtitleOffset != null) {
+            subtitleOffset.setTimeline(null);
+        }
+        final String mimeType = SubtitleUtils.getSubtitleMime(uri);
+        final Thread worker = new Thread(() -> {
+            final SubtitleTimeline loaded = SubtitleTimeline.load(this, uri, mimeType);
+            runOnUiThread(() -> {
+                if (!uri.equals(paintedSubtitleUri)) {
+                    return; // another file, another episode, or a rebuild got there first
+                }
+                if (loaded == null) {
+                    // Nothing to paint: no parser, no cue, or the read failed. Only the renderer can
+                    // show it now, and that costs the re-prepare this exists to avoid.
+                    paintedSubtitleUri = null;
+                    subtitleTimelineUri = null;
+                    attachSubtitleTrack(uri);
+                    return;
+                }
+                subtitleTimeline = loaded;
+                if (subtitleOffset != null) {
+                    subtitleOffset.setTimeline(loaded);
+                }
+                updateSubtitleButton(); // no track moved, so nothing else would
+            });
+        }, "SubtitleTimeline");
+        worker.setDaemon(true);
+        worker.start();
+    }
+
+    /**
+     * Sideloads an external subtitle as a real track, keeping the playlist and the position. The
+     * fallback for a file {@link SubtitleTimeline} cannot parse — everything else is painted instead
+     * (see {@link #addSubtitleTrack}), because this re-opens the media.
+     *
+     * <p>The timeline is rebuilt rather than the item replaced. With the media URI unchanged
+     * {@code replaceMediaItem} updates the item in place and never re-instantiates the source, so an
+     * added subtitle configuration is accepted and then silently ignored — the player reports no new
+     * text track at all. It is the same trap {@link #recoverFromContainerError()} documents for the mime
+     * type. {@code setMediaItems} with the whole list is what re-creates the merged source, and unlike
+     * {@code setMediaItem} it keeps the other episodes, their arrows and their remembered positions.
+     */
+    private void attachSubtitleTrack(Uri subtitleUri) {
+        if (player == null) {
+            return;
+        }
+        // Re-read rather than passed in: this runs a whole file read after the decision to attach.
+        final int index = player.getCurrentMediaItemIndex();
+        final int count = player.getMediaItemCount();
+        if (index < 0 || index >= count) {
+            return;
+        }
+        final MediaItem current = player.getMediaItemAt(index);
+        if (current.localConfiguration != null) {
+            for (MediaItem.SubtitleConfiguration existing : current.localConfiguration.subtitleConfigurations) {
+                if (existing.uri.equals(subtitleUri)) {
+                    // Doing nothing when it is already attached is what stops this from looping: the
+                    // re-prepare produces another track change, which sends the finder looking again.
+                    return;
+                }
+            }
         }
         final MediaItem updated =
                 withSubtitle(current, SubtitleUtils.buildSubtitle(this, subtitleUri, null, true));
@@ -5449,7 +5526,6 @@ public class PlayerActivity extends Activity {
         }
         player.setMediaItems(items, index, position);
         player.prepare();
-        return true;
     }
 
     /** The external subtitle remembered for this media, or null when there is nothing to restore. */
@@ -5474,8 +5550,9 @@ public class PlayerActivity extends Activity {
         if (exoSubtitle == null) {
             return;
         }
-        boolean hasSubtitles = false;
-        boolean textSelected = false;
+        // Seeded from a subtitle painted without a track of its own; the loop below can only add.
+        boolean hasSubtitles = subtitleWithoutTrack() != null;
+        boolean textSelected = paintedSubtitleUri != null;
         if (player != null) {
             for (Tracks.Group group : player.getCurrentTracks().getGroups()) {
                 if (group.getType() == C.TRACK_TYPE_TEXT
@@ -5489,6 +5566,11 @@ public class PlayerActivity extends Activity {
             }
         }
         exoSubtitle.setVisibility(hasSubtitles ? View.VISIBLE : View.GONE);
+        // Media3 owns this button too (it keeps the id it found) and disables it whenever the player
+        // reports no text track — which is exactly the case for a subtitle painted from its file. It
+        // dims the icon with the same alpha this helper applies, so setEnabled alone would leave a
+        // working button that still looks dead. The deferred post() this runs from gives us last word.
+        Utils.setButtonEnabled(this, exoSubtitle, hasSubtitles);
         // Light the CC icon coral while a subtitle track is actually showing.
         exoSubtitle.setSelected(textSelected);
     }
@@ -5820,8 +5902,19 @@ public class PlayerActivity extends Activity {
             return;
         }
         final boolean textEnabled = player.getCurrentTracks().isTypeSelected(C.TRACK_TYPE_TEXT);
+        // A subtitle painted from its file has no track here, so it needs a row of its own — otherwise
+        // it could never be switched off, and "off" would read as the choice while it is on screen.
+        final Uri fileOnly = subtitleWithoutTrack();
+        final boolean painting = paintedSubtitleUri != null;
         final List<MenuItem> items = new ArrayList<>();
-        items.add(new MenuItem(getString(R.string.subtitle_off), null, !textEnabled, this::disableSubtitles));
+        items.add(new MenuItem(getString(R.string.subtitle_off), null, !textEnabled && !painting,
+                this::disableSubtitles));
+        if (fileOnly != null) {
+            // addSubtitleTrack rather than paintSubtitle: it carries the already-on-screen guard, so
+            // tapping the ticked row costs nothing and tapping it after "off" puts the subtitle back.
+            items.add(new MenuItem(subtitleFileLabel(fileOnly), null, painting,
+                    () -> addSubtitleTrack(fileOnly)));
+        }
         int number = 0;
         for (Tracks.Group group : player.getCurrentTracks().getGroups()) {
             if (group.getType() != C.TRACK_TYPE_TEXT) {
@@ -5842,11 +5935,32 @@ public class PlayerActivity extends Activity {
                     label = getString(R.string.audio_track_number, number);
                 }
                 final int index = i;
-                items.add(new MenuItem(label, null, textEnabled && group.isTrackSelected(i),
+                // !painting: an embedded track can stay selected while the file is painted over it
+                // (SubtitleOffset drops the renderer's cues), and two ticked rows is a lie.
+                items.add(new MenuItem(label, null, textEnabled && !painting && group.isTrackSelected(i),
                         () -> applySubtitle(trackGroup, index)));
             }
         }
         showSideMenu(getString(R.string.subtitle_title), items);
+    }
+
+    /** Nothing is painted from a file any more: the renderer's own cues get through again. */
+    private void clearSubtitleTimeline() {
+        paintedSubtitleUri = null;
+        subtitleTimeline = null;
+        subtitleTimelineUri = null;
+        if (subtitleOffset != null) {
+            subtitleOffset.setTimeline(null);
+        }
+    }
+
+    /** Drops a subtitle that had no track of its own — the viewer just picked something else, or off. */
+    private void clearPaintedSubtitle() {
+        if (paintedSubtitleUri == null) {
+            return;
+        }
+        clearSubtitleTimeline();
+        updateSubtitleButton(); // no track moved, so nothing else would
     }
 
     /**
@@ -5857,10 +5971,11 @@ public class PlayerActivity extends Activity {
     private void updateSubtitleTimeline(Tracks tracks) {
         final MediaItem.SubtitleConfiguration selected = selectedSideloadedSubtitle(tracks);
         if (selected == null) {
-            subtitleTimeline = null;
-            subtitleTimelineUri = null;
-            if (subtitleOffset != null) {
-                subtitleOffset.setTimeline(null);
+            // A painted subtitle has no track to be "selected", and this runs on every track change —
+            // an audio pick, an HLS variant switch. Reading that absence as "nothing to show" is what
+            // would wipe it off the screen.
+            if (paintedSubtitleUri == null) {
+                clearSubtitleTimeline();
             }
             return;
         }
@@ -5938,10 +6053,40 @@ public class PlayerActivity extends Activity {
         return formatId.equals(text) || formatId.endsWith(":" + text);
     }
 
+    /**
+     * The remembered external subtitle when the player carries no track for it — the one that is
+     * painted, or can be. This is what keeps it in the picker after the viewer switches it off: without
+     * a track of its own it would otherwise take the CC button with it and become unreachable.
+     */
+    private Uri subtitleWithoutTrack() {
+        final Uri uri = mPrefs.subtitleUri;
+        if (uri == null || player == null) {
+            return null;
+        }
+        final MediaItem item = player.getCurrentMediaItem();
+        if (item != null && item.localConfiguration != null) {
+            for (final MediaItem.SubtitleConfiguration config : item.localConfiguration.subtitleConfigurations) {
+                if (config.uri.equals(uri)) {
+                    return null; // the item carries it, so the renderer and the picker do too
+                }
+            }
+        }
+        return uri;
+    }
+
+    /** What a file with no track is called in the picker — the name its track would have carried. */
+    private String subtitleFileLabel(Uri uri) {
+        // Media3 normalises a track language before it reaches Format.language; a file name is raw.
+        final String language =
+                languageDisplayName(Util.normalizeLanguageCode(SubtitleUtils.getSubtitleLanguage(uri)));
+        return language != null ? language : Utils.getFileName(this, uri);
+    }
+
     private void disableSubtitles() {
         if (player == null) {
             return;
         }
+        clearPaintedSubtitle();
         player.setTrackSelectionParameters(player.getTrackSelectionParameters().buildUpon()
                 .clearOverridesOfType(C.TRACK_TYPE_TEXT)
                 .setTrackTypeDisabled(C.TRACK_TYPE_TEXT, true)
@@ -5952,6 +6097,9 @@ public class PlayerActivity extends Activity {
         if (player == null || group == null) {
             return;
         }
+        // Without this the picked track would show nothing: SubtitleOffset drops the renderer's cues
+        // for as long as a file is painted.
+        clearPaintedSubtitle();
         player.setTrackSelectionParameters(player.getTrackSelectionParameters().buildUpon()
                 .clearOverridesOfType(C.TRACK_TYPE_TEXT)
                 .setTrackTypeDisabled(C.TRACK_TYPE_TEXT, false)
@@ -6196,8 +6344,10 @@ public class PlayerActivity extends Activity {
                     skipOffsetSec == 0 ? null : OffsetPanel.format(skipOffsetSec),
                     false, this::showSkipOffsetDialog));
         }
-        // Right below its twin. Only with subtitles on: there is nothing to shift otherwise.
-        if (player != null && player.getCurrentTracks().isTypeSelected(C.TRACK_TYPE_TEXT)) {
+        // Right below its twin. Only with subtitles on: there is nothing to shift otherwise. A painted
+        // file counts — it is the case SubtitleTimeline was built for — and selects no track.
+        if (player != null && (player.getCurrentTracks().isTypeSelected(C.TRACK_TYPE_TEXT)
+                || paintedSubtitleUri != null)) {
             items.add(new MenuItem(R.drawable.ic_subtitle_offset_24dp,
                     getString(R.string.subtitle_offset_title),
                     subtitleOffsetSec == 0 ? null : OffsetPanel.format(subtitleOffsetSec),
@@ -7901,7 +8051,11 @@ public class PlayerActivity extends Activity {
                     rememberEpisodePosition(player.getCurrentMediaItemIndex(), position);
                 }
                 mPrefs.updateMeta(getSelectedTrack(C.TRACK_TYPE_AUDIO),
-                        getSelectedTrack(C.TRACK_TYPE_TEXT),
+                        // A painted subtitle is on screen with no track selected, so getSelectedTrack
+                        // answers "#none" — which reads back as "the viewer chose off" and disables the
+                        // very track the next rebuild restores from mPrefs.subtitleUri. Null means no
+                        // choice recorded, letting that track's DEFAULT flag select it as a fresh open does.
+                        paintedSubtitleUri != null ? null : getSelectedTrack(C.TRACK_TYPE_TEXT),
                         playerView.getResizeMode(),
                         playerView.getVideoSurfaceView().getScaleX(),
                         currentAspectRatio,
@@ -8028,6 +8182,12 @@ public class PlayerActivity extends Activity {
         stopSkipPolling();
         cancelSegmentFinder();
         cancelSubtitleSearch();
+        // The paint had no track behind it; the rebuild puts the file back as a real one
+        // (rememberedSubtitle). Deliberately not clearSubtitleTimeline(): the parsed timeline has to
+        // survive so initializePlayer can seed the new SubtitleOffset with it, and updateSubtitleTimeline
+        // recognises it by subtitleTimelineUri and re-hands the same object — no re-read, no blank gap.
+        // After the savePlayer() above, which still needs to see the flag.
+        paintedSubtitleUri = null;
         hideSkipPill();
         skipBuilt = false;
         if (timeBar != null) {
@@ -8183,9 +8343,12 @@ public class PlayerActivity extends Activity {
             // The remembered external subtitle belonged to the item that just ended: it was downloaded
             // or picked for that episode, and the next rebuild would put it back — minutes out of sync
             // with what is playing now. PLAYLIST_CHANGED is excluded because that is the transition
-            // addSubtitleTrack() itself causes, and clearing there would undo the attach that raised it.
+            // attachSubtitleTrack() itself causes, and clearing there would undo the attach that raised it.
             if (reason != Player.MEDIA_ITEM_TRANSITION_REASON_PLAYLIST_CHANGED) {
                 mPrefs.updateSubtitle(null);
+                // Painting is not tied to a track, so nothing else would stop the previous episode's
+                // subtitles from being drawn over this one.
+                clearSubtitleTimeline();
                 cancelSubtitleSearch();
             }
             // The new item opens its own audio output; a restart latched on the old one must not tear it down.

--- a/app/src/main/java/com/brouken/player/SubtitleOffset.java
+++ b/app/src/main/java/com/brouken/player/SubtitleOffset.java
@@ -1,0 +1,223 @@
+package com.brouken.player;
+
+import android.os.Handler;
+import android.os.Looper;
+
+import androidx.media3.common.C;
+import androidx.media3.common.text.Cue;
+import androidx.media3.common.text.CueGroup;
+import androidx.media3.exoplayer.ExoPlaybackException;
+import androidx.media3.exoplayer.ForwardingRenderer;
+import androidx.media3.exoplayer.Renderer;
+import androidx.media3.exoplayer.text.TextOutput;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * The subtitle timing offset (positive = subtitles later). Media3 has no such setting and re-timing the
+ * subtitle file would mean reloading the media at every step of the slider, so it is done around the
+ * text renderer, in two halves that both live here:
+ * <ul>
+ *   <li><b>Earlier</b> (negative offset): the renderer runs on a clock shifted <em>forward</em>, so it
+ *       resolves the cue for a moment that has not arrived on screen yet.
+ *   <li><b>Later</b> (positive offset): the renderer keeps the true clock, and every cue group it emits
+ *       is held here until the media position reaches the cue's own time plus the offset.
+ * </ul>
+ * The renderer's clock is never shifted <em>backwards</em>, which is what a delay would naively do: a
+ * text renderer consumes each cue once and drops it, so asking it for an earlier moment shows nothing
+ * at all until the clock has caught back up.
+ * <p>
+ * Groups are therefore kept for {@link #HISTORY_MS} after they have been shown, which is what makes the
+ * panel answer at once: raising the delay by 10 s has to put back on screen the line from 10 s ago, and
+ * then play the lines after it in order — subtitles no one kept cannot be re-timed.
+ * <p>
+ * All of that is the fallback, and even it cannot answer for the first moments after a jump forward —
+ * those lines were never read at all. An external subtitle file is therefore taken over outright: given
+ * a {@link SubtitleTimeline}, the renderer's cues are dropped and the screen is painted from the file
+ * itself at {@code position - offset}. That is exact in both directions, at any offset, from the first
+ * frame after any seek. Tracks embedded in the media have no such timeline and keep the fallback.
+ * <p>
+ * Every deadline is measured in media time rather than on a real-time timer, so a pause holds with it, a
+ * seek lands where it should and playback speed does not stretch the offset.
+ */
+final class SubtitleOffset implements TextOutput {
+
+    /** Where the media position comes from — the player does not exist yet when this is built. */
+    interface Position {
+        /**
+         * Position within the current item in ms, the same clock {@link CueGroup#presentationTimeUs} is
+         * on, or {@link C#TIME_UNSET} when there is no player to ask.
+         */
+        long currentMs();
+
+        /** Whether that position is moving on its own — when it is not, nothing needs repainting. */
+        boolean playing();
+    }
+
+    private static final long TICK_MS = 50; // resolution of the hold, far below what an eye can catch
+    private static final long HISTORY_MS = 32_000; // the panel's ±30 s, and room to spare
+
+    private final TextOutput output;
+    private final Position position;
+    private final Handler handler;
+    private final List<CueGroup> groups = new ArrayList<>(); // as they arrived, oldest first
+    private final Runnable release = this::release;
+    /** Index of the first group not passed on yet; everything before it is history. */
+    private int next;
+    /** The whole subtitle file, when the selected track is one we can hold. Read on the playback thread. */
+    private volatile SubtitleTimeline timeline;
+    /** Blocks of {@link #timeline} currently on screen, or null when what is on screen is unknown. */
+    private int[] painted;
+
+    // Written on the app thread as the panel moves, read on the playback thread by the renderer half.
+    private volatile double offsetSec;
+
+    SubtitleOffset(TextOutput output, Looper outputLooper, Position position) {
+        this.output = output;
+        this.position = position;
+        this.handler = new Handler(outputLooper);
+    }
+
+    /** The text renderer, wrapped so a negative offset can shift its clock. */
+    Renderer wrap(Renderer textRenderer) {
+        return new OffsetRenderer(textRenderer);
+    }
+
+    /**
+     * Takes the selected track over from the renderer, or hands it back with {@code null}. Cheap to call
+     * with what is already set — every track change comes through here.
+     */
+    void setTimeline(SubtitleTimeline timeline) {
+        final boolean same = this.timeline == timeline;
+        this.timeline = timeline;
+        if (!same) {
+            groups.clear();
+            next = 0;
+            painted = null;
+        }
+        release();
+    }
+
+    /** The position started or stopped moving: pick the painting back up, or let it stop. */
+    void wake() {
+        release();
+    }
+
+    void setOffsetSec(double sec) {
+        offsetSec = sec;
+        final long nowMs = position.currentMs();
+        // A larger delay moves groups that were already shown back into the future: hand them out again
+        // from wherever they now belong, so the panel takes effect on this line and not in ten seconds.
+        while (next > 0 && dueMs(groups.get(next - 1)) > nowMs) {
+            next--;
+        }
+        release();
+    }
+
+    /** Drops everything — after a seek or an item change it all belongs to another moment. */
+    void clear() {
+        handler.removeCallbacks(release);
+        groups.clear();
+        next = 0;
+        painted = null;
+        release();
+    }
+
+    @Override
+    public void onCues(CueGroup cueGroup) {
+        if (timeline != null) {
+            return; // the file itself is the source now, and it holds more than the renderer has left
+        }
+        groups.add(cueGroup);
+        release();
+    }
+
+    @Override
+    public void onCues(List<Cue> cues) {
+        // Dropped on purpose: the renderer sends this deprecated form immediately before the group it
+        // belongs to, and release() re-sends the pair in the same order once the group is due.
+    }
+
+    /** Paints from the file, or passes on every held group whose moment has come. */
+    private void release() {
+        handler.removeCallbacks(release);
+        final long nowMs = position.currentMs();
+        final SubtitleTimeline own = timeline;
+        if (own != null) {
+            if (nowMs != C.TIME_UNSET) {
+                paint(own, nowMs);
+            }
+            if (position.playing()) {
+                handler.postDelayed(release, TICK_MS);
+            }
+            return;
+        }
+        // At zero or below there is nothing to hold back: the renderer's own clock has already placed the
+        // cue, and passing it straight through keeps that timing exactly as it resolved it.
+        final long dueBy = (offsetSec <= 0 || nowMs == C.TIME_UNSET) ? Long.MAX_VALUE : nowMs;
+        while (next < groups.size() && dueMs(groups.get(next)) <= dueBy) {
+            final CueGroup group = groups.get(next++);
+            output.onCues(group.cues);
+            output.onCues(group);
+        }
+        if (next < groups.size()) {
+            handler.postDelayed(release, TICK_MS);
+        }
+        int stale = 0;
+        while (stale < next && nowMs != C.TIME_UNSET
+                && groups.get(stale).presentationTimeUs / 1000 < nowMs - HISTORY_MS) {
+            stale++;
+        }
+        groups.subList(0, stale).clear();
+        next -= stale;
+    }
+
+    /** What belongs on screen at this moment, sent on only when it is not there already. */
+    private void paint(SubtitleTimeline timeline, long nowMs) {
+        final long nowUs = nowMs * 1000;
+        final int[] visible = timeline.visibleAt(nowUs - (long) (offsetSec * C.MICROS_PER_SECOND));
+        if (Arrays.equals(visible, painted)) {
+            return;
+        }
+        painted = visible;
+        final CueGroup group = new CueGroup(timeline.cuesOf(visible), nowUs);
+        output.onCues(group.cues);
+        output.onCues(group);
+    }
+
+    private long dueMs(CueGroup group) {
+        return group.presentationTimeUs / 1000 + (long) (offsetSec * 1000);
+    }
+
+    private final class OffsetRenderer extends ForwardingRenderer {
+
+        OffsetRenderer(Renderer textRenderer) {
+            super(textRenderer);
+        }
+
+        @Override
+        public void render(long positionUs, long elapsedRealtimeUs) throws ExoPlaybackException {
+            // Nothing to shift while the file is in charge: its cues are dropped in onCues anyway.
+            final double sec = timeline != null ? 0 : offsetSec;
+            // ponytail: read ahead of what is buffered and there is simply no cue yet, so a subtitle can
+            // lag behind on a slow stream; and right after a seek the reading starts at the seek point,
+            // so the first moments carry no cue. Both settle by themselves as playback goes on.
+            super.render(sec < 0 ? positionUs - (long) (sec * C.MICROS_PER_SECOND) : positionUs,
+                    elapsedRealtimeUs);
+        }
+
+        @Override
+        public boolean isEnded() {
+            // Wrapped, the delegate is no longer the `instanceof TextRenderer` the player looks for when
+            // it hands a text renderer its hard stream-end position — the one thing that ends a text
+            // renderer whose track stops short of the media. Without it playback could sit at the end
+            // without ever reaching STATE_ENDED (no post-playback action, no auto-next), so: ended once
+            // the stream is read out and the player has declared it final. Cues keep coming — the
+            // delegate is not told — and every renderer must be ended before playback is, so the picture
+            // still decides when the item is over.
+            return super.isEnded() || (isCurrentStreamFinal() && hasReadStreamToEnd());
+        }
+    }
+}

--- a/app/src/main/java/com/brouken/player/SubtitleTimeline.java
+++ b/app/src/main/java/com/brouken/player/SubtitleTimeline.java
@@ -1,0 +1,147 @@
+package com.brouken.player;
+
+import android.content.Context;
+import android.net.Uri;
+
+import androidx.media3.common.C;
+import androidx.media3.common.Format;
+import androidx.media3.common.text.Cue;
+import androidx.media3.datasource.DataSource;
+import androidx.media3.datasource.DataSourceUtil;
+import androidx.media3.datasource.DataSpec;
+import androidx.media3.datasource.DefaultDataSource;
+import androidx.media3.extractor.text.CuesWithTiming;
+import androidx.media3.extractor.text.DefaultSubtitleParserFactory;
+import androidx.media3.extractor.text.SubtitleParser;
+
+import com.google.common.collect.ImmutableList;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Every cue of one external subtitle file, held in memory and addressable by time.
+ * <p>
+ * This is what lets the subtitle offset work in both directions and survive a seek. The player's text
+ * renderer reads its stream strictly forward and drops each cue once it has been shown, so it can never
+ * answer for a moment that has already gone by — and a delay is precisely a question about the past.
+ * A jump forward is the same problem: the lines between the new position and the delay behind it were
+ * skipped, and nothing can hand them back. With the file itself in memory, any moment is one lookup
+ * away and the offset is applied by simply looking somewhere else.
+ * <p>
+ * Only sideloaded files can be held this way (a subtitle the app added itself, whose track carries its
+ * URI as the format id — see {@link SubtitleUtils#buildSubtitle}). Tracks embedded in the media stay on
+ * the renderer, where {@link SubtitleOffset} still delays their cues as best it can.
+ * <p>
+ * The bytes are read through the same data source and parsed by the same Media3 parser the player would
+ * have used, so what ends up on screen is what the renderer would have produced, only re-timed. The app
+ * has already re-encoded anything that was not UTF-8 by the time the track exists (Utils.convertInputStreamToUTF).
+ */
+final class SubtitleTimeline {
+
+    private static final int[] NONE = new int[0];
+    /** Shown for this long when a cue carries no duration and nothing follows it. */
+    private static final long OPEN_ENDED_US = 5 * C.MICROS_PER_SECOND;
+
+    private final long[] startUs;
+    private final long[] endUs;
+    private final List<ImmutableList<Cue>> cues;
+
+    private SubtitleTimeline(long[] startUs, long[] endUs, List<ImmutableList<Cue>> cues) {
+        this.startUs = startUs;
+        this.endUs = endUs;
+        this.cues = cues;
+    }
+
+    /**
+     * Reads and parses the whole file. Null when Media3 has no parser for it, when it holds no cue, or
+     * when reading fails — the caller then leaves the track to the renderer.
+     */
+    static SubtitleTimeline load(Context context, Uri uri, String mimeType) {
+        try {
+            final Format format = new Format.Builder().setSampleMimeType(mimeType).build();
+            final SubtitleParser.Factory factory = new DefaultSubtitleParserFactory();
+            if (!factory.supportsFormat(format)) {
+                return null;
+            }
+            final DataSource source = new DefaultDataSource.Factory(context).createDataSource();
+            final byte[] data;
+            try {
+                source.open(new DataSpec(uri));
+                data = DataSourceUtil.readToEnd(source);
+            } finally {
+                DataSourceUtil.closeQuietly(source);
+            }
+            final List<CuesWithTiming> blocks = new ArrayList<>();
+            factory.create(format).parse(data, SubtitleParser.OutputOptions.allCues(), blocks::add);
+            final List<CuesWithTiming> ordered = new ArrayList<>(blocks.size());
+            for (final CuesWithTiming block : blocks) {
+                if (block.startTimeUs != C.TIME_UNSET && !block.cues.isEmpty()) {
+                    ordered.add(block);
+                }
+            }
+            if (ordered.isEmpty()) {
+                return null;
+            }
+            // ASS dialogue lines are not required to be in order, and the lookup below counts on it.
+            Collections.sort(ordered, (a, b) -> Long.compare(a.startTimeUs, b.startTimeUs));
+            final int count = ordered.size();
+            final long[] startUs = new long[count];
+            final long[] endUs = new long[count];
+            final List<ImmutableList<Cue>> cues = new ArrayList<>(count);
+            for (int i = 0; i < count; i++) {
+                final CuesWithTiming block = ordered.get(i);
+                startUs[i] = block.startTimeUs;
+                endUs[i] = block.durationUs != C.TIME_UNSET && block.durationUs > 0
+                        ? block.startTimeUs + block.durationUs
+                        : (i + 1 < count ? ordered.get(i + 1).startTimeUs : block.startTimeUs + OPEN_ENDED_US);
+                cues.add(block.cues);
+            }
+            return new SubtitleTimeline(startUs, endUs, cues);
+        } catch (Throwable t) {
+            // A subtitle is not worth a broken playback: the renderer keeps the track either way.
+            Utils.log("subtitles: timeline failed " + t);
+            return null;
+        }
+    }
+
+    /** Indices of the blocks on screen at this moment, ascending; empty when there is nothing to show. */
+    int[] visibleAt(long timeUs) {
+        int count = 0;
+        int[] found = null;
+        // ponytail: a plain scan that stops at the first cue starting later. A two-hour file is a few
+        // thousand entries and this runs a few times a second — a binary search is worth it only if that
+        // ever shows up in a profile.
+        for (int i = 0; i < startUs.length && startUs[i] <= timeUs; i++) {
+            if (timeUs < endUs[i]) {
+                if (found == null) {
+                    found = new int[4];
+                } else if (count == found.length) {
+                    found = Arrays.copyOf(found, count * 2);
+                }
+                found[count++] = i;
+            }
+        }
+        if (count == 0) {
+            return NONE;
+        }
+        return count == found.length ? found : Arrays.copyOf(found, count);
+    }
+
+    /** The cues of those blocks, in file order — overlapping lines (ASS) all show, as they should. */
+    ImmutableList<Cue> cuesOf(int[] indices) {
+        if (indices.length == 0) {
+            return ImmutableList.of();
+        }
+        if (indices.length == 1) {
+            return cues.get(indices[0]);
+        }
+        final ImmutableList.Builder<Cue> all = ImmutableList.builder();
+        for (final int index : indices) {
+            all.addAll(cues.get(index));
+        }
+        return all.build();
+    }
+}

--- a/app/src/main/res/drawable/ic_subtitle_offset_24dp.xml
+++ b/app/src/main/res/drawable/ic_subtitle_offset_24dp.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:pathData="M20,4H4C2.9,4 2,4.9 2,6v12c0,1.1 0.9,2 2,2h16c1.1,0 2,-0.9 2,-2V6C22,4.9 21.1,4 20,4zM20,18H4V6h16V18zM6,10h2v2H6V10zM6,14h8v2H6V14zM16,14h2v2h-2V14zM10,10h8v2h-8V10z" />
+</vector>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -163,6 +163,7 @@
     <string name="audio_title">Аудиодорожка</string>
     <string name="subtitle_title">Субтитры</string>
     <string name="subtitle_off">Выключены</string>
+    <string name="subtitle_offset_title">Смещение субтитров</string>
     <string name="speed_title">Скорость воспроизведения</string>
     <string name="speed_normal">Обычная</string>
     <string name="audio_track_number">Дорожка %1$d</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -170,6 +170,7 @@
     <string name="audio_title">Аудіодоріжка</string>
     <string name="subtitle_title">Субтитри</string>
     <string name="subtitle_off">Вимкнено</string>
+    <string name="subtitle_offset_title">Зміщення субтитрів</string>
     <string name="speed_title">Швидкість відтворення</string>
     <string name="speed_normal">Звичайна</string>
     <string name="audio_track_number">Доріжка %1$d</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -186,6 +186,7 @@
     <string name="audio_title">Audio track</string>
     <string name="subtitle_title">Subtitles</string>
     <string name="subtitle_off">Off</string>
+    <string name="subtitle_offset_title">Subtitle offset</string>
     <string name="speed_title">Playback speed</string>
     <string name="speed_normal">Normal</string>
     <string name="audio_track_number">Track %1$d</string>


### PR DESCRIPTION
Two commits, both about external subtitles. The second one needs the machinery the first one introduces, so they travel together.

## Shift subtitles against the picture

A timing offset for subtitles (positive = later), which Media3 has no setting for. Re-timing the file itself would mean reloading the media at every step of the slider, so it is done around the text renderer instead:

- **earlier** — the renderer runs on a clock shifted forward, so it resolves the cue for a moment that has not arrived on screen yet;
- **later** — the renderer keeps the true clock and every cue group it emits is held until the media position reaches the cue's own time plus the offset.

The renderer's clock is never shifted backwards, which is what a delay would naively do: a text renderer consumes each cue once and drops it, so asking it for an earlier moment shows nothing until the clock has caught back up. Groups are therefore kept for a little over the panel's ±30 s, which is what makes the panel answer at once instead of in ten seconds.

Even that cannot answer for the first moments after a jump forward — those lines were never read at all. So an external subtitle file is taken over outright: `SubtitleTimeline` holds every cue of the file in memory and `SubtitleOffset` paints the screen from the file itself at `position - offset`. Exact in both directions, at any offset, from the first frame after any seek. Tracks embedded in the media have no such timeline and keep the fallback.

Every deadline is measured in media time rather than on a real-time timer, so a pause holds with it, a seek lands where it should and playback speed does not stretch the offset.

## Show a found subtitle without restarting playback

A subtitle the app finds by itself arrives mid-playback, and attaching it as a track meant `setMediaItems()` + `prepare()`: the merged source is re-instantiated, so the media is re-opened. On an HTTP stream that is a new connection and a range request from the current position — a black frame, a spinner, a gap in the sound and a progress bar back at zero, seconds long, for something nobody asked for. Media3 offers no way around it: `replaceMediaItem` mutates the item in place and never re-creates the source, so the added subtitle configuration is silently ignored.

The file is now parsed into a `SubtitleTimeline` and painted by `SubtitleOffset` straight to the player's text output — where a selected sideloaded subtitle already ends up for the offset to work — so the player is not touched at all. It also breaks a loop at its root: painting raises no track change, so the finder is no longer sent looking again by the very subtitle it just found. The old path stays as the fallback for a file no parser can read, and the track itself turns up on the next player rebuild from the remembered URI, so the state heals by itself.

Everything that read the track list needed a word for a subtitle that has none:

- the CC button — Media3 owns it too and both disables and dims it while the player reports no text track, so it is re-enabled through the same helper the other controls use;
- the picker — the file gets a row of its own, otherwise it could never be switched off and "off" would read as the current choice while subtitles are on screen;
- the offset panel — a painted file is exactly the case `SubtitleTimeline` was built for;
- `savePlayer()` — it must not record `"#none"` while painting, which reads back as "the viewer chose off" and would disable the very track the next rebuild restores.

## Checked on a phone (CPH2447, Android 15)

Progressive HTTP media with no Ukrainian subtitles, auto-search on, cache cleared beforehand. The search answers and the subtitle appears:

```
10:51:30.331  subtitles: tt14688458 / 125988 s1e5 want=[ukr, rus, eng]
10:51:30.544  subtitles: restOpenSubtitles has 1 ukr of 1
10:51:30.761  subtitles: stremio has 1 ukr of 70
10:51:35.298  subtitles: tt14688458 / 125988 s1e6 want=[ukr, rus, eng]
```

Opening the media shows what re-instantiating the source looks like — `MediaCodec.release` at `10:51:29.765`, then video and audio adapters created at `10:51:30.491` and `.563`. Both subtitle attachments after that (one per episode) produced **no `MediaCodec.release` and no decoder creation at all**; picture and sound never broke. The `~AudioTrack` entries in between are the existing `audioRestartPending` path after seeks.

Also checked: media with no text tracks whatsoever (painting with a renderer that was never enabled), the picker showing exactly one ticked row named by the file's language, switching it off and back on, and Home → back (`onPause` → `savePlayer`) leaving `subtitleTrackId` absent from the preferences rather than `"#none"`.
