### PR TITLE
Refill the buffer after a stall instead of resuming on two seconds

### DIFF
--- a/app/src/main/java/com/brouken/player/PlayerActivity.java
+++ b/app/src/main/java/com/brouken/player/PlayerActivity.java
@@ -303,6 +303,13 @@ public class PlayerActivity extends Activity {
     // Progress below this over a whole window is not a load: 8 KB/s is far under anything playable, so it
     // is a socket dribbling keepalives rather than a source that is still working. Wait only for real bytes.
     private static final long LOAD_PROGRESS_MIN_BYTES = 256 * 1024;
+    // How much has to be buffered before playback resumes after a stall, on network media only. Media3
+    // asks for two seconds, which a torrent backend eats with its next pause to fetch pieces from peers:
+    // the player stops again, refills two seconds, stops again — the sawtooth users report as an endless
+    // load on a big remux that no error ever comes out of. Refilling properly costs one wait instead of
+    // twenty. It cannot become unreachable: a high-bitrate file caps its own buffer by bytes long before
+    // this, and shouldStartPlayback starts playing as soon as that cap is hit.
+    private static final int BUFFER_AFTER_REBUFFER_MS = 15_000;
     // Buffering that resolves this fast is not worth an indicator: the spinner would replace the play button
     // for a frame or two and read as a glitch. Recreating the audio track (restartPassthroughAudio) takes
     // about 35 ms, a track switch or a seek inside the buffer are the same order, and a real wait is always
@@ -9963,6 +9970,16 @@ public class PlayerActivity extends Activity {
         playerBuilder.setMediaSourceFactory(
                 new DefaultMediaSourceFactory(this, convertDV7 ? dv7Converter : extractorsFactory)
                         .setDataSourceFactory(dataSourceFactory));
+        // Everything but the last figure is Media3's own default; only the wait after a stall changes,
+        // and only for streams (file:// and content:// keep their separate, shorter defaults, where a
+        // stall means a slow disk rather than a source that fills in bursts).
+        playerBuilder.setLoadControl(new DefaultLoadControl.Builder()
+                .setBufferDurationsMsForStreaming(
+                        DefaultLoadControl.DEFAULT_MIN_BUFFER_MS,
+                        DefaultLoadControl.DEFAULT_MAX_BUFFER_MS,
+                        DefaultLoadControl.DEFAULT_BUFFER_FOR_PLAYBACK_MS,
+                        BUFFER_AFTER_REBUFFER_MS)
+                .build());
 
         player = playerBuilder.build();
 


### PR DESCRIPTION
## Problem

Reported on a Google TV Streamer 4K playing a 2160p BDRemux over a TorrServe stream: the buffer climbs to 42%, drains to a stop, climbs back to 15-20%, drains again — an endless load that never turns into an error. The same file plays steadily in another player.

The percentages come from the stats overlay, where the figure is `getTotalBufferedDuration()` over `DEFAULT_MAX_BUFFER_MS`. So 42% is 21 seconds and 15-20% is 7-10 seconds.

Two separate things were going on:

- **The 42% ceiling is correct and not the bug.** Nothing configured a `LoadControl`, so Media3's defaults applied: the buffer is capped by bytes (~137 MB for video plus audio) rather than by the 50 s window, and at this file's ~50 Mbps that allowance is exactly 21 seconds. A 4K remux cannot buffer past 42% and does not need to.
- **The bug is the return from a stall.** `DEFAULT_BUFFER_FOR_PLAYBACK_AFTER_REBUFFER_MS` is 2000. Two seconds is what a torrent backend spends on its next pause to fetch pieces from peers, so the player stops again immediately, refills two seconds, and stops again. Nothing raises an error along the way — bytes keep arriving, so the load watchdog keeps re-arming — which is why the viewer sees a load that never finishes rather than a message.

## Change

A `DefaultLoadControl` that changes one figure out of four: the wait after a stall goes from 2 s to 15 s, for streams only. Start-up latency is untouched everywhere (`bufferForPlaybackMs` stays at its default), and `file://` / `content://` keep their own, shorter defaults via `setBufferDurationsMsForStreaming`.

The threshold cannot become unreachable. `shouldStartPlayback` starts playback either when the time threshold is met **or** when the byte allowance is full, and a high-bitrate file hits the byte allowance first — verified against the local prebuilt ExoPlayer AAR rather than assumed.

`targetBufferBytes` is deliberately left alone: the ceiling is a memory budget, not a defect, and raising it buys seconds linearly for memory spent linearly.

## Trade-offs

- After a stall on a **live** stream the threshold is now `min(targetLiveOffset / 2, 15 s)`, so live resumes further behind the edge than before. `recoverLiveStall` still snaps back to the edge when it fires.
- The first stall becomes one longer wait instead of a run of short ones. On a healthy stream nothing changes, because a healthy stream does not stall.
- This adds no bandwidth. If a source cannot sustain the file's bitrate on average, the stalls become rarer and longer rather than going away.

## Testing

No unit tests in this project. Checked on the Android TV emulator with a debug build:

- ordinary HTTP VOD — plays, no errors;
- live HLS — plays, no errors, start-up unchanged by eye;
- local playback is untouched by construction (`build()` keeps the local values separate when only the streaming setter is called).

The reported scenario itself can only be confirmed by the reporter: after the first stop the buffer should refill to ~40% rather than 15-20%.