### PR TITLE
Let a session decide how its segments are skipped

### DIFF
--- a/app/src/main/java/com/brouken/player/OffsetPanel.java
+++ b/app/src/main/java/com/brouken/player/OffsetPanel.java
@@ -2,12 +2,16 @@ package com.brouken.player;
 
 import android.app.Activity;
 import android.app.Dialog;
+import android.content.Context;
 import android.content.res.ColorStateList;
 import android.graphics.Color;
 import android.graphics.Typeface;
 import android.graphics.drawable.ColorDrawable;
+import android.graphics.drawable.Drawable;
 import android.graphics.drawable.GradientDrawable;
 import android.graphics.drawable.RippleDrawable;
+import android.graphics.drawable.StateListDrawable;
+import android.util.StateSet;
 import android.util.TypedValue;
 import android.view.Gravity;
 import android.view.View;
@@ -19,6 +23,10 @@ import android.widget.ScrollView;
 import android.widget.SeekBar;
 import android.widget.TextView;
 
+import androidx.core.view.ViewCompat;
+import androidx.core.widget.TextViewCompat;
+
+import java.text.DecimalFormatSymbols;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
@@ -35,7 +43,9 @@ import java.util.Locale;
  * Input is split by device idiom, because one step size cannot serve both: a finger crossing the
  * narrow phone panel covers the whole ± range, so a raw drag moves the value in ragged sub-second
  * hops. Dragging therefore snaps to whole seconds, while the fine {@code stepSec} stays reachable
- * through the ± buttons (touch) and the D-pad (TV).
+ * through the ± buttons. A remote gets the coarse step instead: a focused {@code SeekBar} answers
+ * left and right itself, so the ± buttons beside it cannot be reached by a D-pad at all — the step
+ * a press moves is sized for that in {@link #addLine}.
  *
  * The panel owns the current values and reports every change through {@link Listener}; the caller
  * only holds the returned dialog so it can dismiss it.
@@ -60,6 +70,44 @@ final class OffsetPanel {
         }
     }
 
+    /**
+     * One thing the panel picks rather than nudges: a row of pills, the one in force lit.
+     *
+     * <p>It lives in this panel and not in a menu of its own because what is being picked and what is
+     * being nudged are one thing to the person watching — how this film's skips behave. Pills rather
+     * than a list: four short words fit across the panel, and a choice that shows all of its options at
+     * once is one press to change from a remote as well as from a finger. No caption: the panel's title
+     * already says what is being chosen, and a third label in the same style as the two below it turned
+     * the panel into a list of look-alikes.
+     */
+    static final class Choice {
+
+        interface Picked {
+            /** @param value the chosen option, or null to go back to following the settings */
+            void onPicked(String value);
+        }
+
+        private final CharSequence[] labels;
+        private final String[] values;
+        private final String current;
+        private final String inherited;
+        private final Picked listener;
+
+        /**
+         * @param current   what is in force, lit; null lights nothing (the settings disagree with
+         *                  themselves and no choice has been made yet)
+         * @param inherited what the settings say, lit again when the panel is reset; may be null
+         */
+        Choice(final CharSequence[] labels, final String[] values, final String current,
+               final String inherited, final Picked listener) {
+            this.labels = labels;
+            this.values = values;
+            this.current = current;
+            this.inherited = inherited;
+            this.listener = listener;
+        }
+    }
+
     private OffsetPanel() {
     }
 
