### PR TITLE
Put the second subtitle line above its own, and let a session decide its skips

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -122,6 +122,11 @@ android {
     }
     lint {
         disable 'MissingTranslation'
+        // The mirror of the line above, and Weblate's to reconcile either way: a string deleted here
+        // stays in the translations until they are synced, and lintVital — which runs inside
+        // assembleRelease — treats every one of those leftovers as a fatal error. It failed the
+        // release build on translations of strings this app stopped having months ago.
+        disable 'ExtraTranslation'
         disable 'UnsafeOptInUsageError'
     }
 }

--- a/app/src/main/java/com/brouken/player/OffsetPanel.java
+++ b/app/src/main/java/com/brouken/player/OffsetPanel.java
@@ -2,12 +2,16 @@ package com.brouken.player;
 
 import android.app.Activity;
 import android.app.Dialog;
+import android.content.Context;
 import android.content.res.ColorStateList;
 import android.graphics.Color;
 import android.graphics.Typeface;
 import android.graphics.drawable.ColorDrawable;
+import android.graphics.drawable.Drawable;
 import android.graphics.drawable.GradientDrawable;
 import android.graphics.drawable.RippleDrawable;
+import android.graphics.drawable.StateListDrawable;
+import android.util.StateSet;
 import android.util.TypedValue;
 import android.view.Gravity;
 import android.view.View;
@@ -19,6 +23,10 @@ import android.widget.ScrollView;
 import android.widget.SeekBar;
 import android.widget.TextView;
 
+import androidx.core.view.ViewCompat;
+import androidx.core.widget.TextViewCompat;
+
+import java.text.DecimalFormatSymbols;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
@@ -35,7 +43,9 @@ import java.util.Locale;
  * Input is split by device idiom, because one step size cannot serve both: a finger crossing the
  * narrow phone panel covers the whole ± range, so a raw drag moves the value in ragged sub-second
  * hops. Dragging therefore snaps to whole seconds, while the fine {@code stepSec} stays reachable
- * through the ± buttons (touch) and the D-pad (TV).
+ * through the ± buttons. A remote gets the coarse step instead: a focused {@code SeekBar} answers
+ * left and right itself, so the ± buttons beside it cannot be reached by a D-pad at all — the step
+ * a press moves is sized for that in {@link #addLine}.
  *
  * The panel owns the current values and reports every change through {@link Listener}; the caller
  * only holds the returned dialog so it can dismiss it.
@@ -60,6 +70,44 @@ final class OffsetPanel {
         }
     }
 
+    /**
+     * One thing the panel picks rather than nudges: a row of pills, the one in force lit.
+     *
+     * <p>It lives in this panel and not in a menu of its own because what is being picked and what is
+     * being nudged are one thing to the person watching — how this film's skips behave. Pills rather
+     * than a list: four short words fit across the panel, and a choice that shows all of its options at
+     * once is one press to change from a remote as well as from a finger. No caption: the panel's title
+     * already says what is being chosen, and a third label in the same style as the two below it turned
+     * the panel into a list of look-alikes.
+     */
+    static final class Choice {
+
+        interface Picked {
+            /** @param value the chosen option, or null to go back to following the settings */
+            void onPicked(String value);
+        }
+
+        private final CharSequence[] labels;
+        private final String[] values;
+        private final String current;
+        private final String inherited;
+        private final Picked listener;
+
+        /**
+         * @param current   what is in force, lit; null lights nothing (the settings disagree with
+         *                  themselves and no choice has been made yet)
+         * @param inherited what the settings say, lit again when the panel is reset; may be null
+         */
+        Choice(final CharSequence[] labels, final String[] values, final String current,
+               final String inherited, final Picked listener) {
+            this.labels = labels;
+            this.values = values;
+            this.current = current;
+            this.inherited = inherited;
+            this.listener = listener;
+        }
+    }
+
     private OffsetPanel() {
     }
 
