### PR TITLE
Add two TV settings: single-press Back and keeping the screen on while paused

### DIFF
--- a/app/src/main/java/com/brouken/player/PlayerActivity.java
+++ b/app/src/main/java/com/brouken/player/PlayerActivity.java
@@ -594,6 +594,20 @@ public class PlayerActivity extends Activity {
     // Same guard on TV, once Back has nothing left to close: a stray press on a remote must not drop
     // out of the player.
     private boolean backPressedOnce;
+    // Holding the screen through a pause is what keeps the box's screensaver away, and the screensaver
+    // is what takes the audio output — and, with the memory pressure behind it, sometimes the process —
+    // down with it. What it costs is a still picture and a control bar that never hides (a pause sets
+    // the controller timeout to -1) burnt into a panel for as long as the pause lasts. So the hold comes
+    // with a black sheet faded over everything once the pause has stood a minute, and is given up
+    // altogether once it has stood two hours: whoever fell asleep does not need the television on.
+    private static final long DIM_DELAY_MS = 60_000L;
+    private static final long KEEP_AWAKE_MAX_MS = 2 * 60 * 60 * 1000L;
+    private static final float DIM_ALPHA = 0.85f;
+    private static final int DIM_IN_MS = 800;
+    private static final int DIM_OUT_MS = 300;
+    private View dimOverlay;
+    private final Runnable dimRunnable = this::dim;
+    private final Runnable keepAwakeGiveUpRunnable = () -> playerView.setKeepScreenOn(false);
     // Set while a Down press is opening the controls, so focus lands on the time bar instead of play/pause.
     private boolean focusTimeBarOnShow;
     // The page shown when there is nothing to play; owns its own views, reveal and pulse.
@@ -1145,6 +1159,7 @@ public class PlayerActivity extends Activity {
         restoreApiSession(savedInstanceState != null ? savedInstanceState : inheritedState);
 
         coordinatorLayout = findViewById(R.id.coordinatorLayout);
+        dimOverlay = findViewById(R.id.dim_overlay);
         mAudioManager = (AudioManager) getSystemService(Context.AUDIO_SERVICE);
         playerView = findViewById(R.id.video_view);
         // Built with the view rather than with the player: it paints from a file and asks for the
@@ -2384,6 +2399,9 @@ public class PlayerActivity extends Activity {
     public void onResume() {
         super.onResume();
         restorePlayStateAllowed = true;
+        // Coming back is a sign of life, and it is also where a setting turned off while we were away
+        // stops applying.
+        resetDim();
         // Back in front, so nothing we launched can still need the device's auto-rotate. onActivityResult
         // normally beats us to this; it does not run for a picker that finishes without handing back a result.
         restoreRotationLock();
@@ -2598,9 +2616,10 @@ public class PlayerActivity extends Activity {
         }
         // On TV the remote's Back is pressed mid-interaction all the time, so it has to consume what is
         // open before it means "leave": a pending key-seek, then the controls. Only with nothing left to
-        // close does it ask for a second press. This lives here rather than in onKeyDown because
-        // enableOnBackInvokedCallback routes Back straight to onBackPressed on Android 13+, where it
-        // never arrives as a key event at all.
+        // close does it ask for a second press — which the viewer can turn off, keeping the two steps that
+        // consume something and dropping only the confirmation. This lives here rather than in onKeyDown
+        // because enableOnBackInvokedCallback routes Back straight to onBackPressed on Android 13+, where
+        // it never arrives as a key event at all.
         if (isTvBox && haveMedia && !locked) {
             if (keyScrubTarget >= 0) {
                 playerView.removeCallbacks(keyScrubCommit);
@@ -2616,7 +2635,7 @@ public class PlayerActivity extends Activity {
                 playerView.hideController();
                 return;
             }
-            if (!backPressedOnce) {
+            if (!mPrefs.tvSingleBack && !backPressedOnce) {
                 backPressedOnce = true;
                 Utils.showText(playerView, getString(R.string.press_back_again), 2000);
                 playerView.postDelayed(() -> backPressedOnce = false, 2000);
@@ -3001,6 +3020,13 @@ public class PlayerActivity extends Activity {
 
     @Override
     public boolean dispatchKeyEvent(KeyEvent event) {
+        // Before anything else, including the locked early-return below: a dimmed screen that a locked
+        // player cannot wake is a screen with no way back. The first press only brings the picture back
+        // and is swallowed, the way waking a screen anywhere else does not also press what was under it.
+        if (resetDim()) {
+            return true;
+        }
+
         // While locked, swallow every key at the earliest point — before the view hierarchy,
         // onKeyDown, and the window's default (MediaSession-backed) volume handling — so hardware
         // volume/media/seek keys can't act. BACK is excluded so the normal lock-aware exit path
@@ -9722,6 +9748,7 @@ public class PlayerActivity extends Activity {
             updateSubtitleStyle(this);
             updateOverlayClock();
             updateStats();
+            resetDim();
             // Coming back from the settings screen no longer rebuilds the player by itself (see onStop),
             // but options like the decoder priority or tunneling are baked into it at build time. So
             // rebuild when the screen actually changed something — going in for a look costs nothing.
@@ -10994,7 +11021,7 @@ public class PlayerActivity extends Activity {
                         || player.getPlaybackState() == Player.STATE_READY)) {
                 playerView.postDelayed(rebufferArmRunnable, REBUFFER_ARM_MS);
             }
-            playerView.setKeepScreenOn(isPlaying);
+            resetDim();
 
             if (Utils.isPiPSupported(PlayerActivity.this)) {
                 if (isPlaying) {
@@ -12250,6 +12277,50 @@ public class PlayerActivity extends Activity {
             e.printStackTrace();
         }
         return false;
+    }
+
+    /** Whether a pause is currently entitled to hold the screen awake. */
+    private boolean keepAwakeOnPause() {
+        return mPrefs != null && mPrefs.keepAwakeOnPause && isTvBox && haveMedia && !isInPip();
+    }
+
+    /**
+     * Every sign of life comes through here: it takes the sheet away and re-arms it, and it is the one
+     * place that decides whether the screen is held. Returns true when the caller's event did nothing but
+     * wake the screen, so it can be swallowed — Back on a dimmed screen would otherwise leave the player.
+     */
+    private boolean resetDim() {
+        if (dimOverlay == null) {
+            return false;
+        }
+        playerView.removeCallbacks(dimRunnable);
+        playerView.removeCallbacks(keepAwakeGiveUpRunnable);
+
+        final boolean wasDim = dimOverlay.getVisibility() == View.VISIBLE;
+        if (wasDim) {
+            dimOverlay.animate().cancel();
+            dimOverlay.animate().alpha(0f).setDuration(DIM_OUT_MS)
+                    .withEndAction(() -> dimOverlay.setVisibility(View.GONE));
+        }
+
+        final boolean playing = player != null && player.isPlaying();
+        final boolean holding = keepAwakeOnPause();
+        playerView.setKeepScreenOn(playing || holding);
+        if (holding && !playing) {
+            playerView.postDelayed(dimRunnable, DIM_DELAY_MS);
+            playerView.postDelayed(keepAwakeGiveUpRunnable, KEEP_AWAKE_MAX_MS);
+        }
+        return wasDim;
+    }
+
+    private void dim() {
+        if (!keepAwakeOnPause() || (player != null && player.isPlaying())) {
+            return;
+        }
+        dimOverlay.animate().cancel();
+        dimOverlay.setAlpha(0f);
+        dimOverlay.setVisibility(View.VISIBLE);
+        dimOverlay.animate().alpha(DIM_ALPHA).setDuration(DIM_IN_MS).withEndAction(null);
     }
 
     @RequiresApi(api = Build.VERSION_CODES.N)

--- a/app/src/main/java/com/brouken/player/Prefs.java
+++ b/app/src/main/java/com/brouken/player/Prefs.java
@@ -61,6 +61,8 @@ class Prefs {
     private static final String PREF_KEY_FRAMERATE_MATCHING = "frameRateMatching";
     private static final String PREF_KEY_ALLOW_SYSTEM_FRAMERATE = "allowSystemFrameRate";
     private static final String PREF_KEY_REPEAT_TOGGLE = "repeatToggle";
+    private static final String PREF_KEY_TV_SINGLE_BACK = "tvSingleBack";
+    private static final String PREF_KEY_KEEP_AWAKE_ON_PAUSE = "keepAwakeOnPause";
     private static final String PREF_KEY_SPEED = "speed";
     private static final String PREF_KEY_FILE_ACCESS = "fileAccess";
     private static final String PREF_KEY_DECODER_PRIORITY = "decoderPriority";
@@ -197,6 +199,8 @@ class Prefs {
     public boolean frameRateMatching = false;
     public boolean allowSystemFrameRate = true;
     public boolean repeatToggle = false;
+    public boolean tvSingleBack = false;
+    public boolean keepAwakeOnPause = true;
     public String fileAccess = "auto";
     public int decoderPriority = DefaultRenderersFactory.EXTENSION_RENDERER_MODE_ON;
     public boolean mapDV7ToHevc = false;
@@ -370,6 +374,8 @@ class Prefs {
         frameRateMatching = mSharedPreferences.getBoolean(PREF_KEY_FRAMERATE_MATCHING, frameRateMatching);
         allowSystemFrameRate = mSharedPreferences.getBoolean(PREF_KEY_ALLOW_SYSTEM_FRAMERATE, !Utils.isTvBox(mContext));
         repeatToggle = mSharedPreferences.getBoolean(PREF_KEY_REPEAT_TOGGLE, repeatToggle);
+        tvSingleBack = mSharedPreferences.getBoolean(PREF_KEY_TV_SINGLE_BACK, tvSingleBack);
+        keepAwakeOnPause = mSharedPreferences.getBoolean(PREF_KEY_KEEP_AWAKE_ON_PAUSE, keepAwakeOnPause);
         fileAccess = mSharedPreferences.getString(PREF_KEY_FILE_ACCESS, fileAccess);
         decoderPriority = Integer.parseInt(mSharedPreferences.getString(PREF_KEY_DECODER_PRIORITY, String.valueOf(decoderPriority)));
         mapDV7ToHevc = mSharedPreferences.getBoolean(PREF_KEY_MAP_DV7, mapDV7ToHevc);

--- a/app/src/main/java/com/brouken/player/SettingsActivity.java
+++ b/app/src/main/java/com/brouken/player/SettingsActivity.java
@@ -239,6 +239,17 @@ public class SettingsActivity extends AppCompatActivity
                 // Same reason: there is no finger to hold on the picture.
                 preferenceHoldSpeed.setVisible(false);
             }
+            Preference preferenceSingleBack = findPreference("tvSingleBack");
+            if (preferenceSingleBack != null && !Utils.isTvBox(getContext())) {
+                // Only the remote gets asked for a second Back; touch already leaves on the first one.
+                preferenceSingleBack.setVisible(false);
+            }
+            Preference preferenceKeepAwake = findPreference("keepAwakeOnPause");
+            if (preferenceKeepAwake != null && !Utils.isTvBox(getContext())) {
+                // Holding a phone awake through a pause drains it for no one's benefit: the complaint is
+                // the TV's screensaver, which takes the audio output and the process down with it.
+                preferenceKeepAwake.setVisible(false);
+            }
             ListPreference listPreferenceFileAccess = findPreference("fileAccess");
             if (listPreferenceFileAccess != null) {
                 List<String> entries = new ArrayList<>(Arrays.asList(getResources().getStringArray(R.array.file_access_entries)));

--- a/app/src/main/res/layout/activity_player.xml
+++ b/app/src/main/res/layout/activity_player.xml
@@ -232,4 +232,21 @@
 
     </FrameLayout>
 
+    <!-- Burn-in guard for a paused picture: a black sheet faded in over everything once a pause has
+         stood long enough, and taken away again on the first sign of life. It has to sit above the
+         controls rather than beside the video, because a pause holds the control bar on screen
+         indefinitely (setControllerShowTimeoutMs(-1)) and that bar is the most static thing there is.
+         The elevation is what puts it there: the stats panel, the room pill and the unlock bar are
+         added to this layout at runtime and would otherwise be drawn last. -->
+    <View
+        android:id="@+id/dim_overlay"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:alpha="0"
+        android:background="@color/black"
+        android:elevation="100dp"
+        android:importantForAccessibility="no"
+        android:outlineProvider="none"
+        android:visibility="gone" />
+
 </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -54,6 +54,9 @@
     <string name="pref_title">Настройки</string>
     <string name="pref_repeat_toggle">Переключение повтора</string>
     <string name="pref_repeat_toggle_summary">Дополнительное управление, позволяющее бесконечно зацикливать видео (требуется перезапуск приложения)</string>
+    <string name="pref_tv_single_back">Выход одним нажатием «Назад»</string>
+    <string name="pref_tv_single_back_on">«Назад» выходит из проигрывателя, как только закрывать больше нечего</string>
+    <string name="pref_tv_single_back_off">«Назад» просит нажать ещё раз, прежде чем выйти из проигрывателя</string>
     <string name="pref_disable_volume_brightness_gestures">Отключить жесты громкости и яркости</string>
     <string name="pref_disable_volume_brightness_gestures_on">Свайпы вверх и вниз ничего не делают; перемотка, масштаб и кнопки громкости работают</string>
     <string name="pref_disable_volume_brightness_gestures_off">Проведите вверх или вниз, чтобы изменить яркость в левой части экрана и громкость в правой</string>
@@ -204,6 +207,9 @@
     <string name="stats_report_message">Отправьте эти подробности воспроизведения, сообщая о проблеме с изображением или звуком.</string>
     <string name="pref_show_stats_on">Буфер, декодеры и пропущенные кадры показываются с элементами управления</string>
     <string name="pref_show_stats_off">Подробности воспроизведения скрыты</string>
+    <string name="pref_keep_awake_on_pause">Не гасить экран на паузе</string>
+    <string name="pref_keep_awake_on_pause_on">Заставка устройства не включается; изображение затемняется через минуту, а через два часа экран отдаётся системе</string>
+    <string name="pref_keep_awake_on_pause_off">Пауза остаётся на усмотрение устройства, и его заставка включается как обычно</string>
     <string name="volume_high_warning">Высокая громкость может повредить слух</string>
     <string name="pref_file_access_auto">Авто</string>
     <string name="pref_file_access">Доступ к файлам</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -55,6 +55,9 @@
     <string name="pref_auto_pip_off">Не перемикатися автоматично на режим PiP</string>
     <string name="pref_repeat_toggle">Переключення повтору</string>
     <string name="pref_repeat_toggle_summary">Додатковий контроль, що дозволяє необмежений цикл відео (потрібно перезапустити додаток)</string>
+    <string name="pref_tv_single_back">Вихід одним натисканням «Назад»</string>
+    <string name="pref_tv_single_back_on">«Назад» виходить із програвача, щойно не лишається чого закрити</string>
+    <string name="pref_tv_single_back_off">«Назад» просить натиснути ще раз, перш ніж вийти з програвача</string>
     <string name="pref_disable_volume_brightness_gestures">Вимкнути жести гучності та яскравості</string>
     <string name="pref_disable_volume_brightness_gestures_on">Проведення вгору та вниз нічого не робить; перемотування, масштаб і кнопки гучності працюють</string>
     <string name="pref_disable_volume_brightness_gestures_off">Проведіть вгору або вниз, щоб змінити яскравість у лівій частині екрана та гучність у правій</string>
@@ -211,6 +214,9 @@
     <string name="stats_report_message">Надішліть ці подробиці відтворення, повідомляючи про проблему із зображенням чи звуком.</string>
     <string name="pref_show_stats_on">Буфер, декодери та пропущені кадри показуються з елементами керування</string>
     <string name="pref_show_stats_off">Подробиці відтворення приховані</string>
+    <string name="pref_keep_awake_on_pause">Не вимикати екран на паузі</string>
+    <string name="pref_keep_awake_on_pause_on">Заставка пристрою не вмикається; зображення тьмяніє через хвилину, а через дві години екран віддається системі</string>
+    <string name="pref_keep_awake_on_pause_off">Пауза лишається на розсуд пристрою, і його заставка вмикається як завжди</string>
     <string name="volume_high_warning">Висока гучність може зашкодити слуху</string>
     <string name="pref_file_access">Доступ до файлів</string>
     <string name="pref_file_access_auto">Автоматично</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -56,6 +56,9 @@
     <string name="pref_auto_pip_off">Do not automatically switch to PiP</string>
     <string name="pref_repeat_toggle">Repeat toggle</string>
     <string name="pref_repeat_toggle_summary">Extra control to allow indefinitely loop video (requires app restart)</string>
+    <string name="pref_tv_single_back">Leave with one Back press</string>
+    <string name="pref_tv_single_back_on">Back leaves the player as soon as there is nothing left to close</string>
+    <string name="pref_tv_single_back_off">Back asks for a second press before leaving the player</string>
     <string name="pref_disable_volume_brightness_gestures">Turn off volume and brightness swipes</string>
     <string name="pref_disable_volume_brightness_gestures_on">Swiping up and down does nothing; seeking, zoom and the volume buttons still work</string>
     <string name="pref_disable_volume_brightness_gestures_off">Swipe up and down to change brightness on the left of the screen and volume on the right</string>
@@ -232,6 +235,9 @@
     <string name="stats_report_message">Send these playback details when reporting a problem with picture or sound.</string>
     <string name="pref_show_stats_on">Buffer, decoders and dropped frames are shown with the player controls</string>
     <string name="pref_show_stats_off">Playback details stay hidden</string>
+    <string name="pref_keep_awake_on_pause">Keep the screen on while paused</string>
+    <string name="pref_keep_awake_on_pause_on">The device screensaver stays away; the picture dims after a minute and the screen is released after two hours</string>
+    <string name="pref_keep_awake_on_pause_off">A pause is left to the device, and its screensaver comes on as usual</string>
     <string name="volume_high_warning">High volume may damage your hearing</string>
     <string name="pref_file_access">File access</string>
     <string name="pref_file_access_auto">Auto</string>

--- a/app/src/main/res/xml/root_preferences.xml
+++ b/app/src/main/res/xml/root_preferences.xml
@@ -280,6 +280,13 @@
             app:summary="@string/pref_repeat_toggle_summary"
             app:title="@string/pref_repeat_toggle" />
 
+        <SwitchPreferenceCompat
+            app:key="tvSingleBack"
+            app:defaultValue="false"
+            app:summaryOn="@string/pref_tv_single_back_on"
+            app:summaryOff="@string/pref_tv_single_back_off"
+            app:title="@string/pref_tv_single_back" />
+
     </PreferenceCategory>
 
     <PreferenceCategory app:title="@string/pref_onscreen_header">
@@ -304,6 +311,13 @@
             app:summaryOn="@string/pref_show_stats_on"
             app:summaryOff="@string/pref_show_stats_off"
             app:title="@string/stats_title" />
+
+        <SwitchPreferenceCompat
+            app:key="keepAwakeOnPause"
+            app:defaultValue="true"
+            app:summaryOn="@string/pref_keep_awake_on_pause_on"
+            app:summaryOff="@string/pref_keep_awake_on_pause_off"
+            app:title="@string/pref_keep_awake_on_pause" />
 
     </PreferenceCategory>
 


### PR DESCRIPTION
Two settings TV viewers keep asking for. Both are switches shown only on TV, where the behaviour they change exists.

### Leave with one Back press (off by default)

Drops the confirmation step alone. Back still cancels a pending D-pad seek and still closes the controls first, so leaving a track picker does not leave the player — only the "press back again" step goes away. The locked screen keeps its own two-press guard.

### Keep the screen on while paused (on by default)

The screen was held only while playing, so a pause handed the device straight to its screensaver — which takes the audio output, and under the memory pressure behind it sometimes the process, down with it.

What that costs is a still picture and a control bar that never hides burnt into a panel for as long as the pause lasts, so the hold comes with a black sheet faded over the whole window after a minute, and is given up altogether after two hours. The sheet covers the controls rather than sitting beside the video: a pause holds them on screen indefinitely, which makes the bar the most static thing there is. Any key takes the sheet away and is swallowed doing so, the way waking a screen elsewhere does not also press what was under it.

Dimming is an alpha overlay rather than a window brightness override, which a TV box ignores — the panel is the television's to control.

### Verified on the tv_720p emulator

- The sheet covers the picture, the control bar, the clock and the play button.
- `dumpsys window` while paused: `fl=KEEP_SCREEN_ON` and a `SCREEN_BRIGHT_WAKE_LOCK` for the app; with the setting off, neither is there.
- Back on a dimmed screen wakes it and does not leave the player.
- With single-press Back on, Back hides the controls and the next one leaves; with it off, "Press back again to exit" is unchanged.