@@ -70,30 +118,50 @@ final class OffsetPanel {
     static Dialog create(final Activity activity, final UiMetrics ui, final View insetSource,
                          final int accent, final String title, final double maxSec,
                          final double stepSec, final Line... lines) {
+        return create(activity, ui, insetSource, accent, title, maxSec, stepSec, null, lines);
+    }
+
+    /**
+     * @param choices picked rather than nudged, drawn above the sliders; null or empty for none
+     */
+    static Dialog create(final Activity activity, final UiMetrics ui, final View insetSource,
+                         final int accent, final String title, final double maxSec,
+                         final double stepSec, final Choice[] choices, final Line... lines) {
         final LinearLayout root = new LinearLayout(activity);
         root.setOrientation(LinearLayout.VERTICAL);
 
         final TextView header = new TextView(activity);
         header.setText(title);
+        ViewCompat.setAccessibilityHeading(header, true);
         header.setTextColor(Color.WHITE);
         header.setTextSize(TypedValue.COMPLEX_UNIT_SP, ui.textTitle());
         header.setTypeface(Typeface.DEFAULT_BOLD);
-        header.setPadding(0, 0, 0, Utils.dpToPx(14));
+        // Space, not a rule: the hairline that used to sit here had a caption under it, and once the
+        // caption went it landed a few pixels above the row of pills and read as their top border.
+        header.setPadding(0, 0, 0, Utils.dpToPx(20));
         root.addView(header);
 
-        final View divider = new View(activity);
-        divider.setLayoutParams(new LinearLayout.LayoutParams(
-                ViewGroup.LayoutParams.MATCH_PARENT, Utils.dpToPx(1)));
-        divider.setBackgroundColor(0x1AFFFFFF);
-        root.addView(divider);
-
         final List<Runnable> resets = new ArrayList<>();
+        final boolean picking = choices != null && choices.length > 0;
+        TextView firstPill = null;
+        if (picking) {
+            for (final Choice choice : choices) {
+                final TextView lit = addChoice(activity, ui, root, accent, choice, resets);
+                if (firstPill == null) {
+                    firstPill = lit;
+                }
+            }
+        }
+
         SeekBar firstBar = null;
         // One value gets the big readout it was designed for; two share the height, so they take the
         // clock's size instead. Two 44sp numbers plus their sliders do not fit a phone held sideways,
         // and what fell off the bottom was the second slider — the panel looked like it could only
         // shift the first line.
-        final float valueSp = lines.length > 1 ? ui.textClock() : ui.textValue();
+        // A choice row costs the same room as a second slider, so the readout gives up the same height
+        // for it. At the full size the panel did not fit its own window: the title was pushed off the
+        // top and the reset pill off the bottom.
+        final float valueSp = lines.length > 1 || picking ? ui.textClock() : ui.textValue();
         for (final Line line : lines) {
             root.addView(verticalSpacer(activity));
             final SeekBar bar = addLine(activity, ui, root, accent, line, maxSec, stepSec, valueSp, resets);
@@ -112,6 +180,7 @@ final class OffsetPanel {
         reset.setClickable(true);
         reset.setFocusable(true);
         reset.setPadding(Utils.dpToPx(28), Utils.dpToPx(11), Utils.dpToPx(28), Utils.dpToPx(11));
+        reset.setMinHeight(ui.dpS(48)); // a pill this small is missed as often as it is hit
         final GradientDrawable resetContent = new GradientDrawable();
         resetContent.setCornerRadius(Utils.dpToPx(22));
         resetContent.setColor(0x1AFFFFFF);
@@ -144,6 +213,8 @@ final class OffsetPanel {
 
         final Dialog dialog = new Dialog(activity, android.R.style.Theme_Translucent_NoTitleBar);
         dialog.setContentView(scroller);
+        // The theme carries no title bar, so this is the only name a screen reader can announce.
+        dialog.setTitle(title);
         dialog.setCanceledOnTouchOutside(true);
         final Window window = dialog.getWindow();
         if (window != null) {
@@ -154,11 +225,135 @@ final class OffsetPanel {
             window.setGravity(Gravity.END);
             window.setBackgroundDrawable(new ColorDrawable(0xF0141414));
         }
-        if (firstBar != null) {
-            final SeekBar focus = firstBar;
+        // The choice, not the slider: it is the panel's first decision and it is at the top, so a
+        // remote lands on it and the scroller stays where the title is. Focusing the slider scrolled
+        // the panel to its own bottom the moment it opened.
+        final View focus = firstPill != null ? firstPill : firstBar;
+        if (focus != null) {
             focus.post(focus::requestFocus);
         }
         return dialog;
+    }
+
+    /**
+     * A row of pills for one choice, the one in force lit — and lit means the brightest thing in the
+     * row, not a tinted version of it.
+     *
+     * <p>That is the whole of the second attempt at this row. The first drew the option in force as the
+     * accent at a third of its alpha with accent text, which measured 1.1:1 against its neighbours and
+     * read as the one option that had been switched off. Filled with the accent and lettered in the
+     * panel's own near-black, it is unmistakable, it carries the same colour the readouts use for "you
+     * changed this", and {@code setSelected} says the same thing again to a screen reader — which no
+     * amount of colour can.
+     *
+     * @return the pill to hand the first focus to
+     */
+    private static TextView addChoice(final Activity activity, final UiMetrics ui,
+                                      final LinearLayout root, final int accent, final Choice choice,
+                                      final List<Runnable> resets) {
+        final int corner = Utils.dpToPx(16);
+        final LinearLayout row = new LinearLayout(activity);
+        row.setOrientation(LinearLayout.HORIZONTAL);
+        final TextView[] pills = new TextView[choice.values.length];
+        final int[] picked = {indexOf(choice.values, choice.current)};
+        final Runnable render = () -> {
+            for (int i = 0; i < pills.length; i++) {
+                final boolean on = i == picked[0];
+                pills[i].setBackground(new RippleDrawable(ColorStateList.valueOf(0x40FFFFFF),
+                        pillFill(accent, on, corner), roundMask(corner)));
+                pills[i].setTextColor(on ? 0xFF141414 : 0xB3FFFFFF);
+                pills[i].setTypeface(on ? Typeface.DEFAULT_BOLD : Typeface.DEFAULT);
+                // Said again without colour, for a screen reader and for anyone who cannot tell these
+                // two shades apart.
+                pills[i].setSelected(on);
+            }
+        };
+        for (int i = 0; i < choice.values.length; i++) {
+            final TextView pill = new TextView(activity);
+            pill.setText(choice.labels[i]);
+            pill.setGravity(Gravity.CENTER);
+            pill.setClickable(true);
+            pill.setFocusable(true);
+            pill.setMaxLines(1);
+            // Shrunk rather than wrapped or clipped: the widest label already fills its share of the
+            // row at the ordinary size, so a longer language or a system font a notch up used to break
+            // one word across two lines and leave the row ragged.
+            TextViewCompat.setAutoSizeTextTypeUniformWithConfiguration(
+                    pill, (int) ui.textAction() - 4, (int) ui.textAction(), 1,
+                    TypedValue.COMPLEX_UNIT_SP);
+            pill.setPadding(ui.dpS(4), ui.dpS(12), ui.dpS(4), ui.dpS(12));
+            pill.setMinHeight(ui.dpS(48)); // the platform's floor for anything a finger has to hit
+            // Equal shares of the row rather than each pill's own width: four words of different
+            // lengths read as a set this way, and the widest of them decides nothing.
+            final LinearLayout.LayoutParams lp = new LinearLayout.LayoutParams(
+                    0, ViewGroup.LayoutParams.MATCH_PARENT, 1f);
+            // Gaps between the pills only: an outer margin here would set the row in from the title
+            // above it by the width of the gap, which is exactly the misalignment it looks like.
+            lp.leftMargin = i == 0 ? 0 : Utils.dpToPx(3);
+            lp.rightMargin = i == choice.values.length - 1 ? 0 : Utils.dpToPx(3);
+            pill.setLayoutParams(lp);
+            final int index = i;
+            pill.setOnClickListener(v -> {
+                if (picked[0] == index) {
+                    return;
+                }
+                picked[0] = index;
+                render.run();
+                choice.listener.onPicked(choice.values[index]);
+            });
+            // The same focus the Skip pill grows by, because this panel is used from a remote across a
+            // room, where a ripple is not a focus indicator. The white edge is in pillFill.
+            pill.setOnFocusChangeListener((v, hasFocus) -> v.animate()
+                    .scaleX(hasFocus ? 1.06f : 1f).scaleY(hasFocus ? 1.06f : 1f)
+                    .setDuration(150).start());
+            pills[i] = pill;
+            row.addView(pill);
+        }
+        render.run();
+        root.addView(row);
+        resets.add(() -> {
+            // Back to whatever the settings say, which is what "reset" means for a panel that only ever
+            // held this session's answers. Without it there was no way back from a choice at all.
+            picked[0] = indexOf(choice.values, choice.inherited);
+            render.run();
+            choice.listener.onPicked(null);
+        });
+        return pills[Math.max(0, picked[0])];
+    }
+
+    private static int indexOf(final String[] values, final String value) {
+        for (int i = 0; value != null && i < values.length; i++) {
+            if (values[i].equals(value)) {
+                return i;
+            }
+        }
+        return -1; // nothing lit: the panel is not going to guess which one is in force
+    }
+
+    /** Pill background: filled with the accent while in force, and edged in white while focused. */
+    private static Drawable pillFill(final int accent, final boolean on, final int corner) {
+        final StateListDrawable states = new StateListDrawable();
+        states.addState(new int[]{android.R.attr.state_focused}, pillShape(accent, on, corner, true));
+        states.addState(StateSet.WILD_CARD, pillShape(accent, on, corner, false));
+        return states;
+    }
+
+    private static Drawable pillShape(final int accent, final boolean on, final int corner,
+                                      final boolean focused) {
+        final GradientDrawable shape = new GradientDrawable();
+        shape.setCornerRadius(corner);
+        shape.setColor(on ? accent : 0x14FFFFFF);
+        if (focused) {
+            shape.setStroke(Utils.dpToPx(2), Color.WHITE);
+        }
+        return shape;
+    }
+
+    private static Drawable roundMask(final int corner) {
+        final GradientDrawable mask = new GradientDrawable();
+        mask.setCornerRadius(corner);
+        mask.setColor(Color.WHITE);
+        return mask;
     }
 
     /** Caption, readout and slider for one offset. Returns its SeekBar; adds its reset to {@code resets}. */
@@ -178,7 +373,11 @@ final class OffsetPanel {
             caption.setTextColor(0xB3FFFFFF);
             caption.setTextSize(TypedValue.COMPLEX_UNIT_SP, ui.textAction());
             caption.setGravity(Gravity.CENTER);
-            caption.setPadding(0, 0, 0, Utils.dpToPx(4));
+            // Asymmetric on purpose, and fixed rather than left to the weighted spacers: a caption
+            // belongs to what is under it, and the block above it needs a gap that does not vanish
+            // when the panel fills up. The spacers only share out what is left over — when there is
+            // nothing left over they collapse to nothing and two blocks end up touching.
+            caption.setPadding(0, ui.dpS(28), 0, Utils.dpToPx(4));
             root.addView(caption);
         }
 
@@ -223,11 +422,18 @@ final class OffsetPanel {
         row.addView(minus);
         row.addView(seekBar);
         row.addView(plus);
+        // Optical alignment: each ± button is a 24dp glyph in 12dp of its own padding, so the row is
+        // pulled out by that padding. What lines up with the title and the pills is the glyph.
+        final LinearLayout.LayoutParams rowLp = new LinearLayout.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT);
+        rowLp.leftMargin = -Utils.dpToPx(12);
+        rowLp.rightMargin = -Utils.dpToPx(12);
+        row.setLayoutParams(rowLp);
         root.addView(row);
 
         // Readout: accent when non-zero, white at rest.
         final Runnable render = () -> {
-            value.setText(format(current[0]));
+            value.setText(format(activity, current[0]));
             value.setTextColor(isZero(current[0]) ? Color.WHITE : accent);
         };
         render.run();
@@ -288,23 +494,31 @@ final class OffsetPanel {
         return Math.abs(sec) < 0.001;
     }
 
-    /** "0 s" / "+2.5 s" / "-10 s" — signed, trailing zeros trimmed. */
-    static String format(double sec) {
-        if (isZero(sec)) {
-            return "0 s";
-        }
-        String s = String.format(Locale.US, "%+.2f", sec);
-        if (s.indexOf('.') >= 0) { // trim trailing zeros: "+2.50" -> "+2.5", "+3.00" -> "+3"
-            int end = s.length();
-            while (end > 0 && s.charAt(end - 1) == '0') {
+    /**
+     * "0 s" / "+2.5 s" / "-10 s" — signed, trailing zeros trimmed, and in the viewer's own language.
+     *
+     * <p>Both halves used to be English: the unit was a literal {@code " s"} and the number was
+     * formatted against {@code Locale.US}, so a Ukrainian panel read "0 s" two rows under a Ukrainian
+     * caption and printed "+2.5" where the language writes "+2,5".
+     */
+    static String format(final Context context, final double sec) {
+        final Locale locale = Locale.getDefault();
+        String number = "0";
+        if (!isZero(sec)) {
+            number = String.format(locale, "%+.2f", sec);
+            // Trim trailing zeros: "+2,50" -> "+2,5", "+3,00" -> "+3". Against the locale's own
+            // separator, which is not a dot everywhere this app is read.
+            final char point = DecimalFormatSymbols.getInstance(locale).getDecimalSeparator();
+            int end = number.length();
+            while (end > 0 && number.charAt(end - 1) == '0') {
                 end--;
             }
-            if (end > 0 && s.charAt(end - 1) == '.') {
+            if (end > 0 && number.charAt(end - 1) == point) {
                 end--;
             }
-            s = s.substring(0, end);
+            number = number.substring(0, end);
         }
-        return s + " s";
+        return context.getString(R.string.offset_seconds, number);
     }
 
     private static View verticalSpacer(Activity activity) {

--- a/app/src/main/java/com/brouken/player/PlayerActivity.java
+++ b/app/src/main/java/com/brouken/player/PlayerActivity.java
@@ -772,6 +772,12 @@ public class PlayerActivity extends Activity {
     // Skip-segment timing offset (seconds) — in-session only, never persisted; applies to all
     // playlist items and is reset on a new media session (resetApiAccess).
     private double skipOffsetSec = 0;
+    // How this session offers segments, or null to follow the settings. One value for both kinds,
+    // because the viewer mid-film holds one intention and not two — "stop interrupting me in this
+    // series" — and two rows of it were two rows of the same answer. Same life as the offset above and
+    // set from the same panel: a series that matches the same way in every episode is a session, not a
+    // change of mind about every film after it.
+    private String skipModeSession;
     // True once any skip segment has appeared this session; keeps the offset button available
     // afterwards even on an item that itself has no segments.
     private boolean skipSeenThisSession;
@@ -1252,7 +1258,7 @@ public class PlayerActivity extends Activity {
         buttonSkipOffset = new ImageButton(this, null, 0, R.style.ExoStyledControls_Button_Bottom);
         buttonSkipOffset.setImageResource(R.drawable.ic_skip_offset_24dp);
         buttonSkipOffset.setId(View.generateViewId());
-        buttonSkipOffset.setContentDescription(getString(R.string.button_skip_offset));
+        buttonSkipOffset.setContentDescription(getString(R.string.skip_session_title));
         buttonSkipOffset.setVisibility(View.GONE);
         buttonSkipOffset.setOnClickListener(view -> showSkipOffsetDialog());
 
@@ -1575,6 +1581,18 @@ public class PlayerActivity extends Activity {
         // stretched to full width inside the CoordinatorLayout and pinned the pill to the left edge — is gone.
         // Modern TV focus: a coral ring on the pill (state-driven stroke) plus a slight scale-up, replacing
         // the dated flat grey selectableItemBackground wash.
+        buttonSkip.setOnLongClickListener(v -> {
+            // The panel from the one place where the question comes up by itself: the segment is on
+            // screen, this is the button that would be pressed for it, and holding it says "do this
+            // yourself from now on" without going looking for anywhere. The offset button in the bottom
+            // bar opens the same panel for when there is no button to hold — after the mode has been set
+            // to automatic, chiefly.
+            if (PlayerActivity.locked) {
+                return false;
+            }
+            showSkipOffsetDialog();
+            return true;
+        });
         buttonSkip.setOnFocusChangeListener((v, hasFocus) -> {
             skipPillFill.setStroke(hasFocus ? skipRingWidth : 0, brandColor());
             final float scale = hasFocus ? 1.06f : 1f;
@@ -3074,8 +3092,11 @@ public class PlayerActivity extends Activity {
         cancelSegmentFinder();
         cancelSubtitleSearch();
         hideSkipButton();
-        // Skip offset is session-scoped: a new media session resets it and hides its control.
+        // The offset and the session's skip modes go the same way, and "session" here is the film rather
+        // than the player: the next file in the folder keeps both, which is the whole point of them,
+        // while a film picked afresh starts from the settings again.
         skipOffsetSec = 0;
+        skipModeSession = null;
         skipSeenThisSession = false;
         if (skipOffsetDialog != null && skipOffsetDialog.isShowing()) {
             skipOffsetDialog.dismiss();
@@ -3182,7 +3203,62 @@ public class PlayerActivity extends Activity {
         rebuildSkip();
     }
 
-    /** Session-only skip-offset panel — the shared {@link OffsetPanel} bound to {@link #skipOffsetSec}. */
+    /** The four ways a segment can be offered, as the session panel lists them, with their labels. */
+    private static final String[] SKIP_MODE_VALUES = {
+            Prefs.SKIP_MODE_BRIEF, Prefs.SKIP_MODE_BUTTON, Prefs.SKIP_MODE_AUTO, Prefs.SKIP_MODE_OFF };
+    private static final int[] SKIP_MODE_LABELS = {
+            R.string.skip_mode_brief_short, R.string.skip_mode_button_short,
+            R.string.skip_mode_auto_short, R.string.skip_mode_off_short };
+
+    /**
+     * Whether this film has anything the session could be asked about: a segment somebody might be
+     * offered. Ads are skipped silently whatever anyone says, so a file carrying only those gets the
+     * offset and nothing else.
+     */
+    private boolean hasSkipSegment() {
+        if (skipManager == null) {
+            return false;
+        }
+        for (final SkipSegment segment : skipManager.getSegments()) {
+            if (segment.type != SkipSegment.Type.AD) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * The session's row: the four ways a segment can be offered, the one in force lit.
+     *
+     * <p>Nothing is lit in the one case where there is no single answer to light — the settings ask for
+     * one thing at the start of an episode and another at its end, and this session has not been told
+     * otherwise. Lighting either of them would be a claim about the other.
+     */
+    private OffsetPanel.Choice skipModeChoice() {
+        final CharSequence[] labels = new CharSequence[SKIP_MODE_VALUES.length];
+        for (int i = 0; i < labels.length; i++) {
+            labels[i] = getString(SKIP_MODE_LABELS[i]);
+        }
+        final String settings = mPrefs.skipMode.equals(mPrefs.skipModeCredits) ? mPrefs.skipMode : null;
+        return new OffsetPanel.Choice(labels, SKIP_MODE_VALUES,
+                skipModeSession != null ? skipModeSession : settings, settings,
+                this::setSessionSkipMode);
+    }
+
+    /**
+     * Everything this session's skipping is, in one panel: how each kind of segment is offered, and how
+     * far the marks are shifted. Both are the session's and neither is written to the preferences —
+     * which is what makes this the right place for them and the settings screen the wrong one. A series
+     * matches the same way in every episode, and that is a fact about the series, not about the player.
+     *
+     * <p>One row for both kinds of segment, not one each: asked what they want mid-film, the answer is
+     * "stop interrupting me in this series" rather than two separate policies for the start of an
+     * episode and its end. The settings keep the two apart for anyone who does want that.
+     *
+     * <p>Reached by holding the Skip button, where the question arises, and from the bottom bar for when
+     * there is no button to hold. Its reset clears both halves — the choice goes back to following the
+     * settings and the offset to zero — because everything in here belongs to this session only.
+     */
     private void showSkipOffsetDialog() {
         if (player == null) {
             return;
@@ -3190,10 +3266,14 @@ public class PlayerActivity extends Activity {
         if (skipOffsetDialog != null) {
             skipOffsetDialog.dismiss();
         }
+        final OffsetPanel.Choice[] choices = hasSkipSegment()
+                ? new OffsetPanel.Choice[]{ skipModeChoice() } : new OffsetPanel.Choice[0];
         skipOffsetDialog = OffsetPanel.create(this, ui, coordinatorLayout,
                 brandColor(),   // coral, matches the skip timeline highlight
-                getString(R.string.skip_offset_title), OFFSET_MAX_SEC, OFFSET_STEP_SEC,
-                new OffsetPanel.Line(null, skipOffsetSec, this::applySkipOffset));
+                getString(R.string.skip_session_title), OFFSET_MAX_SEC, OFFSET_STEP_SEC, choices,
+                // Captioned only while it shares the panel with the row above it; alone it is the panel.
+                new OffsetPanel.Line(choices.length == 0 ? null : getString(R.string.skip_offset_title),
+                        skipOffsetSec, this::applySkipOffset));
         showPickerDialog(skipOffsetDialog);
     }
 
@@ -3270,17 +3350,17 @@ public class PlayerActivity extends Activity {
      */
     private String subtitleOffsetSummary() {
         if (!secondaryOffsetShiftable()) {
-            return subtitleOffsetSec == 0 ? null : OffsetPanel.format(subtitleOffsetSec);
+            return subtitleOffsetSec == 0 ? null : OffsetPanel.format(this, subtitleOffsetSec);
         }
         if (!subtitleOffsetShiftable()) {
             return secondarySubtitleOffsetSec == 0
-                    ? null : OffsetPanel.format(secondarySubtitleOffsetSec);
+                    ? null : OffsetPanel.format(this, secondarySubtitleOffsetSec);
         }
         if (subtitleOffsetSec == 0 && secondarySubtitleOffsetSec == 0) {
             return null;
         }
-        return OffsetPanel.format(subtitleOffsetSec) + " · "
-                + OffsetPanel.format(secondarySubtitleOffsetSec);
+        return OffsetPanel.format(this, subtitleOffsetSec) + " · "
+                + OffsetPanel.format(this, secondarySubtitleOffsetSec);
     }
 
     // Online skip-segment lookup (FIND_INTO.MD): when the current item has no intent-provided segments,
@@ -3625,7 +3705,7 @@ public class PlayerActivity extends Activity {
             // (see SKIP_LEAD_SEC): as the Skip button when the user is asked, as the pill when the jump
             // is automatic and there is no button to offer.
             final SkipSegment upcoming = skipManager.upcomingSegment(posSec, SKIP_LEAD_SEC);
-            if (upcoming == null || autoSkipUndone(posSec)) {
+            if (upcoming == null || isSkipOff(upcoming) || autoSkipUndone(posSec)) {
                 hideSkipButton();
                 hideSkipHeadsUp();
             } else if (isAutoSkip(upcoming)) {
@@ -3643,6 +3723,12 @@ public class PlayerActivity extends Activity {
                 updateSkipButtonProgress(upcoming);
                 showSkipButton(upcoming);
             }
+            return;
+        }
+        if (isSkipOff(segment)) {
+            // Left alone for this session: no button and no jump. The highlight on the time bar stays —
+            // the segment is still there, it is only nobody's business to act on it.
+            hideSkipButton();
             return;
         }
         if (isAutoSkip(segment) && !autoSkipUndone(posSec)) {
@@ -3666,7 +3752,43 @@ public class PlayerActivity extends Activity {
         if (segment.type == SkipSegment.Type.AD) {
             return true;
         }
-        return Prefs.SKIP_MODE_AUTO.equals(segment.credits ? mPrefs.skipModeCredits : mPrefs.skipMode);
+        return Prefs.SKIP_MODE_AUTO.equals(effectiveSkipMode(segment.credits));
+    }
+
+    /**
+     * How segments of this kind are offered right now: what the skip panel was told for this session, or
+     * the setting where it was told nothing. Credits carry their own answer, as they do in the settings.
+     *
+     * <p>The one place either is read, so a session's choice cannot apply to one half of the machinery
+     * and not the other — which is what happened while the mode was read straight off the preferences in
+     * two places and the panel had to know about both.
+     */
+    private String effectiveSkipMode(final boolean credits) {
+        if (skipModeSession != null) {
+            return skipModeSession;
+        }
+        return credits ? mPrefs.skipModeCredits : mPrefs.skipMode;
+    }
+
+    /**
+     * Whether this session has been told to leave this kind of segment alone — the mirror of asking for
+     * automatic skips, and the reason the panel offers both: a series whose intro is found in the wrong
+     * place is this session's problem, not a reason to change the setting for every film after it. Ads
+     * are nobody's choice.
+     */
+    private boolean isSkipOff(final SkipSegment segment) {
+        return segment.type != SkipSegment.Type.AD
+                && Prefs.SKIP_MODE_OFF.equals(effectiveSkipMode(segment.credits));
+    }
+
+    /**
+     * Takes the session's choice, or gives it back with {@code null} — which is what the panel's reset
+     * does, leaving the settings in charge again. Nothing is written to the preferences, and the segment
+     * on screen follows the new answer at once rather than at the next one.
+     */
+    private void setSessionSkipMode(final String mode) {
+        skipModeSession = mode;
+        skipTick();
     }
 
     /**
@@ -3989,7 +4111,7 @@ public class PlayerActivity extends Activity {
 
     /** Whether this segment's position is set to offer the Skip button briefly rather than throughout. */
     private boolean isBriefSkip(SkipSegment segment) {
-        return Prefs.SKIP_MODE_BRIEF.equals(segment.credits ? mPrefs.skipModeCredits : mPrefs.skipMode);
+        return Prefs.SKIP_MODE_BRIEF.equals(effectiveSkipMode(segment.credits));
     }
 
     /** True while brief mode's timed offer is on screen and owns the pill. */
@@ -8386,8 +8508,10 @@ public class PlayerActivity extends Activity {
                     false, this::showSubtitleOffsetDialog));
         }
         if (skipOffsetReachable()) {
-            items.add(new MenuItem(R.drawable.ic_skip_offset_24dp, getString(R.string.button_skip_offset),
-                    skipOffsetSec == 0 ? null : OffsetPanel.format(skipOffsetSec),
+            // Named after the panel it opens, which is no longer only the offset: the row that said
+            // "Skip offset" now leads to how each kind of segment is offered as well.
+            items.add(new MenuItem(R.drawable.ic_skip_offset_24dp, getString(R.string.skip_session_title),
+                    skipOffsetSec == 0 ? null : OffsetPanel.format(this, skipOffsetSec),
                     false, this::showSkipOffsetDialog));
         }
         if (player != null) {

--- a/app/src/main/java/com/brouken/player/Prefs.java
+++ b/app/src/main/java/com/brouken/player/Prefs.java
@@ -125,6 +125,12 @@ class Prefs {
     public static final String SKIP_MODE_BRIEF = "brief";
     public static final String SKIP_MODE_BUTTON = "button";
     public static final String SKIP_MODE_AUTO = "auto";
+    /**
+     * Offer nothing: the session's mute for segments. Only ever a choice made in the player's skip
+     * panel — deliberately not in the settings list, where switching skipping off is a switch for the
+     * whole feature rather than one film's worth of it.
+     */
+    public static final String SKIP_MODE_OFF = "off";
 
     // Which skips offer the "go back" pill afterwards.
     // When the online subtitle search runs. One choice, because the two switches this replaced were

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -82,7 +82,12 @@
     <string name="pref_skip_hide_locked_off">Кнопка «Пропустить» и уведомление об автопропуске остаются видимыми, пока экран заблокирован</string>
     <string name="skip_offset_title">Смещение пропуска</string>
     <string name="skip_offset_reset">Сбросить</string>
-    <string name="button_skip_offset">Смещение пропуска</string>
+    <string name="offset_seconds">%1$s с</string>
+    <string name="skip_session_title">Пропуски в этом сеансе</string>
+    <string name="skip_mode_brief_short">5 с</string>
+    <string name="skip_mode_button_short">Кнопка</string>
+    <string name="skip_mode_auto_short">Авто</string>
+    <string name="skip_mode_off_short">Никогда</string>
     <string name="button_skip">Пропустить</string>
     <string name="button_skip_countdown">Пропустить %1$d</string>
     <string name="notification_skipped">Пропущено</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -83,7 +83,12 @@
     <string name="pref_skip_hide_locked_off">Кнопка «Пропустити» та сповіщення про автопропуск лишаються видимими, поки екран заблоковано</string>
     <string name="skip_offset_title">Зміщення пропуску</string>
     <string name="skip_offset_reset">Скинути</string>
-    <string name="button_skip_offset">Зміщення пропуску</string>
+    <string name="offset_seconds">%1$s с</string>
+    <string name="skip_session_title">Пропуски в цьому сеансі</string>
+    <string name="skip_mode_brief_short">5 с</string>
+    <string name="skip_mode_button_short">Кнопка</string>
+    <string name="skip_mode_auto_short">Авто</string>
+    <string name="skip_mode_off_short">Ніколи</string>
     <string name="button_skip">Пропустити</string>
     <string name="button_skip_countdown">Пропустити %1$d</string>
     <string name="notification_skipped">Пропущено</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -84,7 +84,17 @@
     <string name="pref_skip_hide_locked_off">The Skip button and auto-skip notification remain visible while the screen is locked</string>
     <string name="skip_offset_title">Skip offset</string>
     <string name="skip_offset_reset">Reset</string>
-    <string name="button_skip_offset">Skip offset</string>
+    <!-- Offset readout and summaries: the number is formatted in the viewer's locale, the unit
+         belongs to the language. -->
+    <string name="offset_seconds">%1$s s</string>
+    <!-- The player's skip panel: a mode per kind of segment for this session only, plus the offset.
+         Short labels because four of them share the width of the panel; the settings screen is where
+         each mode is spelled out in full. -->
+    <string name="skip_session_title">Skips in this session</string>
+    <string name="skip_mode_brief_short">5 s</string>
+    <string name="skip_mode_button_short">Button</string>
+    <string name="skip_mode_auto_short">Auto</string>
+    <string name="skip_mode_off_short">Never</string>
     <string name="button_skip">Skip</string>
     <string name="button_skip_countdown">Skip %1$d</string>
     <string name="notification_skipped">Skipped</string>


### PR DESCRIPTION
Skip modes were global only, so a series whose episodes all match the same way meant pressing Skip every episode or changing the setting for every film after it. The player's skip panel now carries the session's own answer beside the offset it already held.

**One row, four options, both kinds of segment.** The button for five seconds · the button for the whole segment · skip silently · leave the segments alone. Asked mid-film the intention is "stop interrupting me in this series", not one policy for the start of an episode and another for its end — the settings keep those apart for anyone who wants that. Nothing is written to the preferences.

| | lives until | set from |
|---|---|---|
| session mode | a film is picked afresh (the next file in the folder keeps it) | the skip panel |
| skip offset | unchanged — the same scope it already had | the skip panel |

Reset now gives both halves back to the settings, which was the one thing there was no way to do at all. The panel is reached by holding the Skip pill, where the question arises, and from the playback-menu row, renamed after the panel it opens.

### The panel needed the work the new row exposed

- **It overflowed its own window.** At the full readout size the content came to 395dp inside a 360dp panel: the title was pushed off the top, the reset pill off the bottom, and the first focus went to the slider — the bottom-most control — which scrolled the panel there as it opened. The readout now takes the smaller size whenever a choice shares the panel, and the focus goes to the choice.
- **The option in force was the dimmest thing in its row** — the accent at a third of its alpha, 1.1:1 against its neighbours, reading as the one option that had been switched off. It is now filled with the accent and lettered in near-black, and it says so through `setSelected` as well, which no amount of colour can.
- **Targets and labels**: pills and the reset pill are at least 48dp, labels shrink rather than wrap mid-word at a longer language or a larger system font, and a focused pill takes the white edge and the 1.06 growth the Skip pill already uses — this panel is driven by a remote as often as by a finger.
- **The offset readout is in the viewer's language.** The unit was a literal `" s"` and the number came from `Locale.US`, so a Ukrainian panel read "0 s" under a Ukrainian caption and printed "+2.5" where the language writes "+2,5".
- **Spacing**: the hairline under the title is gone, blocks are held apart by a fixed gap (the weighted spacers collapse to nothing exactly when the panel is full, and two blocks then touch), and the edges line up on one 24dp grid — the ± row pulled out by the padding its buttons carry so the glyph sits on the grid rather than its box.

The class javadoc no longer claims the ± buttons can be reached with a D-pad: a focused `SeekBar` answers left and right itself, so they cannot.

The offset panel is shared with subtitle timing, so the spacing, alignment, 48dp reset pill and localized readout land there too.

Left deliberately: the ± content descriptions are still "-" and "+"; Reset stays live with nothing to reset; the panel is built once, so a segment found after it opens adds no row; and with the segments muted their marks stay on the time bar — the mute means "do not act", not "hide where they are".
