### PR TITLE
Keep the controls up while the remote is still walking them

### DIFF
--- a/app/src/main/java/com/brouken/player/PlayerActivity.java
+++ b/app/src/main/java/com/brouken/player/PlayerActivity.java
@@ -532,7 +532,8 @@ public class PlayerActivity extends Activity {
     private boolean pickerDialogOpen;
     // Media3 keeps the controller shown indefinitely while paused (it forces the auto-hide timeout to 0),
     // so reuse the same CONTROLLER_TIMEOUT + hideController() to also clear the UI on pause. A tap re-shows
-    // and re-arms it, exactly like during playback (see scheduleHideControllerOnPause).
+    // and re-arms it, exactly like during playback, and so does any key while the controls are up (see
+    // scheduleHideControllerOnPause and dispatchKeyEvent).
     private final Runnable hideControllerAction = () -> {
         if (player != null && !player.getPlayWhenReady() && controllerVisibleFully)
             playerView.hideController();
@@ -2943,6 +2944,14 @@ public class PlayerActivity extends Activity {
             }
             return true;
         } else {
+            // Any key press is activity: postpone the pause auto-hide. Media3 keeps the controller up
+            // indefinitely while paused, so hideControllerAction is what clears it — and that was armed
+            // only by a visibility change, never by a key. The controls therefore went away
+            // CONTROLLER_TIMEOUT after they appeared, in the middle of walking the D-pad over them, and
+            // the next key, arriving with them gone, seeked instead of moving the focus.
+            if (event.getAction() == KeyEvent.ACTION_DOWN) {
+                scheduleHideControllerOnPause();
+            }
             return super.dispatchKeyEvent(event);
         }
     }


### PR DESCRIPTION
Reported on TV: pause with OK, press Down twice to reach the bottom row, then Right — the panel disappears and the film seeks forward instead. The menu is unreachable on the first try.

**Cause.** Media3 pins the controller open while playback is paused, so the player hides it itself through `hideControllerAction`, `CONTROLLER_TIMEOUT` (3.5 s) after it appears. `scheduleHideControllerOnPause()` was called only from the controller visibility listener and from a play/pause transition — never from a key. Moving the focus changes no visibility, so the countdown ran regardless of what the remote was doing, and reaching the bottom row costs two presses of Down (play/pause → time bar → buttons). The controls vanished mid-walk; media3's auto-show brought them back with the focus reset to play/pause, and a Right press arriving while they were gone went to `seekWithKey` — the fast-forward the viewer never asked for. Playback is unaffected because there media3's own timeout is reset by every D-pad key.

**Fix.** `dispatchKeyEvent` postpones the pause auto-hide on every key that reaches the controls. The timeout is unchanged and now measured from the last press, so the frame is still uncovered once the remote is put down.

**Checked on the TV emulator, before and after** (pause → Down → Down → Right, 1.6 s apart):

| | before | after |
|---|---|---|
| +4.7 s, after both Downs | focus back on play/pause: the panel had gone and returned, both presses wasted | panel up, focus on the aspect-ratio button |
| +5.9 s, on Right | panel coming and going; on a real box this is the seek | focus moves to the gear, position unchanged |
| +4.5 s after the last press | — | panel gone, frame uncovered |

Playing state re-checked: no panel 9 s into playback, as before.