### PR TITLE
Ask for the whole file by range so range-only servers answer at all

### DIFF
--- a/app/src/main/java/com/brouken/player/PlayerActivity.java
+++ b/app/src/main/java/com/brouken/player/PlayerActivity.java
@@ -9969,6 +9969,15 @@ public class PlayerActivity extends Activity {
                 headers.put("Authorization", "Basic " + Base64.encodeToString(userInfo.getBytes(), Base64.NO_WRAP));
             }
 
+            // Some proxies (Telegram-stream bridges among them) answer range requests only: a GET with
+            // no Range header gets no response at all, not even headers, so nothing is ever transferred
+            // and the load watchdog reports a timeout on a stream that is working. Media3 is the client
+            // that opens without one — HttpUtil.buildRangeRequestHeader returns null at position 0 with
+            // an unbounded length — so seed the whole-file range every browser sends. A default request
+            // property is the lowest priority DefaultHttpDataSource has: it overwrites this whenever it
+            // computes a real range, leaving seeks and byte-range segments alone.
+            headers.put("Range", "bytes=0-");
+
             // Always our own factory, headers or not, for the read timeout. Media3 defaults it to 8 s,
             // which is a verdict a torrent-backed server cannot meet: it answers the range request at
             // once and then goes quiet for as long as fetching those pieces from peers takes. Silence is
@@ -9983,9 +9992,7 @@ public class PlayerActivity extends Activity {
             if (userAgent != null) {
                 defaultHttpDataSourceFactory.setUserAgent(userAgent);
             }
-            if (!headers.isEmpty()) {
-                defaultHttpDataSourceFactory.setDefaultRequestProperties(headers);
-            }
+            defaultHttpDataSourceFactory.setDefaultRequestProperties(headers);
             upstreamFactory = new DefaultDataSource.Factory(this, defaultHttpDataSourceFactory);
         }
 


### PR DESCRIPTION
A user reported a Telegram-stream proxy URL that plays in other players but not
in ours; reproduced.

The server replies only to range requests, verified against the endpoint directly:

| Request | Result |
|---|---|
| `GET` with `Range: bytes=0-` | `206`, first byte after 1.8 s, ~1.6 MB/s |
| `GET` with `Range: bytes=1000000-1050000` | `206` |
| `GET` with no `Range` | **hangs — 0 bytes, no response headers at all** |
| `HEAD` | hangs |

Media3 is the client that opens without a range: `HttpUtil.buildRangeRequestHeader`
returns `null` at position 0 with an unbounded length, so the very first read carries
no `Range` header. Nothing is ever transferred, and 30 s later the load watchdog
reports a timeout on a stream that is working. Browsers and VLC send `bytes=0-` on
the opening request, which is why the same file plays there.

So send it too, as a *default* request property — the lowest priority
`DefaultHttpDataSource` has. It overwrites the seeded value via
`setRequestProperty(RANGE, …)` whenever it computes a real range, so seeks and
byte-range segments are untouched. HLS playlists and segments now come back as
`206` instead of `200`; `DefaultHttpDataSource` accepts both (the status only
decides `bytesToSkip`, which is 0 at position 0 either way).

The `!headers.isEmpty()` guard goes away with it, since the map can no longer be
empty.

## Verified on device

Debug build on a phone, launched at the reported URL:

- video `MediaCodec` adapter created ~2.7 s in — the 3.37 MB faststart `moov` was
  parsed straight away;
- buffer filled to 15.8 s and held there (`DefaultLoadControl` full);
- no `InvalidResponseCodeException`, no player error, no load timeout;
- playback and seeking confirmed by the reporter.