@@ -70,30 +118,50 @@ final class OffsetPanel {
     static Dialog create(final Activity activity, final UiMetrics ui, final View insetSource,
                          final int accent, final String title, final double maxSec,
                          final double stepSec, final Line... lines) {
+        return create(activity, ui, insetSource, accent, title, maxSec, stepSec, null, lines);
+    }
+
+    /**
+     * @param choices picked rather than nudged, drawn above the sliders; null or empty for none
+     */
+    static Dialog create(final Activity activity, final UiMetrics ui, final View insetSource,
+                         final int accent, final String title, final double maxSec,
+                         final double stepSec, final Choice[] choices, final Line... lines) {
         final LinearLayout root = new LinearLayout(activity);
         root.setOrientation(LinearLayout.VERTICAL);
 
         final TextView header = new TextView(activity);
         header.setText(title);
+        ViewCompat.setAccessibilityHeading(header, true);
         header.setTextColor(Color.WHITE);
         header.setTextSize(TypedValue.COMPLEX_UNIT_SP, ui.textTitle());
         header.setTypeface(Typeface.DEFAULT_BOLD);
-        header.setPadding(0, 0, 0, Utils.dpToPx(14));
+        // Space, not a rule: the hairline that used to sit here had a caption under it, and once the
+        // caption went it landed a few pixels above the row of pills and read as their top border.
+        header.setPadding(0, 0, 0, Utils.dpToPx(20));
         root.addView(header);
 
-        final View divider = new View(activity);
-        divider.setLayoutParams(new LinearLayout.LayoutParams(
-                ViewGroup.LayoutParams.MATCH_PARENT, Utils.dpToPx(1)));
-        divider.setBackgroundColor(0x1AFFFFFF);
-        root.addView(divider);
-
         final List<Runnable> resets = new ArrayList<>();
+        final boolean picking = choices != null && choices.length > 0;
+        TextView firstPill = null;
+        if (picking) {
+            for (final Choice choice : choices) {
+                final TextView lit = addChoice(activity, ui, root, accent, choice, resets);
+                if (firstPill == null) {
+                    firstPill = lit;
+                }
+            }
+        }
+
         SeekBar firstBar = null;
         // One value gets the big readout it was designed for; two share the height, so they take the
         // clock's size instead. Two 44sp numbers plus their sliders do not fit a phone held sideways,
         // and what fell off the bottom was the second slider — the panel looked like it could only
         // shift the first line.
-        final float valueSp = lines.length > 1 ? ui.textClock() : ui.textValue();
+        // A choice row costs the same room as a second slider, so the readout gives up the same height
+        // for it. At the full size the panel did not fit its own window: the title was pushed off the
+        // top and the reset pill off the bottom.
+        final float valueSp = lines.length > 1 || picking ? ui.textClock() : ui.textValue();
         for (final Line line : lines) {
             root.addView(verticalSpacer(activity));
             final SeekBar bar = addLine(activity, ui, root, accent, line, maxSec, stepSec, valueSp, resets);
@@ -112,6 +180,7 @@ final class OffsetPanel {
         reset.setClickable(true);
         reset.setFocusable(true);
         reset.setPadding(Utils.dpToPx(28), Utils.dpToPx(11), Utils.dpToPx(28), Utils.dpToPx(11));
+        reset.setMinHeight(ui.dpS(48)); // a pill this small is missed as often as it is hit
         final GradientDrawable resetContent = new GradientDrawable();
         resetContent.setCornerRadius(Utils.dpToPx(22));
         resetContent.setColor(0x1AFFFFFF);
@@ -144,6 +213,8 @@ final class OffsetPanel {
 
         final Dialog dialog = new Dialog(activity, android.R.style.Theme_Translucent_NoTitleBar);
         dialog.setContentView(scroller);
+        // The theme carries no title bar, so this is the only name a screen reader can announce.
+        dialog.setTitle(title);
         dialog.setCanceledOnTouchOutside(true);
         final Window window = dialog.getWindow();
         if (window != null) {
@@ -154,11 +225,135 @@ final class OffsetPanel {
             window.setGravity(Gravity.END);
             window.setBackgroundDrawable(new ColorDrawable(0xF0141414));
         }
-        if (firstBar != null) {
-            final SeekBar focus = firstBar;
+        // The choice, not the slider: it is the panel's first decision and it is at the top, so a
+        // remote lands on it and the scroller stays where the title is. Focusing the slider scrolled
+        // the panel to its own bottom the moment it opened.
+        final View focus = firstPill != null ? firstPill : firstBar;
+        if (focus != null) {
             focus.post(focus::requestFocus);
         }
         return dialog;
+    }
+
+    /**
+     * A row of pills for one choice, the one in force lit — and lit means the brightest thing in the
+     * row, not a tinted version of it.
+     *
+     * <p>That is the whole of the second attempt at this row. The first drew the option in force as the
+     * accent at a third of its alpha with accent text, which measured 1.1:1 against its neighbours and
+     * read as the one option that had been switched off. Filled with the accent and lettered in the
+     * panel's own near-black, it is unmistakable, it carries the same colour the readouts use for "you
+     * changed this", and {@code setSelected} says the same thing again to a screen reader — which no
+     * amount of colour can.
+     *
+     * @return the pill to hand the first focus to
+     */
+    private static TextView addChoice(final Activity activity, final UiMetrics ui,
+                                      final LinearLayout root, final int accent, final Choice choice,
+                                      final List<Runnable> resets) {
+        final int corner = Utils.dpToPx(16);
+        final LinearLayout row = new LinearLayout(activity);
+        row.setOrientation(LinearLayout.HORIZONTAL);
+        final TextView[] pills = new TextView[choice.values.length];
+        final int[] picked = {indexOf(choice.values, choice.current)};
+        final Runnable render = () -> {
+            for (int i = 0; i < pills.length; i++) {
+                final boolean on = i == picked[0];
+                pills[i].setBackground(new RippleDrawable(ColorStateList.valueOf(0x40FFFFFF),
+                        pillFill(accent, on, corner), roundMask(corner)));
+                pills[i].setTextColor(on ? 0xFF141414 : 0xB3FFFFFF);
+                pills[i].setTypeface(on ? Typeface.DEFAULT_BOLD : Typeface.DEFAULT);
+                // Said again without colour, for a screen reader and for anyone who cannot tell these
+                // two shades apart.
+                pills[i].setSelected(on);
+            }
+        };
+        for (int i = 0; i < choice.values.length; i++) {
+            final TextView pill = new TextView(activity);
+            pill.setText(choice.labels[i]);
+            pill.setGravity(Gravity.CENTER);
+            pill.setClickable(true);
+            pill.setFocusable(true);
+            pill.setMaxLines(1);
+            // Shrunk rather than wrapped or clipped: the widest label already fills its share of the
+            // row at the ordinary size, so a longer language or a system font a notch up used to break
+            // one word across two lines and leave the row ragged.
+            TextViewCompat.setAutoSizeTextTypeUniformWithConfiguration(
+                    pill, (int) ui.textAction() - 4, (int) ui.textAction(), 1,
+                    TypedValue.COMPLEX_UNIT_SP);
+            pill.setPadding(ui.dpS(4), ui.dpS(12), ui.dpS(4), ui.dpS(12));
+            pill.setMinHeight(ui.dpS(48)); // the platform's floor for anything a finger has to hit
+            // Equal shares of the row rather than each pill's own width: four words of different
+            // lengths read as a set this way, and the widest of them decides nothing.
+            final LinearLayout.LayoutParams lp = new LinearLayout.LayoutParams(
+                    0, ViewGroup.LayoutParams.MATCH_PARENT, 1f);
+            // Gaps between the pills only: an outer margin here would set the row in from the title
+            // above it by the width of the gap, which is exactly the misalignment it looks like.
+            lp.leftMargin = i == 0 ? 0 : Utils.dpToPx(3);
+            lp.rightMargin = i == choice.values.length - 1 ? 0 : Utils.dpToPx(3);
+            pill.setLayoutParams(lp);
+            final int index = i;
+            pill.setOnClickListener(v -> {
+                if (picked[0] == index) {
+                    return;
+                }
+                picked[0] = index;
+                render.run();
+                choice.listener.onPicked(choice.values[index]);
+            });
+            // The same focus the Skip pill grows by, because this panel is used from a remote across a
+            // room, where a ripple is not a focus indicator. The white edge is in pillFill.
+            pill.setOnFocusChangeListener((v, hasFocus) -> v.animate()
+                    .scaleX(hasFocus ? 1.06f : 1f).scaleY(hasFocus ? 1.06f : 1f)
+                    .setDuration(150).start());
+            pills[i] = pill;
+            row.addView(pill);
+        }
+        render.run();
+        root.addView(row);
+        resets.add(() -> {
+            // Back to whatever the settings say, which is what "reset" means for a panel that only ever
+            // held this session's answers. Without it there was no way back from a choice at all.
+            picked[0] = indexOf(choice.values, choice.inherited);
+            render.run();
+            choice.listener.onPicked(null);
+        });
+        return pills[Math.max(0, picked[0])];
+    }
+
+    private static int indexOf(final String[] values, final String value) {
+        for (int i = 0; value != null && i < values.length; i++) {
+            if (values[i].equals(value)) {
+                return i;
+            }
+        }
+        return -1; // nothing lit: the panel is not going to guess which one is in force
+    }
+
+    /** Pill background: filled with the accent while in force, and edged in white while focused. */
+    private static Drawable pillFill(final int accent, final boolean on, final int corner) {
+        final StateListDrawable states = new StateListDrawable();
+        states.addState(new int[]{android.R.attr.state_focused}, pillShape(accent, on, corner, true));
+        states.addState(StateSet.WILD_CARD, pillShape(accent, on, corner, false));
+        return states;
+    }
+
+    private static Drawable pillShape(final int accent, final boolean on, final int corner,
+                                      final boolean focused) {
+        final GradientDrawable shape = new GradientDrawable();
+        shape.setCornerRadius(corner);
+        shape.setColor(on ? accent : 0x14FFFFFF);
+        if (focused) {
+            shape.setStroke(Utils.dpToPx(2), Color.WHITE);
+        }
+        return shape;
+    }
+
+    private static Drawable roundMask(final int corner) {
+        final GradientDrawable mask = new GradientDrawable();
+        mask.setCornerRadius(corner);
+        mask.setColor(Color.WHITE);
+        return mask;
     }
 
     /** Caption, readout and slider for one offset. Returns its SeekBar; adds its reset to {@code resets}. */
@@ -178,7 +373,11 @@ final class OffsetPanel {
             caption.setTextColor(0xB3FFFFFF);
             caption.setTextSize(TypedValue.COMPLEX_UNIT_SP, ui.textAction());
             caption.setGravity(Gravity.CENTER);
-            caption.setPadding(0, 0, 0, Utils.dpToPx(4));
+            // Asymmetric on purpose, and fixed rather than left to the weighted spacers: a caption
+            // belongs to what is under it, and the block above it needs a gap that does not vanish
+            // when the panel fills up. The spacers only share out what is left over — when there is
+            // nothing left over they collapse to nothing and two blocks end up touching.
+            caption.setPadding(0, ui.dpS(28), 0, Utils.dpToPx(4));
             root.addView(caption);
         }
 
@@ -223,11 +422,18 @@ final class OffsetPanel {
         row.addView(minus);
         row.addView(seekBar);
         row.addView(plus);
+        // Optical alignment: each ± button is a 24dp glyph in 12dp of its own padding, so the row is
+        // pulled out by that padding. What lines up with the title and the pills is the glyph.
+        final LinearLayout.LayoutParams rowLp = new LinearLayout.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT);
+        rowLp.leftMargin = -Utils.dpToPx(12);
+        rowLp.rightMargin = -Utils.dpToPx(12);
+        row.setLayoutParams(rowLp);
         root.addView(row);
 
         // Readout: accent when non-zero, white at rest.
         final Runnable render = () -> {
-            value.setText(format(current[0]));
+            value.setText(format(activity, current[0]));
             value.setTextColor(isZero(current[0]) ? Color.WHITE : accent);
         };
         render.run();
@@ -288,23 +494,31 @@ final class OffsetPanel {
         return Math.abs(sec) < 0.001;
     }
 
-    /** "0 s" / "+2.5 s" / "-10 s" — signed, trailing zeros trimmed. */
-    static String format(double sec) {
-        if (isZero(sec)) {
-            return "0 s";
-        }
-        String s = String.format(Locale.US, "%+.2f", sec);
-        if (s.indexOf('.') >= 0) { // trim trailing zeros: "+2.50" -> "+2.5", "+3.00" -> "+3"
-            int end = s.length();
-            while (end > 0 && s.charAt(end - 1) == '0') {
+    /**
+     * "0 s" / "+2.5 s" / "-10 s" — signed, trailing zeros trimmed, and in the viewer's own language.
+     *
+     * <p>Both halves used to be English: the unit was a literal {@code " s"} and the number was
+     * formatted against {@code Locale.US}, so a Ukrainian panel read "0 s" two rows under a Ukrainian
+     * caption and printed "+2.5" where the language writes "+2,5".
+     */
+    static String format(final Context context, final double sec) {
+        final Locale locale = Locale.getDefault();
+        String number = "0";
+        if (!isZero(sec)) {
+            number = String.format(locale, "%+.2f", sec);
+            // Trim trailing zeros: "+2,50" -> "+2,5", "+3,00" -> "+3". Against the locale's own
+            // separator, which is not a dot everywhere this app is read.
+            final char point = DecimalFormatSymbols.getInstance(locale).getDecimalSeparator();
+            int end = number.length();
+            while (end > 0 && number.charAt(end - 1) == '0') {
                 end--;
             }
-            if (end > 0 && s.charAt(end - 1) == '.') {
+            if (end > 0 && number.charAt(end - 1) == point) {
                 end--;
             }
-            s = s.substring(0, end);
+            number = number.substring(0, end);
         }
-        return s + " s";
+        return context.getString(R.string.offset_seconds, number);
     }
 
     private static View verticalSpacer(Activity activity) {

--- a/app/src/main/java/com/brouken/player/OffsetPanel.java
+++ b/app/src/main/java/com/brouken/player/OffsetPanel.java
@@ -181,13 +181,11 @@ final class OffsetPanel {
         reset.setFocusable(true);
         reset.setPadding(Utils.dpToPx(28), Utils.dpToPx(11), Utils.dpToPx(28), Utils.dpToPx(11));
         reset.setMinHeight(ui.dpS(48)); // a pill this small is missed as often as it is hit
-        final GradientDrawable resetContent = new GradientDrawable();
-        resetContent.setCornerRadius(Utils.dpToPx(22));
-        resetContent.setColor(0x1AFFFFFF);
-        final GradientDrawable resetMask = new GradientDrawable();
-        resetMask.setCornerRadius(Utils.dpToPx(22));
-        resetMask.setColor(Color.WHITE);
-        reset.setBackground(new RippleDrawable(ColorStateList.valueOf(0x40FFFFFF), resetContent, resetMask));
+        // The same focus edge the pills take: a ripple is touch feedback, not something a remote across
+        // a room can find, and this pill is the last stop of the D-pad path through here.
+        final int resetCorner = Utils.dpToPx(22);
+        reset.setBackground(new RippleDrawable(ColorStateList.valueOf(0x20FFFFFF),
+                pillFill(accent, false, resetCorner), roundMask(resetCorner)));
         final LinearLayout.LayoutParams resetLp = new LinearLayout.LayoutParams(
                 ViewGroup.LayoutParams.WRAP_CONTENT, ViewGroup.LayoutParams.WRAP_CONTENT);
         resetLp.gravity = Gravity.CENTER_HORIZONTAL;
@@ -259,7 +257,7 @@ final class OffsetPanel {
         final Runnable render = () -> {
             for (int i = 0; i < pills.length; i++) {
                 final boolean on = i == picked[0];
-                pills[i].setBackground(new RippleDrawable(ColorStateList.valueOf(0x40FFFFFF),
+                pills[i].setBackground(new RippleDrawable(ColorStateList.valueOf(0x20FFFFFF),
                         pillFill(accent, on, corner), roundMask(corner)));
                 pills[i].setTextColor(on ? 0xFF141414 : 0xB3FFFFFF);
                 pills[i].setTypeface(on ? Typeface.DEFAULT_BOLD : Typeface.DEFAULT);
@@ -301,11 +299,6 @@ final class OffsetPanel {
                 render.run();
                 choice.listener.onPicked(choice.values[index]);
             });
-            // The same focus the Skip pill grows by, because this panel is used from a remote across a
-            // room, where a ripple is not a focus indicator. The white edge is in pillFill.
-            pill.setOnFocusChangeListener((v, hasFocus) -> v.animate()
-                    .scaleX(hasFocus ? 1.06f : 1f).scaleY(hasFocus ? 1.06f : 1f)
-                    .setDuration(150).start());
             pills[i] = pill;
             row.addView(pill);
         }
@@ -344,7 +337,10 @@ final class OffsetPanel {
         shape.setCornerRadius(corner);
         shape.setColor(on ? accent : 0x14FFFFFF);
         if (focused) {
-            shape.setStroke(Utils.dpToPx(2), Color.WHITE);
+            // The accent, like the Skip pill's own focus ring — and white only on the pill that is
+            // already the accent, where a coral edge would not show. One signal and one language: an
+            // edge appears, nothing moves and nothing changes size, so the row keeps its rhythm.
+            shape.setStroke(Utils.dpToPx(2), on ? Color.WHITE : accent);
         }
         return shape;
     }

--- a/app/src/main/java/com/brouken/player/OpenSubtitles.java
+++ b/app/src/main/java/com/brouken/player/OpenSubtitles.java
@@ -51,9 +51,11 @@ final class OpenSubtitles {
 
     /**
      * Consumer key shipped with the app. The 100 downloads a day are counted per client rather than
-     * pooled, so one heavy user cannot drain everybody else's — but it is still a shared resource:
-     * abuse gets it revoked for every install at once. Hence this source is asked last, and only for
-     * what the keyless ones could not produce.
+     * pooled, so a hundred a day is a hundred for this device — which is why this source leads the
+     * search rather than covering for the free ones: what was being saved by holding it back was a
+     * budget nobody spends. It is still a shared resource in one sense, that abuse gets the key
+     * revoked for every install at once, so nothing here asks for more than one file at a time and
+     * the free indexes stay in place as the answer for a key that has been spent or withdrawn.
      */
     private static final String KEY = "IxrxupVBKx7dhBkAAtW7QbwnhDMgOdEO";
 

--- a/app/src/main/java/com/brouken/player/PlayerActivity.java
+++ b/app/src/main/java/com/brouken/player/PlayerActivity.java
@@ -2089,11 +2089,6 @@ public class PlayerActivity extends Activity {
                     controllerChromeVisible = false;
                 }
 
-                // The bar has come or gone over the band the hint sits in, so the lines re-place
-                // themselves. Posted, because the bar's height is only measurable once it is laid out.
-                if (controllerVisible != wasVisible) {
-                    playerView.post(PlayerActivity.this::updateSubtitleLayout);
-                }
                 if (controllerVisible) {
                     updateMediaInfo();
                     startEndsAtUpdates();
@@ -6804,8 +6799,8 @@ public class PlayerActivity extends Activity {
         if (!secondaryOnDemand()) {
             return SecondarySubtitles.State.SHOWN;
         }
-        // Nothing stands where the hint would be: a pause is what asks for it, and until it is asked
-        // for the first line keeps its usual place.
+        // A pause is what asks for it, and until it is asked for its slot above the first line stands
+        // empty. The first line keeps its usual place either way.
         return locked || !secondarySubtitles.isPeeking()
                 ? SecondarySubtitles.State.HIDDEN : SecondarySubtitles.State.SHOWN;
     }
@@ -11618,6 +11613,40 @@ public class PlayerActivity extends Activity {
         return null;
     }
 
+    /**
+     * Where the hint is drawn: in a band of its own, under the first line while the second line is
+     * simply on and above it while it is asked for. Both lines sit at the bottom of the picture either
+     * way, and in both modes the band is reserved — so nothing moves when the hint arrives or goes.
+     *
+     * <p>Which line the band is taken out of is the whole difference between the two modes. With the
+     * hint always on it comes out from under the first line, which then sits a band higher for the whole
+     * film — the price of reading both lines all the time. On demand the first line is read on its own
+     * for almost all of the film, so it keeps the place every other mode gives it and the room is
+     * reserved above it instead: {@code gap + mainRoom}.
+     *
+     * <p>Reserved, not measured, and for the same reason as the band itself. Tucking the hint exactly
+     * against the first line's painted top edge is not possible — media3 does not report where it drew
+     * the glyphs, and a slot that follows the text is a first line that jumps. So {@code mainRoom} is
+     * the room two lines of the main size take and the hint's slot begins above that. The ceiling: a cue
+     * that wraps to a third line grows into the slot.
+     *
+     * @param gap      the resting distance from the bottom edge, the one the first line keeps
+     * @param mainRoom the room held for the first line to grow into, or 0 when the hint sits under it
+     */
+    private void placeHint(final int gap, final int mainRoom) {
+        final View hint = playerView.findViewById(R.id.subtitle_secondary);
+        if (hint == null) {
+            return;
+        }
+        final FrameLayout.LayoutParams lp = (FrameLayout.LayoutParams) hint.getLayoutParams();
+        // Set rather than left to the layout: the mode can be changed while the player is up, and the
+        // hint used to be placed against the top edge on demand.
+        lp.gravity = Gravity.BOTTOM | Gravity.CENTER_HORIZONTAL;
+        lp.topMargin = 0;
+        lp.bottomMargin = gap + mainRoom;
+        hint.setLayoutParams(lp);
+    }
+
     /** Line box as a multiple of the text size, for reserving the band without measuring anything. */
     private static final float SECONDARY_LINE_HEIGHT = 1.3f;
     /** Matches SecondarySubtitles.MAX_LINES: the band has to hold whatever the line may grow to. */
@@ -11697,21 +11726,12 @@ public class PlayerActivity extends Activity {
         // was the first attempt and only moves cues that carry no position of their own — a track muxed
         // into MP4 or HLS usually does carry one, and those landed on top of the hint.
         // CanvasSubtitleOutput lays every cue out inside the padding, positioned or not.
-        // Both lines move up together while the control bar is over the place the hint sits in. Only
-        // while a hint is actually drawn: on demand the bar is what the peek arrives on top of — a pause
-        // is what asks for the hint and a pause is what shows the controller — and lifting the main line
-        // whenever the controller appears would make ordinary subtitles jump on every tap.
-        final int lift = controllerLift(gap);
-        Utils.setViewParams(subtitleView, 0, 0, 0, band + lift,
+        Utils.setViewParams(subtitleView, 0, 0, 0, band,
                 subtitleSideMargin(orientation), 0, subtitleSideMargin(orientation), 0);
 
-        final View hint = playerView.findViewById(R.id.subtitle_secondary);
-        if (hint != null) {
-            final ViewGroup.MarginLayoutParams lp =
-                    (ViewGroup.MarginLayoutParams) hint.getLayoutParams();
-            lp.bottomMargin = gap + lift;
-            hint.setLayoutParams(lp);
-        }
+        // On demand the hint sits above the first line, so what has to be reserved is a line of the
+        // main size rather than of its own; the band under the first line is then nothing.
+        placeHint(gap, secondaryOnDemand() ? secondaryBandPx(mainPx) : 0);
         if (secondarySubtitles != null) {
             secondarySubtitles.style(mPrefs.subtitleSecondaryTextColor,
                     mPrefs.subtitleSecondaryBackgroundColor, hintPx,
@@ -11719,10 +11739,10 @@ public class PlayerActivity extends Activity {
                             mPrefs.subtitleStyleBold ? Typeface.BOLD : Typeface.NORMAL),
                     ui.dpS(6), ui.dpS(8), ui.dpS(4));
         }
-        // Translation rather than more padding: a hint that comes and goes would otherwise relayout the
-        // subtitle view on every frame of the move, and the number the text size is derived from is the
-        // height minus that padding — the very coupling phase 3a took out.
-        slideSubtitles(subtitleView, secondaryPeekShiftPx(hintPx));
+        // Zero, and it stays zero: the band under the first line is reserved for as long as a second
+        // line is chosen, so neither line has anywhere to travel to. Still called, because a rebuilt
+        // view can come back carrying a translation from before.
+        slideSubtitles(subtitleView, 0);
     }
 
     /**
@@ -11743,39 +11763,6 @@ public class PlayerActivity extends Activity {
         }
         subtitleShift = target;
         subtitleView.setTranslationY(target);
-    }
-
-    /**
-     * How far the two lines rise to clear the control bar, or 0 when there is nothing to clear.
-     *
-     * <p>The hint sits a fixed gap off the bottom edge, and that is exactly where the bar's row of
-     * buttons is — so a hint and a visible controller land on top of each other. On demand that is not
-     * an edge case but the normal course of events: the pause that asks for the hint is the same press
-     * that puts the controller up, and the controller does not hide again while playback is stopped.
-     *
-     * @param gap the resting distance from the bottom edge, already counted once
-     */
-    private int controllerLift(final int gap) {
-        if (!controllerVisible || secondarySubtitles == null || !secondarySubtitles.isVisible()) {
-            return 0;
-        }
-        // Measured off the chrome itself rather than from one view's height: the block to clear is the
-        // time bar and the button row together, and they are siblings with margins between them, so a
-        // single height came out short and left the hint's plate resting on the progress line.
-        final Rect window = new Rect();
-        if (!playerView.getGlobalVisibleRect(window)) {
-            return 0;
-        }
-        int top = window.bottom;
-        for (final int id : new int[] { R.id.exo_bottom_bar, androidx.media3.ui.R.id.exo_progress }) {
-            final View view = findViewById(id);
-            final Rect bounds = new Rect();
-            if (view != null && view.getVisibility() == View.VISIBLE
-                    && view.getGlobalVisibleRect(bounds)) {
-                top = Math.min(top, bounds.top);
-            }
-        }
-        return Math.max(0, window.bottom - top + ui.dpS(16) - gap);
     }
 
     private int subtitleViewHeightPx(final SubtitleView subtitleView) {
@@ -11828,40 +11815,39 @@ public class PlayerActivity extends Activity {
     }
 
     /**
-     * Height reserved for the second line while it is on.
+     * The height a line of subtitles at {@code textPx} is given — the band the second line sits in, and
+     * on demand the room held under that band for the first line.
      *
      * <p>Fixed rather than measured, and that is the whole design. The main line is bottom-anchored
-     * inside a full-bleed {@code SubtitleView}, so placing anything exactly above it would mean
-     * measuring the cue it is currently drawing — and a band that follows the hint is a main line that
-     * jumps every time the hint appears. So the band is reserved for as long as a second line is
-     * chosen, and the main line's position becomes a function of one boolean instead of of the text.
+     * inside a full-bleed {@code SubtitleView}, so placing anything exactly against it would mean
+     * measuring the cue it is currently drawing — and a band that follows the text is a line that jumps
+     * every time the other one appears. So the room is reserved for as long as a second line is chosen,
+     * and where each line sits becomes a function of one boolean instead of of the text.
      */
-    private int secondaryBandPx(final float hintPx) {
-        return Math.round(SECONDARY_MAX_LINES * hintPx * SECONDARY_LINE_HEIGHT)
+    private int secondaryBandPx(final float textPx) {
+        return Math.round(SECONDARY_MAX_LINES * textPx * SECONDARY_LINE_HEIGHT)
                 + 2 * ui.dpS(4) + ui.dpS(12);
     }
 
     /**
-     * What the band holds when nothing has been asked for: two lines of hint while the second line is
-     * simply on, and nothing at all while it is waiting to be asked for. On demand that is the whole
-     * point — the first line keeps its usual place, and the seventh of the screen the band costs is
-     * spent for the seconds the hint is being read rather than for the film.
+     * The band under the first line: held for as long as a second line is chosen and whether or not the
+     * hint is being drawn at this moment, and nothing at all on demand.
+     *
+     * <p>On demand it was tried both ways and it is neither. Opened by the peek and closed after it, the
+     * band cost the picture nothing while nobody was reading it — a real saving and the wrong trade,
+     * because the peek is asked for with a pause, so every pause moved both lines up and back down
+     * again. Held for the whole film instead, nothing moved, but the line being read sat a band higher
+     * from the first frame to the last for the sake of a hint that is on screen for seconds of it. So on
+     * demand the first line is left exactly where every other mode puts it, and the hint's slot is
+     * reserved above it — see {@link #placeHint}.
      */
     private int secondaryRestingBandPx(final float hintPx) {
-        if (secondarySubtitles == null || !secondarySubtitles.isVisible() || secondaryOnDemand()) {
+        if (secondarySubtitles == null || !secondaryActive() || secondaryOnDemand()) {
             return 0;
         }
         return secondaryBandPx(hintPx);
     }
 
-    /** How far the lines travel while a hint that was asked for is on screen. */
-    private int secondaryPeekShiftPx(final float hintPx) {
-        if (secondarySubtitles == null || !secondaryOnDemand()
-                || secondarySubtitles.getState() != SecondarySubtitles.State.SHOWN) {
-            return 0;
-        }
-        return secondaryBandPx(hintPx);
-    }
 
     @TargetApi(26)
     boolean updatePictureInPictureActions(final int iconId, final int resTitle, final int controlType, final int requestCode) {

--- a/app/src/main/java/com/brouken/player/PlayerActivity.java
+++ b/app/src/main/java/com/brouken/player/PlayerActivity.java
@@ -772,6 +772,12 @@ public class PlayerActivity extends Activity {
     // Skip-segment timing offset (seconds) — in-session only, never persisted; applies to all
     // playlist items and is reset on a new media session (resetApiAccess).
     private double skipOffsetSec = 0;
+    // How this session offers segments, or null to follow the settings. One value for both kinds,
+    // because the viewer mid-film holds one intention and not two — "stop interrupting me in this
+    // series" — and two rows of it were two rows of the same answer. Same life as the offset above and
+    // set from the same panel: a series that matches the same way in every episode is a session, not a
+    // change of mind about every film after it.
+    private String skipModeSession;
     // True once any skip segment has appeared this session; keeps the offset button available
     // afterwards even on an item that itself has no segments.
     private boolean skipSeenThisSession;
@@ -1252,7 +1258,7 @@ public class PlayerActivity extends Activity {
         buttonSkipOffset = new ImageButton(this, null, 0, R.style.ExoStyledControls_Button_Bottom);
         buttonSkipOffset.setImageResource(R.drawable.ic_skip_offset_24dp);
         buttonSkipOffset.setId(View.generateViewId());
-        buttonSkipOffset.setContentDescription(getString(R.string.button_skip_offset));
+        buttonSkipOffset.setContentDescription(getString(R.string.skip_session_title));
         buttonSkipOffset.setVisibility(View.GONE);
         buttonSkipOffset.setOnClickListener(view -> showSkipOffsetDialog());
 
@@ -1575,6 +1581,18 @@ public class PlayerActivity extends Activity {
         // stretched to full width inside the CoordinatorLayout and pinned the pill to the left edge — is gone.
         // Modern TV focus: a coral ring on the pill (state-driven stroke) plus a slight scale-up, replacing
         // the dated flat grey selectableItemBackground wash.
+        buttonSkip.setOnLongClickListener(v -> {
+            // The panel from the one place where the question comes up by itself: the segment is on
+            // screen, this is the button that would be pressed for it, and holding it says "do this
+            // yourself from now on" without going looking for anywhere. The offset button in the bottom
+            // bar opens the same panel for when there is no button to hold — after the mode has been set
+            // to automatic, chiefly.
+            if (PlayerActivity.locked) {
+                return false;
+            }
+            showSkipOffsetDialog();
+            return true;
+        });
         buttonSkip.setOnFocusChangeListener((v, hasFocus) -> {
             skipPillFill.setStroke(hasFocus ? skipRingWidth : 0, brandColor());
             final float scale = hasFocus ? 1.06f : 1f;
@@ -3074,8 +3092,11 @@ public class PlayerActivity extends Activity {
         cancelSegmentFinder();
         cancelSubtitleSearch();
         hideSkipButton();
-        // Skip offset is session-scoped: a new media session resets it and hides its control.
+        // The offset and the session's skip modes go the same way, and "session" here is the film rather
+        // than the player: the next file in the folder keeps both, which is the whole point of them,
+        // while a film picked afresh starts from the settings again.
         skipOffsetSec = 0;
+        skipModeSession = null;
         skipSeenThisSession = false;
         if (skipOffsetDialog != null && skipOffsetDialog.isShowing()) {
             skipOffsetDialog.dismiss();
@@ -3182,7 +3203,62 @@ public class PlayerActivity extends Activity {
         rebuildSkip();
     }
 
-    /** Session-only skip-offset panel — the shared {@link OffsetPanel} bound to {@link #skipOffsetSec}. */
+    /** The four ways a segment can be offered, as the session panel lists them, with their labels. */
+    private static final String[] SKIP_MODE_VALUES = {
+            Prefs.SKIP_MODE_BRIEF, Prefs.SKIP_MODE_BUTTON, Prefs.SKIP_MODE_AUTO, Prefs.SKIP_MODE_OFF };
+    private static final int[] SKIP_MODE_LABELS = {
+            R.string.skip_mode_brief_short, R.string.skip_mode_button_short,
+            R.string.skip_mode_auto_short, R.string.skip_mode_off_short };
+
+    /**
+     * Whether this film has anything the session could be asked about: a segment somebody might be
+     * offered. Ads are skipped silently whatever anyone says, so a file carrying only those gets the
+     * offset and nothing else.
+     */
+    private boolean hasSkipSegment() {
+        if (skipManager == null) {
+            return false;
+        }
+        for (final SkipSegment segment : skipManager.getSegments()) {
+            if (segment.type != SkipSegment.Type.AD) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * The session's row: the four ways a segment can be offered, the one in force lit.
+     *
+     * <p>Nothing is lit in the one case where there is no single answer to light — the settings ask for
+     * one thing at the start of an episode and another at its end, and this session has not been told
+     * otherwise. Lighting either of them would be a claim about the other.
+     */
+    private OffsetPanel.Choice skipModeChoice() {
+        final CharSequence[] labels = new CharSequence[SKIP_MODE_VALUES.length];
+        for (int i = 0; i < labels.length; i++) {
+            labels[i] = getString(SKIP_MODE_LABELS[i]);
+        }
+        final String settings = mPrefs.skipMode.equals(mPrefs.skipModeCredits) ? mPrefs.skipMode : null;
+        return new OffsetPanel.Choice(labels, SKIP_MODE_VALUES,
+                skipModeSession != null ? skipModeSession : settings, settings,
+                this::setSessionSkipMode);
+    }
+
+    /**
+     * Everything this session's skipping is, in one panel: how each kind of segment is offered, and how
+     * far the marks are shifted. Both are the session's and neither is written to the preferences —
+     * which is what makes this the right place for them and the settings screen the wrong one. A series
+     * matches the same way in every episode, and that is a fact about the series, not about the player.
+     *
+     * <p>One row for both kinds of segment, not one each: asked what they want mid-film, the answer is
+     * "stop interrupting me in this series" rather than two separate policies for the start of an
+     * episode and its end. The settings keep the two apart for anyone who does want that.
+     *
+     * <p>Reached by holding the Skip button, where the question arises, and from the bottom bar for when
+     * there is no button to hold. Its reset clears both halves — the choice goes back to following the
+     * settings and the offset to zero — because everything in here belongs to this session only.
+     */
     private void showSkipOffsetDialog() {
         if (player == null) {
             return;
@@ -3190,10 +3266,14 @@ public class PlayerActivity extends Activity {
         if (skipOffsetDialog != null) {
             skipOffsetDialog.dismiss();
         }
+        final OffsetPanel.Choice[] choices = hasSkipSegment()
+                ? new OffsetPanel.Choice[]{ skipModeChoice() } : new OffsetPanel.Choice[0];
         skipOffsetDialog = OffsetPanel.create(this, ui, coordinatorLayout,
                 brandColor(),   // coral, matches the skip timeline highlight
-                getString(R.string.skip_offset_title), OFFSET_MAX_SEC, OFFSET_STEP_SEC,
-                new OffsetPanel.Line(null, skipOffsetSec, this::applySkipOffset));
+                getString(R.string.skip_session_title), OFFSET_MAX_SEC, OFFSET_STEP_SEC, choices,
+                // Captioned only while it shares the panel with the row above it; alone it is the panel.
+                new OffsetPanel.Line(choices.length == 0 ? null : getString(R.string.skip_offset_title),
+                        skipOffsetSec, this::applySkipOffset));
         showPickerDialog(skipOffsetDialog);
     }
 
@@ -3270,17 +3350,17 @@ public class PlayerActivity extends Activity {
      */
     private String subtitleOffsetSummary() {
         if (!secondaryOffsetShiftable()) {
-            return subtitleOffsetSec == 0 ? null : OffsetPanel.format(subtitleOffsetSec);
+            return subtitleOffsetSec == 0 ? null : OffsetPanel.format(this, subtitleOffsetSec);
         }
         if (!subtitleOffsetShiftable()) {
             return secondarySubtitleOffsetSec == 0
-                    ? null : OffsetPanel.format(secondarySubtitleOffsetSec);
+                    ? null : OffsetPanel.format(this, secondarySubtitleOffsetSec);
         }
         if (subtitleOffsetSec == 0 && secondarySubtitleOffsetSec == 0) {
             return null;
         }
-        return OffsetPanel.format(subtitleOffsetSec) + " · "
-                + OffsetPanel.format(secondarySubtitleOffsetSec);
+        return OffsetPanel.format(this, subtitleOffsetSec) + " · "
+                + OffsetPanel.format(this, secondarySubtitleOffsetSec);
     }
 
     // Online skip-segment lookup (FIND_INTO.MD): when the current item has no intent-provided segments,
@@ -3625,7 +3705,7 @@ public class PlayerActivity extends Activity {
             // (see SKIP_LEAD_SEC): as the Skip button when the user is asked, as the pill when the jump
             // is automatic and there is no button to offer.
             final SkipSegment upcoming = skipManager.upcomingSegment(posSec, SKIP_LEAD_SEC);
-            if (upcoming == null || autoSkipUndone(posSec)) {
+            if (upcoming == null || isSkipOff(upcoming) || autoSkipUndone(posSec)) {
                 hideSkipButton();
                 hideSkipHeadsUp();
             } else if (isAutoSkip(upcoming)) {
@@ -3643,6 +3723,12 @@ public class PlayerActivity extends Activity {
                 updateSkipButtonProgress(upcoming);
                 showSkipButton(upcoming);
             }
+            return;
+        }
+        if (isSkipOff(segment)) {
+            // Left alone for this session: no button and no jump. The highlight on the time bar stays —
+            // the segment is still there, it is only nobody's business to act on it.
+            hideSkipButton();
             return;
         }
         if (isAutoSkip(segment) && !autoSkipUndone(posSec)) {
@@ -3666,7 +3752,43 @@ public class PlayerActivity extends Activity {
         if (segment.type == SkipSegment.Type.AD) {
             return true;
         }
-        return Prefs.SKIP_MODE_AUTO.equals(segment.credits ? mPrefs.skipModeCredits : mPrefs.skipMode);
+        return Prefs.SKIP_MODE_AUTO.equals(effectiveSkipMode(segment.credits));
+    }
+
+    /**
+     * How segments of this kind are offered right now: what the skip panel was told for this session, or
+     * the setting where it was told nothing. Credits carry their own answer, as they do in the settings.
+     *
+     * <p>The one place either is read, so a session's choice cannot apply to one half of the machinery
+     * and not the other — which is what happened while the mode was read straight off the preferences in
+     * two places and the panel had to know about both.
+     */
+    private String effectiveSkipMode(final boolean credits) {
+        if (skipModeSession != null) {
+            return skipModeSession;
+        }
+        return credits ? mPrefs.skipModeCredits : mPrefs.skipMode;
+    }
+
+    /**
+     * Whether this session has been told to leave this kind of segment alone — the mirror of asking for
+     * automatic skips, and the reason the panel offers both: a series whose intro is found in the wrong
+     * place is this session's problem, not a reason to change the setting for every film after it. Ads
+     * are nobody's choice.
+     */
+    private boolean isSkipOff(final SkipSegment segment) {
+        return segment.type != SkipSegment.Type.AD
+                && Prefs.SKIP_MODE_OFF.equals(effectiveSkipMode(segment.credits));
+    }
+
+    /**
+     * Takes the session's choice, or gives it back with {@code null} — which is what the panel's reset
+     * does, leaving the settings in charge again. Nothing is written to the preferences, and the segment
+     * on screen follows the new answer at once rather than at the next one.
+     */
+    private void setSessionSkipMode(final String mode) {
+        skipModeSession = mode;
+        skipTick();
     }
 
     /**
@@ -3989,7 +4111,7 @@ public class PlayerActivity extends Activity {
 
     /** Whether this segment's position is set to offer the Skip button briefly rather than throughout. */
     private boolean isBriefSkip(SkipSegment segment) {
-        return Prefs.SKIP_MODE_BRIEF.equals(segment.credits ? mPrefs.skipModeCredits : mPrefs.skipMode);
+        return Prefs.SKIP_MODE_BRIEF.equals(effectiveSkipMode(segment.credits));
     }
 
     /** True while brief mode's timed offer is on screen and owns the pill. */
@@ -8386,8 +8508,10 @@ public class PlayerActivity extends Activity {
                     false, this::showSubtitleOffsetDialog));
         }
         if (skipOffsetReachable()) {
-            items.add(new MenuItem(R.drawable.ic_skip_offset_24dp, getString(R.string.button_skip_offset),
-                    skipOffsetSec == 0 ? null : OffsetPanel.format(skipOffsetSec),
+            // Named after the panel it opens, which is no longer only the offset: the row that said
+            // "Skip offset" now leads to how each kind of segment is offered as well.
+            items.add(new MenuItem(R.drawable.ic_skip_offset_24dp, getString(R.string.skip_session_title),
+                    skipOffsetSec == 0 ? null : OffsetPanel.format(this, skipOffsetSec),
                     false, this::showSkipOffsetDialog));
         }
         if (player != null) {

--- a/app/src/main/java/com/brouken/player/Prefs.java
+++ b/app/src/main/java/com/brouken/player/Prefs.java
@@ -382,10 +382,16 @@ class Prefs {
         subtitleSearchLanguage = mSharedPreferences.getBoolean(PREF_KEY_SUBTITLE_SEARCH_LANGUAGE, subtitleSearchLanguage);
         subtitleTranslate = getSubtitleTranslate(mContext);
         subtitleTranslateBackends = getSubtitleTranslateBackends(mContext);
-        subtitleSourceOpenSubtitles = mSharedPreferences.getBoolean(PREF_KEY_SOURCE_OPENSUBTITLES, subtitleSourceOpenSubtitles);
-        subtitleSourceShegu = mSharedPreferences.getBoolean(PREF_KEY_SOURCE_SHEGU, subtitleSourceShegu);
-        subtitleSourceStremio = mSharedPreferences.getBoolean(PREF_KEY_SOURCE_STREMIO, subtitleSourceStremio);
-        subtitleSourceRest = mSharedPreferences.getBoolean(PREF_KEY_SOURCE_REST, subtitleSourceRest);
+        // Which indexes are asked is a debug affordance — a way to exercise one source on its own
+        // when a result looks wrong — and the release build has no screen for it. So the release build
+        // does not read these either: a source switched off while testing would otherwise stay off for
+        // good, invisibly, with nothing anywhere to turn it back on.
+        if (BuildConfig.DEBUG) {
+            subtitleSourceOpenSubtitles = mSharedPreferences.getBoolean(PREF_KEY_SOURCE_OPENSUBTITLES, subtitleSourceOpenSubtitles);
+            subtitleSourceShegu = mSharedPreferences.getBoolean(PREF_KEY_SOURCE_SHEGU, subtitleSourceShegu);
+            subtitleSourceStremio = mSharedPreferences.getBoolean(PREF_KEY_SOURCE_STREMIO, subtitleSourceStremio);
+            subtitleSourceRest = mSharedPreferences.getBoolean(PREF_KEY_SOURCE_REST, subtitleSourceRest);
+        }
         subtitleStyleBold = mSharedPreferences.getBoolean(PREF_KEY_SUBTITLE_STYLE_BOLD, subtitleStyleBold);
         subtitleScale = Float.parseFloat(mSharedPreferences.getString(PREF_KEY_SUBTITLE_SCALE, String.valueOf(subtitleScale)));
         subtitleTextColor = Color.parseColor(mSharedPreferences.getString(PREF_KEY_SUBTITLE_TEXT_COLOR, "#FFFFFFFF"));
@@ -555,10 +561,17 @@ class Prefs {
         return migrated;
     }
 
-    /** Translation endpoints to try, in order. Unset means the two that were answering when shipped. */
+    /**
+     * Translation endpoints to try, in order. Unset means the two that were answering when shipped —
+     * and in a release build that is the only answer, for the same reason as the source switches
+     * above: the choice is a debug affordance, so a release build must not be carrying one made
+     * during testing with no screen on which to see or undo it.
+     */
     public static String getSubtitleTranslateBackends(final Context context) {
-        final String stored = PreferenceManager.getDefaultSharedPreferences(context)
-                .getString(PREF_KEY_SUBTITLE_TRANSLATE_BACKENDS, null);
+        final String stored = BuildConfig.DEBUG
+                ? PreferenceManager.getDefaultSharedPreferences(context)
+                        .getString(PREF_KEY_SUBTITLE_TRANSLATE_BACKENDS, null)
+                : null;
         // Folded onto the ids that exist now, so a setting written when every Mozhi host was its
         // own entry still means Mozhi rather than nothing.
         return SubtitleTranslate.normalize(

--- a/app/src/main/java/com/brouken/player/Prefs.java
+++ b/app/src/main/java/com/brouken/player/Prefs.java
@@ -125,6 +125,12 @@ class Prefs {
     public static final String SKIP_MODE_BRIEF = "brief";
     public static final String SKIP_MODE_BUTTON = "button";
     public static final String SKIP_MODE_AUTO = "auto";
+    /**
+     * Offer nothing: the session's mute for segments. Only ever a choice made in the player's skip
+     * panel — deliberately not in the settings list, where switching skipping off is a switch for the
+     * whole feature rather than one film's worth of it.
+     */
+    public static final String SKIP_MODE_OFF = "off";
 
     // Which skips offer the "go back" pill afterwards.
     // When the online subtitle search runs. One choice, because the two switches this replaced were

--- a/app/src/main/java/com/brouken/player/SettingsActivity.java
+++ b/app/src/main/java/com/brouken/player/SettingsActivity.java
@@ -306,6 +306,21 @@ public class SettingsActivity extends AppCompatActivity
                 });
             }
 
+            // Both of these exist to take a source out of the picture while a result is being
+            // chased down, and neither is anybody's setting: which index answered and which endpoint
+            // translated are not decisions a viewer has any way to judge. So they are shown in a debug
+            // build and are not in a release one — where Prefs also stops reading what they wrote.
+            if (!BuildConfig.DEBUG) {
+                final Preference sources = findPreference("subtitleSourcesCategory");
+                if (sources != null) {
+                    sources.setVisible(false);
+                }
+                final Preference endpoints = findPreference("subtitleTranslateBackends");
+                if (endpoints != null) {
+                    endpoints.setVisible(false);
+                }
+            }
+
             final Preference translateBackends = findPreference("subtitleTranslateBackends");
             if (translateBackends != null) {
                 final LinkedHashMap<String, String> services = SubtitleTranslate.backends();

--- a/app/src/main/java/com/brouken/player/SubtitleSearch.java
+++ b/app/src/main/java/com/brouken/player/SubtitleSearch.java
@@ -29,20 +29,31 @@ import okhttp3.Response;
 import okhttp3.ResponseBody;
 
 /**
- * Where an online subtitle comes from. Four sources, tried in the order below until one of them has
- * the wanted language, each switchable on its own so a single source can be exercised in isolation.
+ * Where an online subtitle comes from. Four sources, all asked at once and answered in the order
+ * below, each switchable on its own so a single source can be exercised in isolation.
  *
  * <ol>
+ *   <li>{@link OpenSubtitles} (api.opensubtitles.com) — the fullest index, the only one that filters
+ *       by language server-side and the only one that knows whether a file is machine-translated,
+ *       how often it was downloaded and whether its uploader is trusted. First because that is what
+ *       decides whether the file is any good, and the three below can offer none of it.</li>
  *   <li>rest.opensubtitles.org — the retired legacy API, still answering and still the quickest to
  *       reply. One language per request and a gzipped file at the end of it.</li>
  *   <li>opensubtitles-v3.strem.io — imdb only, unmetered, already normalised to UTF-8.</li>
- *   <li>{@link OpenSubtitles} — the fullest index, the only one that filters by language server-side
- *       and knows whether a file is machine-translated. Third because it is the only metered one:
- *       100 downloads a day, and the two above cost nothing.</li>
  *   <li>shegu.st — tmdb only, unmetered, no language filter (the whole index arrives and is sifted
  *       here). Last because it is the least dependable: its index changed size twice within five
- *       minutes of testing, and about half its entries point at the host source 2 already is.</li>
+ *       minutes of testing, and about half its entries point at the host source 3 already is.</li>
  * </ol>
+ *
+ * <p>The keyed source led once before and was demoted during the build for being the only metered
+ * one — 100 downloads a day against three that cost nothing. That was the wrong way round, and the
+ * measurements in the feature's own notes said so at the time: the quota is counted per client, not
+ * pooled, so a hundred a day is a hundred for this device alone, which no viewer reaches. What was
+ * actually being saved was a budget nobody was spending, and what it cost was every search — the
+ * free indexes have no machine-translation flag, so the file that wins is whatever they list first.
+ * Its cost now: a search is free, and the metered call is the download, so a unit goes on any file
+ * this source offers that is looked at — including the rare one that loses to a better language from
+ * a free index further down.</p>
  *
  * Two of these normalise their URLs the way api.opensubtitles.com does and answer a redirect when
  * they are not given what they want: {@code rest.opensubtitles.org} needs its path segments in
@@ -170,41 +181,31 @@ final class SubtitleSearch {
                 + " s" + id.season + "e" + id.episode + " want=" + preferred
                 + " media=" + durationMs + "ms");
 
-        // The three keyless indexes are asked at once: none of them costs anything, they disagree
-        // about which files exist, and asking them in turn means waiting out each one's timeout
-        // before the next gets a chance. Results are still taken in source order, not in whichever
-        // order they happen to answer — but only the ones ahead of a hit are waited for.
+        // All four are asked at once: they disagree about which files exist, and asking them in turn
+        // means waiting out each one's timeout before the next gets a chance. Answers are still taken
+        // in source order, not in whichever order they arrive — but only the sources ahead of a hit
+        // are waited for, so the keyed one leading costs the others nothing when it delivers.
         // Whether a machine translation may be taken at all is one answer for every source that says
         // so — the setting is about the class of file, not about who is offering it.
         final boolean allowMachine = prefs.subtitleTranslate;
-        final List<Callable<Result>> keyless = new ArrayList<>(3);
+        final List<Callable<Result>> sources = new ArrayList<>(4);
+        if (prefs.subtitleSourceOpenSubtitles) {
+            sources.add(() -> fromOpenSubtitles(id, preferred, allowMachine));
+        }
         if (prefs.subtitleSourceRest) {
-            keyless.add(() -> best(SOURCE_REST,
+            sources.add(() -> best(SOURCE_REST,
                     restOpenSubtitles(id, preferred, answered, allowMachine), preferred, durationMs));
         }
         if (prefs.subtitleSourceStremio) {
-            keyless.add(() -> best(SOURCE_STREMIO, stremio(id, answered), preferred, durationMs));
+            sources.add(() -> best(SOURCE_STREMIO, stremio(id, answered), preferred, durationMs));
         }
         if (prefs.subtitleSourceShegu) {
-            keyless.add(() -> best(SOURCE_SHEGU, shegu(id, answered), preferred, durationMs));
+            sources.add(() -> best(SOURCE_SHEGU, shegu(id, answered), preferred, durationMs));
         }
-        final Result keylessHit = firstDelivered(keyless, sink, preferred);
-        if (keylessHit != null) {
-            return keylessHit;
-        }
-        // Only now the metered one. It is the fullest index, but its download call is the single
-        // thing here that spends one of a hundred a day — so it is asked only for what the free
-        // sources could not produce.
-        if (!cancelled() && prefs.subtitleSourceOpenSubtitles) {
-            final Result result = fromOpenSubtitles(id, preferred, allowMachine);
-            if (delivered(result, sink)) {
-                return result;
-            }
-        }
-        return null;
+        return firstDelivered(sources, sink, preferred);
     }
 
-    /** How long all the keyless sources together get before the search moves on without them. */
+    /** How long all the sources together get before the search moves on without them. */
     private static final int PARALLEL_TIMEOUT_SEC = 15;
 
     /**
@@ -218,7 +219,7 @@ final class SubtitleSearch {
      * arrives, and anything below it is held until the sources that might still beat it have answered.
      *
      *
-     * <p>The results are collected one source at a time on purpose. Waiting for all three before
+     * <p>The results are collected one source at a time on purpose. Waiting for all of them before
      * looking at any of them made every search as slow as its slowest source: rest.opensubtitles.org
      * answers a search in about 0.2 s and shegu.st, which is one small origin behind Cloudflare with
      * nothing cached ({@code cf-cache-status: DYNAMIC}) and no language filter, takes 0.3 s warm and

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -169,13 +169,13 @@
     <string name="subtitle_secondary_title">Дополнительные субтитры</string>
     <string name="subtitle_main_title">Основные субтитры</string>
     <string name="subtitle_search_found_secondary">Дополнительные субтитры: %1$s</string>
-    <string name="subtitle_secondary_unavailable">Эту дорожку нельзя показать второй строкой</string>
+    <string name="subtitle_secondary_unavailable">Эту дорожку нельзя показать как дополнительные субтитры</string>
     <string name="subtitle_secondary_peek_hint">Дополнительные субтитры появляются на паузе</string>
     <string name="pref_subtitle_secondary_header">Дополнительные субтитры</string>
     <string name="pref_subtitle_secondary_mode">Когда показывать</string>
-    <string name="pref_subtitle_secondary_mode_off">Никогда — второй строки нет совсем</string>
-    <string name="pref_subtitle_secondary_mode_always">Всегда — под первой строкой</string>
-    <string name="pref_subtitle_secondary_mode_demand">По требованию — появляется, когда попросишь, и уходит</string>
+    <string name="pref_subtitle_secondary_mode_off">Никогда — дополнительных субтитров нет совсем</string>
+    <string name="pref_subtitle_secondary_mode_always">Всегда — под основными субтитрами</string>
+    <string name="pref_subtitle_secondary_mode_demand">По требованию — над основными субтитрами на паузе</string>
     <string name="speed_title">Скорость воспроизведения</string>
     <string name="speed_normal">Обычная</string>
     <string name="audio_track_number">Дорожка %1$d</string>
@@ -297,7 +297,7 @@
     <string name="pref_subtitle_source_rest_summary">Закрытый API. Пока отвечает, но может отключиться в любой момент</string>
     <string name="pref_language_subtitle_none">Не задано — субтитры выключены, пока вы их не включите</string>
     <string name="pref_language_subtitle_secondary">Дополнительные субтитры по умолчанию</string>
-    <string name="pref_language_subtitle_secondary_none">Не задано — вторая строка выбирается только вручную во время просмотра</string>
+    <string name="pref_language_subtitle_secondary_none">Не задано — дополнительные субтитры выбираются только вручную во время просмотра</string>
     <string name="pref_subtitle_style_bold">Полужирный стиль</string>
     <string name="pref_subtitle_style_bold_on">Использовать полужирный шрифт как обычный</string>
     <string name="pref_subtitle_style_bold_off">Использовать стандартный шрифт по умолчанию</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -82,7 +82,12 @@
     <string name="pref_skip_hide_locked_off">Кнопка «Пропустить» и уведомление об автопропуске остаются видимыми, пока экран заблокирован</string>
     <string name="skip_offset_title">Смещение пропуска</string>
     <string name="skip_offset_reset">Сбросить</string>
-    <string name="button_skip_offset">Смещение пропуска</string>
+    <string name="offset_seconds">%1$s с</string>
+    <string name="skip_session_title">Пропуски в этом сеансе</string>
+    <string name="skip_mode_brief_short">5 с</string>
+    <string name="skip_mode_button_short">Кнопка</string>
+    <string name="skip_mode_auto_short">Авто</string>
+    <string name="skip_mode_off_short">Никогда</string>
     <string name="button_skip">Пропустить</string>
     <string name="button_skip_countdown">Пропустить %1$d</string>
     <string name="notification_skipped">Пропущено</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -285,7 +285,7 @@
     <string name="subtitle_search_season">Сезон %1$d</string>
     <string name="subtitle_search_episode">Эпизод %1$d</string>
     <string name="pref_subtitle_translate">Машинный перевод</string>
-    <string name="pref_subtitle_translate_on">Текст отправляется в Google Переводчик</string>
+    <string name="pref_subtitle_translate_on">Текст отправляется в онлайн-сервис перевода</string>
     <string name="pref_subtitle_translate_off">Субтитры показываются на том языке, на котором найдены</string>
     <string name="pref_subtitle_translate_backends">Сервисы перевода</string>
     <string name="pref_subtitle_translate_backends_none">Не задано — субтитры не переводятся</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -285,7 +285,7 @@
     <string name="subtitle_search_season">Сезон %1$d</string>
     <string name="subtitle_search_episode">Епізод %1$d</string>
     <string name="pref_subtitle_translate">Машинний переклад</string>
-    <string name="pref_subtitle_translate_on">Текст надсилається до Google Перекладача</string>
+    <string name="pref_subtitle_translate_on">Текст надсилається до онлайн-сервісу перекладу</string>
     <string name="pref_subtitle_translate_off">Субтитри показуються тією мовою, якою їх знайдено</string>
     <string name="pref_subtitle_translate_backends">Сервіси перекладу</string>
     <string name="pref_subtitle_translate_backends_none">Не задано — субтитри не перекладаються</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -176,13 +176,13 @@
     <string name="subtitle_secondary_title">Додаткові субтитри</string>
     <string name="subtitle_main_title">Основні субтитри</string>
     <string name="subtitle_search_found_secondary">Додаткові субтитри: %1$s</string>
-    <string name="subtitle_secondary_unavailable">Цю дорожку не можна показати другим рядком</string>
+    <string name="subtitle_secondary_unavailable">Цю дорожку не можна показати як додаткові субтитри</string>
     <string name="subtitle_secondary_peek_hint">Додаткові субтитри з’являються на паузі</string>
     <string name="pref_subtitle_secondary_header">Додаткові субтитри</string>
     <string name="pref_subtitle_secondary_mode">Коли показувати</string>
-    <string name="pref_subtitle_secondary_mode_off">Ніколи — другого рядка немає взагалі</string>
-    <string name="pref_subtitle_secondary_mode_always">Завжди — під першим рядком</string>
-    <string name="pref_subtitle_secondary_mode_demand">На вимогу — з’являється, коли попросити, і зникає</string>
+    <string name="pref_subtitle_secondary_mode_off">Ніколи — додаткових субтитрів немає взагалі</string>
+    <string name="pref_subtitle_secondary_mode_always">Завжди — під основними субтитрами</string>
+    <string name="pref_subtitle_secondary_mode_demand">На вимогу — над основними субтитрами на паузі</string>
     <string name="speed_title">Швидкість відтворення</string>
     <string name="speed_normal">Звичайна</string>
     <string name="audio_track_number">Доріжка %1$d</string>
@@ -297,7 +297,7 @@
     <string name="pref_subtitle_source_rest_summary">Закритий API. Ще відповідає, але може вимкнутись будь-коли</string>
     <string name="pref_language_subtitle_none">Не задано — субтитри вимкнені, доки ви їх не увімкнете</string>
     <string name="pref_language_subtitle_secondary">Додаткові субтитри за замовчуванням</string>
-    <string name="pref_language_subtitle_secondary_none">Не задано — другий рядок обирається лише вручну під час перегляду</string>
+    <string name="pref_language_subtitle_secondary_none">Не задано — додаткові субтитри обираються лише вручну під час перегляду</string>
     <string name="pref_subtitle_style_bold">Жирний стиль</string>
     <string name="pref_subtitle_style_bold_on">Використовувати жирний шрифт замість звичайного</string>
     <string name="pref_subtitle_style_bold_off">Використовувати звичайний шрифт за замовчуванням</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -83,7 +83,12 @@
     <string name="pref_skip_hide_locked_off">Кнопка «Пропустити» та сповіщення про автопропуск лишаються видимими, поки екран заблоковано</string>
     <string name="skip_offset_title">Зміщення пропуску</string>
     <string name="skip_offset_reset">Скинути</string>
-    <string name="button_skip_offset">Зміщення пропуску</string>
+    <string name="offset_seconds">%1$s с</string>
+    <string name="skip_session_title">Пропуски в цьому сеансі</string>
+    <string name="skip_mode_brief_short">5 с</string>
+    <string name="skip_mode_button_short">Кнопка</string>
+    <string name="skip_mode_auto_short">Авто</string>
+    <string name="skip_mode_off_short">Ніколи</string>
     <string name="button_skip">Пропустити</string>
     <string name="button_skip_countdown">Пропустити %1$d</string>
     <string name="notification_skipped">Пропущено</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -84,7 +84,17 @@
     <string name="pref_skip_hide_locked_off">The Skip button and auto-skip notification remain visible while the screen is locked</string>
     <string name="skip_offset_title">Skip offset</string>
     <string name="skip_offset_reset">Reset</string>
-    <string name="button_skip_offset">Skip offset</string>
+    <!-- Offset readout and summaries: the number is formatted in the viewer's locale, the unit
+         belongs to the language. -->
+    <string name="offset_seconds">%1$s s</string>
+    <!-- The player's skip panel: a mode per kind of segment for this session only, plus the offset.
+         Short labels because four of them share the width of the panel; the settings screen is where
+         each mode is spelled out in full. -->
+    <string name="skip_session_title">Skips in this session</string>
+    <string name="skip_mode_brief_short">5 s</string>
+    <string name="skip_mode_button_short">Button</string>
+    <string name="skip_mode_auto_short">Auto</string>
+    <string name="skip_mode_off_short">Never</string>
     <string name="button_skip">Skip</string>
     <string name="button_skip_countdown">Skip %1$d</string>
     <string name="notification_skipped">Skipped</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -192,13 +192,13 @@
     <string name="subtitle_secondary_title">Secondary subtitles</string>
     <string name="subtitle_main_title">Main subtitles</string>
     <string name="subtitle_search_found_secondary">Secondary subtitles: %1$s</string>
-    <string name="subtitle_secondary_unavailable">This track cannot be shown as a second line</string>
+    <string name="subtitle_secondary_unavailable">This track cannot be shown as secondary subtitles</string>
     <string name="subtitle_secondary_peek_hint">Secondary subtitles appear when you pause</string>
     <string name="pref_subtitle_secondary_header">Secondary subtitles</string>
     <string name="pref_subtitle_secondary_mode">When to show</string>
-    <string name="pref_subtitle_secondary_mode_off">Never — no second line at all</string>
-    <string name="pref_subtitle_secondary_mode_always">Always — under the first line</string>
-    <string name="pref_subtitle_secondary_mode_demand">On demand — shown when asked for, then gone</string>
+    <string name="pref_subtitle_secondary_mode_off">Never — no secondary subtitles at all</string>
+    <string name="pref_subtitle_secondary_mode_always">Always — under the main subtitles</string>
+    <string name="pref_subtitle_secondary_mode_demand">On demand — above the main subtitles when you pause</string>
     <string name="speed_title">Playback speed</string>
     <string name="speed_normal">Normal</string>
     <string name="audio_track_number">Track %1$d</string>
@@ -274,7 +274,7 @@
     <string name="pref_language_subtitle">Default subtitle track</string>
     <string name="pref_language_subtitle_none">Not set — subtitles stay off until you turn them on</string>
     <string name="pref_language_subtitle_secondary">Secondary subtitle track</string>
-    <string name="pref_language_subtitle_secondary_none">Not set — the second line is only ever chosen during playback</string>
+    <string name="pref_language_subtitle_secondary_none">Not set — secondary subtitles are only ever chosen during playback</string>
     <string name="pref_subtitle_search_screen">Search online</string>
     <string name="pref_subtitle_search_when">When to search</string>
     <string name="pref_subtitle_search_never">Never — only when I ask</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -309,7 +309,7 @@
     <string name="subtitle_search_season">Season %1$d</string>
     <string name="subtitle_search_episode">Episode %1$d</string>
     <string name="pref_subtitle_translate">Machine translation</string>
-    <string name="pref_subtitle_translate_on">The text goes to Google Translate</string>
+    <string name="pref_subtitle_translate_on">The text goes to an online translation service</string>
     <string name="pref_subtitle_translate_off">Subtitles are shown in the language they were found in</string>
     <string name="pref_subtitle_translate_backends">Translation services</string>
     <string name="pref_subtitle_translate_backends_none">Not set — subtitles are never translated</string>

--- a/app/src/main/res/xml/root_preferences.xml
+++ b/app/src/main/res/xml/root_preferences.xml
@@ -162,11 +162,19 @@
                 app:summary="@string/pref_subtitle_search_language_summary"
                 app:title="@string/pref_subtitle_search_language" />
 
-            <!-- Tried top to bottom until one has the wanted language. Individually switchable so a
+            <!-- Asked all at once and answered top to bottom, which is why OpenSubtitles.com stands
+                 first: it is the only one that knows whether a file is machine-translated, so it is
+                 the only one whose answer says anything about quality. Individually switchable so a
                  single source can be exercised on its own when a result looks wrong — a testing
                  affordance, which is why it sits at the bottom of a sub-screen and not on the way to
                  anything. -->
             <PreferenceCategory app:title="@string/pref_subtitle_sources">
+
+                <SwitchPreferenceCompat
+                    app:key="subtitleSourceOpenSubtitles"
+                    app:defaultValue="true"
+                    app:summary="@string/pref_subtitle_source_opensubtitles_summary"
+                    app:title="@string/pref_subtitle_source_opensubtitles" />
 
                 <SwitchPreferenceCompat
                     app:key="subtitleSourceRest"
@@ -185,12 +193,6 @@
                     app:defaultValue="true"
                     app:summary="@string/pref_subtitle_source_shegu_summary"
                     app:title="@string/pref_subtitle_source_shegu" />
-
-                <SwitchPreferenceCompat
-                    app:key="subtitleSourceOpenSubtitles"
-                    app:defaultValue="true"
-                    app:summary="@string/pref_subtitle_source_opensubtitles_summary"
-                    app:title="@string/pref_subtitle_source_opensubtitles" />
 
             </PreferenceCategory>
 

--- a/app/src/main/res/xml/root_preferences.xml
+++ b/app/src/main/res/xml/root_preferences.xml
@@ -168,7 +168,9 @@
                  single source can be exercised on its own when a result looks wrong — a testing
                  affordance, which is why it sits at the bottom of a sub-screen and not on the way to
                  anything. -->
-            <PreferenceCategory app:title="@string/pref_subtitle_sources">
+            <PreferenceCategory
+                app:key="subtitleSourcesCategory"
+                app:title="@string/pref_subtitle_sources">
 
                 <SwitchPreferenceCompat
                     app:key="subtitleSourceOpenSubtitles"

--- a/app/src/main/res/xml/root_preferences.xml
+++ b/app/src/main/res/xml/root_preferences.xml
@@ -93,8 +93,8 @@
             <!-- Size, colour and plate of its own. Edge and weight stay inherited from the first line —
                  nobody sets an outline for one line and not the other. The same three lists the main
                  line uses, so the colour chips and the clash check in SettingsActivity cover these for
-                 free. The defaults are chosen so that nobody has to come here: same size as the line
-                 above, dimmed text on a translucent plate, which is what tells a hint apart from the
+                 free. The defaults are chosen so that nobody has to come here: the same size as the
+                 main subtitles, dimmed text on a translucent plate, which is what tells a hint apart from the
                  line being read. -->
             <ListPreference
                 app:key="subtitleSecondaryScale"


### PR DESCRIPTION
Everything on this branch since #134: where the second subtitle line sits, a session's own answer for skip segments, and which index the subtitle search asks first.

### The second line goes above the one it translates

On demand the hint was drawn against the top edge of the picture, a screen away from the line it belongs to. It now sits directly above that line — the always-on arrangement with the order swapped, both lines at the bottom, both fixed. The band under the first line stays 0 on demand; the hint's bottom margin is the resting gap plus the room two lines of the main size take, reserved rather than measured, because media3 does not report where it painted the glyphs and a slot that follows the text is a first line that jumps. Reserving room above it costs the picture nothing while no hint is asked for, so the first line keeps the place every other mode gives it. Known ceiling: a cue that wraps to a third line grows into the slot.

### A session decides how its segments are skipped

Skip modes were global only, so a series whose episodes all match the same way meant pressing Skip every episode or changing the setting for every film after it. The skip panel now carries the session's own answer beside the offset it already held: one row of four — the button for five seconds, the button for the whole segment, skip silently, or leave the segments alone.

One row for both kinds of segment rather than one each: asked mid-film the intention is "stop interrupting me in this series", not one policy for the start of an episode and another for its end. The settings keep those apart for anyone who wants that, and nothing here is written to the preferences. The choice lives as long as the offset already did — the next file in the folder keeps it, a film picked afresh starts from the settings again — and the panel's reset gives both halves back to the settings, which was the one thing there was no way to do at all. Reached by holding the Skip pill, where the question arises, and from the playback-menu row, renamed after the panel it opens.

### The panel that holds them

The new row exposed work the panel needed, and the offset panel is shared with subtitle timing, so this lands there too:

- **it overflowed its own window** — 395dp of content in a 360dp panel, so the title was pushed off the top, the reset pill off the bottom, and the first focus went to the slider, which scrolled the panel there as it opened. The readout takes the smaller size whenever a choice shares the panel, and the focus goes to the choice;
- **the option in force was the dimmest thing in its row** (the accent at a third of its alpha, 1.1:1 against its neighbours, reading as switched off). It is filled with the accent and lettered in near-black now, and says so through `setSelected` as well;
- **48dp targets** for the pills and the reset pill, labels that shrink rather than wrap mid-word, and one focus signal for a remote: an edge in the accent — white on the pill that is already the accent — with nothing moving or changing size, so a row of equals stays a row of equals;
- **the offset readout is in the viewer's language.** The unit was a literal `" s"` and the number came from `Locale.US`, so a Ukrainian panel read "0 s" under a Ukrainian caption and printed "+2.5" where the language writes "+2,5";
- **spacing**: the hairline under the title is gone, blocks are held apart by a fixed gap (weighted spacers collapse to nothing exactly when the panel is full), and edges line up on one 24dp grid, with the ± row pulled out by the padding its buttons carry so the glyph sits on the grid rather than its box.

Checked with a D-pad on the TV emulator: the panel opens on the choice, left/right walks the pills, down reaches the slider and then reset, up comes back, OK lights the choice and applies it at once, reset clears it, and one press of BACK closes.

### The subtitle search asks the index that knows about the file first

api.opensubtitles.com led by decision and on measurements, and was demoted during the build for being the only metered one — 100 downloads a day against three indexes that cost nothing. That trade was backwards: the quota is counted per client rather than pooled, so a hundred a day is a hundred for one device, and what was being saved was a budget nobody spends. What it cost was every search, because only that source knows whether a file is machine-translated, how often it was downloaded and whether its uploader is trusted. The measured example: the most downloaded Russian file for Silo S01E05 is `ai_translated` with 1930 downloads against 222 for the human one.

All four sources are now asked at once with the keyed one answering first, so a free index only wins the languages it does not have, and they are no longer a fallback that runs *after* — a spent or withdrawn key costs no wall clock. Its cost, plainly: the metered call is the download, so a unit goes on any file this source offers that is looked at, including the rare one that loses to a better language from a free index.

### Source and endpoint switches are debug-only

Which index answered and which endpoint translated are not decisions a viewer can judge; those switches exist to take one source out of the picture while a wrong-looking result is chased down. The release build no longer shows them — and no longer reads what they wrote, because both sides share an applicationId and therefore the preferences: a source switched off during testing would otherwise stay off for good, invisibly, with nothing anywhere to turn it back on.

---

Built for `latestUniversal` and `legacyUniversal`; the release variant compiles. Tested by hand on a phone (OxygenOS 14) and with a D-pad on the `tv_720p` emulator.
