### PR TITLE
Accept subtitles that run past the end of the media, and let the search say what it did

### DIFF
--- a/app/src/main/java/com/brouken/player/PlayerActivity.java
+++ b/app/src/main/java/com/brouken/player/PlayerActivity.java
@@ -5255,15 +5255,21 @@ public class PlayerActivity extends Activity {
      * both, and the dump leaves a TV box by QR instead of a clipboard nothing there can paste from.
      */
     private void showPlayerState() {
-        final StringBuilder state = new StringBuilder();
-        appendPlayerState(state);
-        if (state.length() == 0) {
+        final String state = playerStateReport();
+        if (state.isEmpty()) {
             return;
         }
         final Format video = player == null ? null : player.getVideoFormat();
         ErrorActivity.showReport(this, getString(R.string.stats_report_title),
                 getString(R.string.stats_report_message),
-                video == null ? null : Format.toLogString(video), state.toString().trim());
+                video == null ? null : Format.toLogString(video), state);
+    }
+
+    /** The dump the report screen shows, also handed to any message worth a "Details" button. */
+    private String playerStateReport() {
+        final StringBuilder state = new StringBuilder();
+        appendPlayerState(state);
+        return state.toString().trim();
     }
 
     // Small episode-number chip, inset from the poster's top-start corner so its rounded corners don't
@@ -6559,11 +6565,14 @@ public class PlayerActivity extends Activity {
                 // the guess.
                 final String device = Utils.toIso3Language(Locale.getDefault().getLanguage());
                 if (device == null) {
+                    Utils.log("subtitles: no language list and no device language, not searching");
                     return;
                 }
                 preferred = Collections.singletonList(device);
             } else if (forSecondary
                     || Utils.splitLanguages(mPrefs.languageSubtitleSecondary).isEmpty()) {
+                Utils.log("subtitles: no subtitle language set, not searching"
+                        + (mPrefs.subtitleSearch ? "" : " (online search is off too)"));
                 return;
             }
             // Falls through with an empty list on purpose: the first line wanting nothing is not the end
@@ -6594,6 +6603,8 @@ public class PlayerActivity extends Activity {
         }
         if (missing.isEmpty() && secondary.isEmpty()) {
             if (!manual) {
+                Utils.log("subtitles: nothing wanted (want=" + preferred
+                        + " already satisfied by the tracks present), not searching");
                 return;
             }
             // Asked for regardless: whatever track outranked the list is evidently not doing the job.
@@ -6603,6 +6614,15 @@ public class PlayerActivity extends Activity {
                 missing = preferred;
             }
         }
+        Utils.log("subtitles: search " + (manual ? "manual" : "auto")
+                + ", online=" + mPrefs.subtitleSearch
+                + ", strict=" + mPrefs.subtitleSearchStrict
+                + ", translate=" + mPrefs.subtitleTranslate
+                + ", sources=" + (mPrefs.subtitleSourceOpenSubtitles ? "os " : "")
+                + (mPrefs.subtitleSourceRest ? "rest " : "")
+                + (mPrefs.subtitleSourceStremio ? "stremio " : "")
+                + (mPrefs.subtitleSourceShegu ? "shegu" : "")
+                + ", list=" + mPrefs.languageSubtitle + "/" + mPrefs.languageSubtitleSecondary);
         final MediaId id = mediaIdAt(player.getCurrentMediaItemIndex());
         if (id.isEmpty()) {
             // Nothing to ask the sources about. Every one of them is keyed by imdb or tmdb, so a file
@@ -6610,8 +6630,9 @@ public class PlayerActivity extends Activity {
             Utils.log("subtitles: no title id, not searching");
             if (manual) {
                 // Asked for out loud, so it is answered out loud. Silence here reads as a search that
-                // is still running, and this one never started.
-                Toast.makeText(this, R.string.subtitle_search_none, Toast.LENGTH_SHORT).show();
+                // is still running, and this one never started. Carries the dump so "it finds nothing"
+                // can be reported with the trace behind it instead of from memory.
+                showSnack(getString(R.string.subtitle_search_none), playerStateReport());
             }
             return;
         }
@@ -6677,9 +6698,13 @@ public class PlayerActivity extends Activity {
         final List<String> secondaryTargets =
                 secondaryCached ? Collections.<String>emptyList() : secondary;
         if (mainTargets.isEmpty() && secondaryTargets.isEmpty()) {
+            Utils.log("subtitles: already cached for this item, not searching");
             return;
         }
         if (offline) {
+            // Silent until now, and the likeliest reason a search "finds nothing": the switch is off by
+            // default, so an automatic search never goes to the network and never says why.
+            Utils.log("subtitles: online search is off, only the cache was asked");
             return; // the cache has been asked, and that is as far as the switch allows
         }
 
@@ -6737,7 +6762,7 @@ public class PlayerActivity extends Activity {
                         return;
                     }
                     subtitleSearchNotice(0);
-                    Toast.makeText(this, R.string.subtitle_search_none, Toast.LENGTH_SHORT).show();
+                    showSnack(getString(R.string.subtitle_search_none), playerStateReport());
                 });
             }
         }, "SubtitleSearch");
@@ -12932,6 +12957,12 @@ public class PlayerActivity extends Activity {
         }
         if (!mPrefs.revokedAudioMimes.isEmpty()) {
             sb.append("\nAudio passthrough revoked: ").append(mPrefs.revokedAudioMimes);
+        }
+        // Last, and after a blank line: it is many lines long, and everything above is the
+        // one-glance summary somebody reads before deciding whether to read the trace at all.
+        final String trace = Utils.recentLog();
+        if (!trace.isEmpty()) {
+            sb.append("\n\nTrace:\n").append(trace);
         }
     }
 

--- a/app/src/main/java/com/brouken/player/SubtitleFetcher.java
+++ b/app/src/main/java/com/brouken/player/SubtitleFetcher.java
@@ -4,7 +4,6 @@ import android.net.Uri;
 
 import androidx.media3.common.C;
 
-import java.io.File;
 import java.io.FilterInputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -40,6 +39,8 @@ class SubtitleFetcher {
     private final String cacheName;
     /** Length of what is playing, or {@link C#TIME_UNSET} when it is not known — see {@link #fitsMedia}. */
     private final long durationMs;
+    /** The last copy {@link #fitsMedia} turned away, kept as the answer of last resort. */
+    private Uri lastRejected;
 
     private static final int CONNECT_TIMEOUT_SEC = 10;
     private static final int READ_TIMEOUT_SEC = 20;
@@ -57,9 +58,6 @@ class SubtitleFetcher {
 
     /** Subtitles are text; anything this size is not one, and is not worth the memory to find out. */
     private static final long MAX_BYTES = 2_000_000;
-
-    /** How far past the end of the media a file's last line may still sit. See {@link #fitsMedia}. */
-    private static final long FIT_MARGIN_MS = 10_000;
 
     /**
      * Candidates already turned away, as url + the length they were turned away for. The answer depends
@@ -132,7 +130,12 @@ class SubtitleFetcher {
                 return file;
             }
         }
-        return null;
+        // Nothing fitted, so the choice is no longer between a good file and a bad one but between a
+        // bad file and none. Out of sync is visible and one tap from being replaced; empty is not.
+        if (lastRejected != null) {
+            Utils.log("subtitle download: nothing fitted, taking the wrong-cut file anyway");
+        }
+        return lastRejected;
     }
 
     /**
@@ -202,6 +205,10 @@ class SubtitleFetcher {
             final Uri file = Utils.convertInputStreamToUTF(activity, url, stream, cacheName);
             if (file != null && !fitsMedia(file)) {
                 WRONG_CUT.add(wrongCutKey(url));
+                // Left on disk rather than deleted, and remembered: if no candidate fits, this is what
+                // the viewer gets instead of nothing. Every download writes over the same cacheName, so
+                // the copy still there when the list runs out is the one this points at.
+                lastRejected = file;
                 return null;
             }
             return file;
@@ -227,8 +234,19 @@ class SubtitleFetcher {
      * <p>Only a file that runs past the end of the video is turned away, which is the half that
      * proves itself. The opposite — a theatrical file over an extended cut — ends early, and so does
      * any honest file whose last line comes well before the credits do, so there is nothing to tell
-     * those two apart by. {@link #FIT_MARGIN_MS} is for the few seconds a re-encode can lose off the
-     * tail, not for a difference in cut.
+     * those two apart by.
+     *
+     * <p>How many lines are out there decides it, not how far the last one sits, because the whole
+     * file is in hand here and the count is what actually separates the two. Measured on real files:
+     * the Ukrainian file for Wicked Little Letters that started all this has <b>one</b> line past the
+     * end, 39 s out, and it reads "Переклад субтитрів: Elena Astankova"; the Russian theatrical file
+     * for The Martian has <b>two</b>, 23 s and 25 s out; the Russian file for the extended cut of the
+     * same film has <b>61</b>, spread from 19 s to 282 s out. No single distance separates those —
+     * 282 s sits inside any margin wide enough for the first two — while 1, 2 and 61 separate cleanly.
+     *
+     * <p>{@link SubtitleSearch#cutMargin} still bounds it, for the stray line hours out that a count of
+     * one would otherwise wave through, and {@link SubtitleSearch#TAIL_GRACE_MS} still passes a trivial
+     * overhang whatever its count: a copy trimmed by a few seconds can leave several lines over.
      */
     private boolean fitsMedia(Uri file) {
         if (durationMs == C.TIME_UNSET || durationMs <= 0) {
@@ -242,14 +260,19 @@ class SubtitleFetcher {
         // The last cue's start, not its end: a line shown over the final seconds legitimately runs on
         // past the last frame, and rejecting for that would throw away files that are perfectly synced.
         final long lastMs = timeline.startUs(timeline.size() - 1) / 1000;
-        if (lastMs <= durationMs + FIT_MARGIN_MS) {
+        final long over = lastMs - durationMs;
+        if (over <= SubtitleSearch.TAIL_GRACE_MS) {
             return true;
         }
-        Utils.log("subtitle download: last cue " + lastMs + "ms past a " + durationMs
-                + "ms media, wrong cut — skipping");
-        // Deleted, or the next search would find it in the cache and hand over the same bad file for
-        // good: the cached copy is named after the title and the language, not after this candidate.
-        new File(String.valueOf(file.getPath())).delete();
+        int past = 0;
+        for (int i = timeline.size() - 1; i >= 0 && timeline.startUs(i) / 1000 > durationMs; i--) {
+            past++;
+        }
+        if (past <= 2 && over <= SubtitleSearch.cutMargin(durationMs)) {
+            return true;
+        }
+        Utils.log("subtitle download: " + past + " cue(s) past the end, last " + (over / 1000)
+                + "s past a " + durationMs + "ms media, wrong cut — skipping");
         return false;
     }
 

--- a/app/src/main/java/com/brouken/player/SubtitleSearch.java
+++ b/app/src/main/java/com/brouken/player/SubtitleSearch.java
@@ -157,6 +157,9 @@ final class SubtitleSearch {
     static Result find(MediaId identifier, List<String> preferred, Prefs prefs, long durationMs,
                        Sink sink, AtomicBoolean answered) {
         if (identifier == null || identifier.isEmpty() || preferred.isEmpty()) {
+            Utils.log("subtitles: nothing to ask with (id="
+                    + (identifier == null ? "null" : identifier.isEmpty() ? "empty" : "ok")
+                    + ", want=" + preferred + ")");
             return null;
         }
         // A series whose episode number never arrived would be searched as "any episode of this
@@ -293,8 +296,38 @@ final class SubtitleSearch {
         return null;
     }
 
-    /** Anything past the end of the media, with the few seconds a re-encode can lose off the tail. */
-    private static final long CUT_MARGIN_MS = 10_000;
+    /**
+     * How far past the end of the media a file's last line may sit and still be for this cut.
+     *
+     * <p>Ten flat seconds once, which turned out to reject perfectly good files: a report from a viewer
+     * who "never finds subtitles" showed a 100-minute film whose only Ukrainian file — the same one from
+     * all four sources — ends 39 s after the video does, so every source was refused and the search came
+     * back empty. Nothing about that file is for another cut. A last line sits past the final frame
+     * whenever the translator credited themselves after the picture, whenever the release the file was
+     * timed to carried a distributor logo this copy does not, and whenever the copy is trimmed at the
+     * tail.
+     *
+     * <p>A share of the length rather than a number of seconds, because that is what the difference
+     * actually scales with: 39 s over a 100-minute film is 0.65 % and plainly the same cut, while the
+     * same 39 s over a 22-minute episode is 3 % and worth a second look. Four per cent is four minutes
+     * for a feature and under a minute for an episode, and it stays well below what a real second cut
+     * costs — an extended feature runs ten to thirty minutes longer, so it is still turned away. The
+     * floor is for the shortest clips, where a percentage is no margin at all.
+     *
+     * <p>The two mistakes are not worth the same: a file wrongly refused leaves the viewer with no
+     * subtitles at all, while one wrongly taken is visibly out of sync and one tap from being replaced.
+     * Which is also why nothing here is final — see {@link #ofOneCut} and SubtitleFetcher.fitsMedia.
+     */
+    static long cutMargin(long durationMs) {
+        return Math.max(30_000L, durationMs / 25);
+    }
+
+    /**
+     * An overhang too small to mean anything: the few seconds a re-encode loses off the tail. Kept
+     * separate from {@link #cutMargin} because the two are asked different questions — this one is
+     * "is there anything to look at", the other "how far out may a tail artefact sit".
+     */
+    static final long TAIL_GRACE_MS = 10_000;
 
     /**
      * How far apart two files' last lines may be and still be the same cut. Generous, because within
@@ -322,21 +355,31 @@ final class SubtitleSearch {
         if (durationMs <= 0) {
             return inLanguage;
         }
+        final long margin = cutMargin(durationMs);
+        // The anchor is drawn only from files that plainly fit, TAIL_GRACE_MS and no more.
+        // Drawn from everything the margin allows instead, a file for a longer cut sets the anchor and
+        // then evicts the correct ones through CUT_TOLERANCE_MS below: for The Martian's theatrical cut
+        // the extended file's 2:25:35 would anchor the whole language and drop all four files that end
+        // around 2:15, which is every honest one there is.
         long latest = 0;
         for (Candidate candidate : inLanguage) {
-            if (candidate.lastMs > 0 && candidate.lastMs <= durationMs + CUT_MARGIN_MS) {
+            if (candidate.lastMs > 0 && candidate.lastMs <= durationMs + TAIL_GRACE_MS) {
                 latest = Math.max(latest, candidate.lastMs);
             }
         }
         final List<Candidate> kept = new ArrayList<>(inLanguage.size());
         for (Candidate candidate : inLanguage) {
             if (candidate.lastMs <= 0
-                    || (candidate.lastMs <= durationMs + CUT_MARGIN_MS
+                    || (candidate.lastMs <= durationMs + margin
                         && candidate.lastMs >= latest - CUT_TOLERANCE_MS)) {
                 kept.add(candidate);
             }
         }
-        return kept;
+        // Nothing left means every file in this language looks like another cut, and the choice is no
+        // longer between a good file and a bad one — it is between a bad file and none. Hand them all
+        // back: out of sync is one tap from being replaced, and the download still gets the closer look
+        // that SubtitleFetcher.fitsMedia gives it.
+        return kept.isEmpty() ? inLanguage : kept;
     }
 
     /** {@code "03:57:34"} as ms, or 0 for anything else — the field is often absent or empty. */
@@ -442,19 +485,30 @@ final class SubtitleSearch {
      * answer arrives to a player that no longer exists.
      */
     private static Result fromOpenSubtitles(MediaId id, List<String> preferred, boolean allowMachine) {
+        // Every exit here used to be silent, and this is the one source that does not go through best():
+        // so when it won, the trace jumped from its quota line straight to a file being painted, and when
+        // it lost there was nothing at all. It is also the source most likely to answer, being the keyed
+        // one, which made its silence the largest hole in a report about subtitles.
         final List<String> codes = OpenSubtitles.toIso639_1(preferred);
         if (codes.isEmpty()) {
+            Utils.log("subtitles: " + SOURCE_OPENSUBTITLES + " has no 639-1 code for " + preferred);
             return null;
         }
-        final OpenSubtitles.Candidate best =
-                OpenSubtitles.pick(OpenSubtitles.search(id, codes), codes, allowMachine);
+        final List<OpenSubtitles.Candidate> found = OpenSubtitles.search(id, codes);
+        final OpenSubtitles.Candidate best = OpenSubtitles.pick(found, codes, allowMachine);
         if (best == null || cancelled()) {
+            Utils.log("subtitles: " + SOURCE_OPENSUBTITLES + " has " + found.size()
+                    + " file(s), none taken" + (allowMachine ? "" : " (machine translations refused)"));
             return null;
         }
         final String link = OpenSubtitles.link(best.fileId);
         if (link == null) {
+            Utils.log("subtitles: " + SOURCE_OPENSUBTITLES + " picked " + best.language
+                    + " but the download link was refused");
             return null;
         }
+        Utils.log("subtitles: " + SOURCE_OPENSUBTITLES + " has 1 " + best.language
+                + (best.machine ? " machine-translated" : "") + " of " + found.size());
         return new Result(SOURCE_OPENSUBTITLES, Utils.toIso3Language(best.language),
                 Collections.singletonList(link), best.machine);
     }

--- a/app/src/main/java/com/brouken/player/Utils.java
+++ b/app/src/main/java/com/brouken/player/Utils.java
@@ -31,6 +31,7 @@ import android.os.storage.StorageVolume;
 import android.provider.DocumentsContract;
 import android.provider.OpenableColumns;
 import android.provider.Settings;
+import android.os.SystemClock;
 import android.util.Log;
 import android.util.Rational;
 import android.view.Display;
@@ -72,6 +73,7 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.ArrayDeque;
 import java.util.Locale;
 import java.util.Map;
 import java.util.MissingResourceException;
@@ -579,9 +581,64 @@ class Utils {
         return (bitrate / 1000) + " kbps";
     }
 
+    /**
+     * Every line the app traces about itself. Kept in memory in every build, not only a debug one: the
+     * subtitle search, the fetchers and the title lookup already say what they asked and what came back,
+     * and that is exactly what a report about "it finds nothing for me" has to carry — but Log.d reaches
+     * nobody who is not holding an adb cable. The report screen appends recentLog(), so the trace leaves
+     * a phone by the Upload button and a TV box by its QR.
+     *
+     * <p>Bounded, and consecutive duplicates are folded: onTracksChanged fires several times per item,
+     * so the same "not searching" line would otherwise push everything useful out of the window.
+     */
+    private static final int LOG_LINES = 200;
+    private static final ArrayDeque<String> LOG = new ArrayDeque<>();
+    private static final long LOG_BASE_MS = SystemClock.elapsedRealtime();
+    private static String lastLogged;
+    private static int lastLoggedRepeats;
+
     public static void log(final String text) {
         if (BuildConfig.DEBUG) {
             Log.d("JustPlayer", text);
+        }
+        synchronized (LOG) {
+            if (text.equals(lastLogged)) {
+                lastLoggedRepeats++;
+                // Rewrite the tail rather than grow: the count is the information, the repetition is not.
+                LOG.removeLast();
+                LOG.addLast(logLine(text) + " (x" + (lastLoggedRepeats + 1) + ")");
+                return;
+            }
+            lastLogged = text;
+            lastLoggedRepeats = 0;
+            while (LOG.size() >= LOG_LINES) {
+                LOG.removeFirst();
+            }
+            LOG.addLast(logLine(text));
+        }
+    }
+
+    // Seconds since the process started rather than a wall clock: what a reader needs from this is how
+    // long a source took and where a fifteen-second budget ran out, not what time it was.
+    private static String logLine(final String text) {
+        final long ms = SystemClock.elapsedRealtime() - LOG_BASE_MS;
+        return String.format(Locale.US, "%6.2f %s", ms / 1000f, text);
+    }
+
+    /** The trace so far, oldest first; empty string when nothing has been traced. */
+    public static String recentLog() {
+        synchronized (LOG) {
+            if (LOG.isEmpty()) {
+                return "";
+            }
+            final StringBuilder sb = new StringBuilder();
+            for (String line : LOG) {
+                if (sb.length() > 0) {
+                    sb.append('\n');
+                }
+                sb.append(line);
+            }
+            return sb.toString();
         }
     }
 


### PR DESCRIPTION
A viewer who reported never finding subtitles was being refused every file there was — and the search had no way to say so. This fixes the refusal and gives the search a voice.

## The bug

The only Ukrainian file for a 100-minute film — the same one offered by all four sources — ends **39 s** after the video does:

```
media    6 004 875 ms  (100 min 05 s)
last cue 6 044 121 ms  (100 min 44 s)
over by     39 246 ms  = 0.65 % of the length
```

The margin for "this is another cut" was **10 s**, held under two names: `SubtitleSearch.CUT_MARGIN_MS` before a download and `SubtitleFetcher.FIT_MARGIN_MS` after one. So the file was refused twice over, and every source came back with `listed but would not download`.

Nothing about it is for another cut. It is 1384 lines of Wicked Little Letters with a single line past the final frame, and that line reads `Переклад субтитрів: Elena Astankova`. A last line sits out there whenever the translator credited themselves after the picture, whenever the release the file was timed to carried a distributor logo this copy does not, and whenever the copy is trimmed at the tail.

## What actually separates the two

Not how far the last line sits — **how many lines are out there**. Measured on three real files against a real media length:

| file | lines past the end | last one out by |
| --- | --- | --- |
| Wicked Little Letters, ukr — correct | **1** | 39 s |
| The Martian, rus, theatrical — correct for a 141 min cut | **2** | 25 s |
| The Martian, rus, **extended** — genuinely the wrong cut | **61** | 282 s, the tail starting at 19 s |

No single distance separates those: 282 s sits inside any margin wide enough for the first two. 1, 2 and 61 separate cleanly.

So `SubtitleFetcher.fitsMedia`, which has the whole file in hand, counts them. One or two is a tail artefact; a tail of them is another cut. Two things still bound it:

- a **distance**, for the stray line hours out that a count of one would otherwise wave through;
- an **overhang under ten seconds passes whatever its count**, because a copy trimmed by a few seconds can leave several lines over — that is master's old rule, kept as a floor, so nothing master accepted is now refused.

That distance is a **share of the length**, not a number of seconds, because that is what the difference scales with: 39 s over a 100-minute film is 0.65 %, the same 39 s over a 22-minute episode is 3 % and worth a second look. **Four per cent**, floored at thirty seconds for the shortest clips. An extended feature runs ten to thirty minutes longer and is still turned away.

## The check before the download

`SubtitleSearch.ofOneCut` keeps its own pass, because all it has there is one timestamp out of the index and a download saved is a download saved. It now draws its anchor **only from files that plainly fit**, within ten seconds.

That matters, and only real data showed it. Drawn from everything the wider margin allows, a file for a longer cut sets the anchor and then evicts the correct ones through `CUT_TOLERANCE_MS`. For The Martian's theatrical cut, the six Russian files in the index:

| | files kept |
| --- | --- |
| before (10 s margin) | 4 of 6 — drops the correct 1080p file, which is 22 s over |
| a wider margin, anchor drawn from all of it | **2 of 6** — the extended file anchors the language and evicts all four honest ones |
| now (4 %, anchor within 10 s) | 6 of 6 — the extended one is then refused after its download |

## Neither check is final any more

A refusal used to leave the viewer with no subtitles at all. That is the worse of the two mistakes: a file wrongly taken is visibly out of sync and one tap from being replaced. So:

- when a language has no plausible file left, the search hands back everything it has rather than nothing;
- when no candidate fits, the download keeps the last copy it turned away and offers that. Every candidate writes over the same cache name, so the copy still on disk when the list runs out is exactly the one to hand back.

No value of the margin can now produce "the search found nothing" out of files that exist.

## Why the diagnostics come with it

The trace already existed — thirty-two `Utils.log` points across the search, the fetchers, the translator and the title lookup, saying what was asked and what came back. All of it sat behind `BuildConfig.DEBUG`, so in a shipped build it reached nobody without an adb cable, and this bug hid there for as long as that was true.

- `Utils.log` now also feeds a bounded in-memory buffer in **every** build, timestamped from process start, folding consecutive duplicates (`onTracksChanged` fires several times per item, and the same line would otherwise push everything useful out of the window).
- `appendPlayerState` appends it, which puts the trace on the playback report screen **and on every playback-error screen** — where Copy / Share / Upload and its QR already exist. Nothing new to build for delivery.
- "Nothing found" carries the same dump behind **Details**.

**Six decisions that ended a search were silent**, and every one of them reads to a viewer exactly like a search that found nothing:

| Reason | What it says now |
| --- | --- |
| no subtitle language set (the factory setting) | `no subtitle language set, not searching (online search is off too)` |
| no device language to guess with | `no language list and no device language, not searching` |
| the tracks present already satisfy the list | `nothing wanted (want=[…] already satisfied by the tracks present)` |
| the online search is switched off | `online search is off, only the cache was asked` |
| a copy is already cached | `already cached for this item, not searching` |
| nothing to ask the sources with | `nothing to ask with (id=empty, want=[…])` |

The settings behind an attempt — mode, strict, translation, which sources are on, both language lists — are logged before it starts.

And the **keyed OpenSubtitles source**, the one that does not go through `best()`, had four silent exits and no summary: when it won, the trace jumped from its quota line straight to a file being painted; when it lost, there was nothing at all. Being the likeliest to answer, that was the largest hole in a report about subtitles.

## Verified

The diagnostics found the bug; the fix was then checked against the sources themselves rather than against the numbers in a report.

- The film from the report was re-queried on all four sources. One human Ukrainian file exists, the same file id from every one of them, and it was downloaded and parsed: 1384 cues, one past the end, the translator's credit. Refused at 10 s, accepted now.
- The Martian's Russian files were downloaded too — theatrical and extended — which is where the 2-versus-61 measurement and the anchor defect above come from.
- A live trace showing per-source counts, the OpenSubtitles quota, the ids resolved, and the rejection reason: `stremio has 6 eng of 92`, `OpenSubtitles: 79 downloads left today`, `subtitle download: … cue(s) past the end … wrong cut — skipping`.
- The duplicate folding (`(x7)`) and the "not searching" lines firing on paths that used to be silent.

The trace carries no film title and no file name — only imdb/tmdb ids and cache file names.

Builds clean on `latestUniversal` and on the `legacy` variant. **Not for merging yet** — the change wants a spell on a real device first.
