### PR TITLE
Fix torrent streaming stalls, the held passthrough output, and the sleeping Mi Box

### DIFF
--- a/android-file-chooser/src/main/java/com/obsez/android/lib/filechooser/permissions/PermissionActivity.java
+++ b/android-file-chooser/src/main/java/com/obsez/android/lib/filechooser/permissions/PermissionActivity.java
@@ -23,10 +23,23 @@ public class PermissionActivity extends AppCompatActivity {
         super.onCreate(savedInstanceState);
 
         Intent intent = getIntent();
+        // Both extras can be missing, and then there is nothing to ask for. It happens when the system
+        // relaunches this activity from a task it restored rather than from PermissionsUtil: a task that
+        // survived a reboot keeps only the persistable part of its intent, so the permission array is
+        // gone. A field crash arrived exactly that way — the process started straight into this activity
+        // nine minutes after the device booted. Closing is the whole correct response; the original code
+        // called length on null and took the app down with it, and its finish() calls had no return, so
+        // even an empty array walked on into the "there are no permissions" throw below.
         String[] permissions = intent.getStringArrayExtra(INTENT_EXTRA_PERMISSIONS);
-        if (permissions.length == 0) finish();
+        if (permissions == null || permissions.length == 0) {
+            finish();
+            return;
+        }
         _requestCode = intent.getIntExtra(INTENT_EXTRA_REQUEST_CODE, -1);
-        if (_requestCode == -1) finish();
+        if (_requestCode == -1) {
+            finish();
+            return;
+        }
         _permissionListener = PermissionsUtil.getPermissionListener(_requestCode);
 
         for (String permission : permissions) {
@@ -59,6 +72,7 @@ public class PermissionActivity extends AppCompatActivity {
         @NonNull int[] grantResults) {
         if (requestCode != _requestCode) {
             finish();
+            return;
         }
         _permissions_denied.clear();
         for (int i = permissions.length - 1; i >= 0; --i) {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -136,6 +136,12 @@ dependencies {
     def androidxCoreVersion = '1.8.0'
     implementation "androidx.media3:media3-session:$media3_version"
     implementation "androidx.media3:media3-datasource:$media3_version"
+    // Media reads go through OkHttp rather than HttpURLConnection, for the connection pool (see
+    // MEDIA_HTTP_CLIENT). Excludes media3-exoplayer like every other media3 module here, so it resolves
+    // against the local prebuilt AAR.
+    implementation("androidx.media3:media3-datasource-okhttp:$media3_version") {
+        exclude group: "androidx.media3", module: "media3-exoplayer"
+    }
     implementation "androidx.media3:media3-decoder:$media3_version"
     implementation "androidx.media3:media3-common:$media3_version"
     implementation "androidx.media3:media3-container:$media3_version"

--- a/app/src/main/java/com/brouken/player/MediaCache.java
+++ b/app/src/main/java/com/brouken/player/MediaCache.java
@@ -1,0 +1,142 @@
+package com.brouken.player;
+
+import android.content.Context;
+
+import androidx.media3.database.StandaloneDatabaseProvider;
+import androidx.media3.datasource.DataSink;
+import androidx.media3.datasource.DataSource;
+import androidx.media3.datasource.DataSpec;
+import androidx.media3.datasource.cache.CacheDataSink;
+import androidx.media3.datasource.cache.CacheDataSource;
+import androidx.media3.datasource.cache.LeastRecentlyUsedCacheEvictor;
+import androidx.media3.datasource.cache.SimpleCache;
+
+import java.io.File;
+import java.io.IOException;
+
+/**
+ * A small on-disk cache in front of the network, sized for one thing: the parts of a container that are
+ * read again and again.
+ *
+ * <p>Every {@code prepare()} on a progressive stream re-parses the container from scratch, and for a
+ * Matroska that means four cold range requests before the first sample — the header at offset 0, the Cues
+ * element which sits at the very end of the file, a cluster back at the front, and only then the playback
+ * offset. Measured on a 56 GB remux: 357 KB, 380 KB, 70 KB, then the stream. Against a torrent backend
+ * that is the worst possible shape, because such a server blocks the response and re-prioritises its
+ * download to whatever offset was asked for — so a re-read drags the swarm to the file tail and back
+ * while the viewer waits. The recovery ladder can do that several times in a cascade.
+ *
+ * <p>Those three reads are identical every time, so they are worth keeping. The rest of the stream is
+ * not: caching a 50 Mbps film would write six megabytes a second to a TV box's flash for no gain. Hence
+ * the cap below — each opened range may contribute at most its first megabyte, which covers the header
+ * and the Cues whole and takes one megabyte off the playback stream. After the first play of a file its
+ * container is on disk and a re-prepare asks the network for one range instead of four.
+ *
+ * <p>Best effort throughout: if the cache cannot be created the chain is returned unwrapped, and a cache
+ * error during playback is ignored rather than surfaced (FLAG_IGNORE_CACHE_ON_ERROR).
+ */
+final class MediaCache {
+
+    /** Enough for the container heads of a good few films; evicted least-recently-used. */
+    private static final long MAX_BYTES = 16 * 1024 * 1024;
+    /** How much of each opened range may be written. See the class comment. */
+    private static final long PER_OPEN_BYTES = 1024 * 1024;
+    /** The build whose bytes are on disk; a different one starts empty (see clearOnNewBuild). */
+    private static final String PREF_KEY_CACHE_BUILD = "mediaCacheBuild";
+
+    private static SimpleCache cache;
+    private static boolean unavailable;
+
+    private MediaCache() {
+    }
+
+    /**
+     * The chain with the cache in front of it, or {@code upstream} unchanged when a cache cannot be had.
+     * Sits below the track-name tee, so what the tee parses is the same bytes whether they came from the
+     * network or from disk.
+     */
+    static DataSource.Factory wrap(final Context context, final DataSource.Factory upstream) {
+        final SimpleCache simpleCache = get(context);
+        if (simpleCache == null) {
+            return upstream;
+        }
+        final CacheDataSource.Factory factory = new CacheDataSource.Factory()
+                .setCache(simpleCache)
+                .setUpstreamDataSourceFactory(upstream)
+                .setCacheWriteDataSinkFactory(() -> new HeadSink(simpleCache))
+                .setFlags(CacheDataSource.FLAG_IGNORE_CACHE_ON_ERROR);
+        return factory;
+    }
+
+    private static synchronized SimpleCache get(final Context context) {
+        if (cache == null && !unavailable) {
+            try {
+                final File directory = new File(context.getCacheDir(), "media");
+                clearOnNewBuild(context, directory);
+                cache = new SimpleCache(directory,
+                        new LeastRecentlyUsedCacheEvictor(MAX_BYTES),
+                        new StandaloneDatabaseProvider(context));
+            } catch (Exception e) {
+                // A second instance on the same directory, or no room to write: play without a cache.
+                unavailable = true;
+                Utils.log("media cache: unavailable, " + e);
+            }
+        }
+        return cache;
+    }
+
+    /**
+     * Drops everything the previous build cached. A container head that no longer matches what the
+     * server serves reads exactly like a corrupt stream, and after an update the first play of a file
+     * would otherwise be answered partly from bytes an older build wrote, with nothing to tell the two
+     * apart. Keyed on the version code, so it happens once per install and needs nothing remembered by
+     * hand.
+     */
+    private static void clearOnNewBuild(final Context context, final File directory) {
+        final android.content.SharedPreferences prefs =
+                android.preference.PreferenceManager.getDefaultSharedPreferences(context);
+        if (prefs.getInt(PREF_KEY_CACHE_BUILD, 0) == BuildConfig.VERSION_CODE) {
+            return;
+        }
+        if (directory.exists()) {
+            SimpleCache.delete(directory, new StandaloneDatabaseProvider(context));
+        }
+        prefs.edit().putInt(PREF_KEY_CACHE_BUILD, BuildConfig.VERSION_CODE).apply();
+    }
+
+    /**
+     * Writes through to the real cache sink until the byte cap for this open is reached, then swallows
+     * the rest. Swallowing rather than failing: the write is the cache's business, not the playback's,
+     * and {@link CacheDataSink} commits the part it did receive when it is closed.
+     */
+    private static final class HeadSink implements DataSink {
+
+        private final DataSink delegate;
+        private long written;
+
+        HeadSink(final SimpleCache cache) {
+            delegate = new CacheDataSink(cache, PER_OPEN_BYTES);
+        }
+
+        @Override
+        public void open(final DataSpec dataSpec) throws IOException {
+            written = 0;
+            delegate.open(dataSpec);
+        }
+
+        @Override
+        public void write(final byte[] buffer, final int offset, final int length) throws IOException {
+            if (written >= PER_OPEN_BYTES) {
+                return;
+            }
+            final int allowed = (int) Math.min(length, PER_OPEN_BYTES - written);
+            delegate.write(buffer, offset, allowed);
+            written += allowed;
+        }
+
+        @Override
+        public void close() throws IOException {
+            delegate.close();
+        }
+    }
+}

--- a/app/src/main/java/com/brouken/player/PlayerActivity.java
+++ b/app/src/main/java/com/brouken/player/PlayerActivity.java
@@ -69,6 +69,7 @@ import android.view.MotionEvent;
 import android.view.Surface;
 import android.view.SurfaceView;
 import android.view.View;
+import android.view.WindowManager;
 import android.view.ViewGroup;
 import android.view.ViewOutlineProvider;
 import android.view.Window;
@@ -114,6 +115,7 @@ import androidx.media3.common.Tracks;
 import androidx.media3.common.audio.AudioProcessor;
 import androidx.media3.common.util.StuckPlayerException;
 import androidx.media3.datasource.DefaultDataSource;
+import androidx.media3.datasource.okhttp.OkHttpDataSource;
 import androidx.media3.datasource.DefaultHttpDataSource;
 import androidx.media3.datasource.HttpDataSource;
 import androidx.media3.decoder.ffmpeg.FfmpegLibrary;
@@ -312,13 +314,6 @@ public class PlayerActivity extends Activity {
     // Progress below this over a whole window is not a load: 8 KB/s is far under anything playable, so it
     // is a socket dribbling keepalives rather than a source that is still working. Wait only for real bytes.
     private static final long LOAD_PROGRESS_MIN_BYTES = 256 * 1024;
-    // How much has to be buffered before playback resumes after a stall, on network media only. Media3
-    // asks for two seconds, which a torrent backend eats with its next pause to fetch pieces from peers:
-    // the player stops again, refills two seconds, stops again — the sawtooth users report as an endless
-    // load on a big remux that no error ever comes out of. Refilling properly costs one wait instead of
-    // twenty. It cannot become unreachable: a high-bitrate file caps its own buffer by bytes long before
-    // this, and shouldStartPlayback starts playing as soon as that cap is hit.
-    private static final int BUFFER_AFTER_REBUFFER_MS = 15_000;
     // Buffering that resolves this fast is not worth an indicator: the spinner would replace the play button
     // for a frame or two and read as a glitch. Recreating the audio track (restartPassthroughAudio) takes
     // about 35 ms, a track switch or a seek inside the buffer are the same order, and a real wait is always
@@ -368,12 +363,36 @@ public class PlayerActivity extends Activity {
     // thread by the analytics listener, reset per player build.
     private String videoDecoderName;
     private String audioDecoderName;
+    // Audio mimes this run has dropped from passthrough to a decoder (see recoverByRevokingAudioMime).
+    // Deliberately not reset by initializePlayer: that recovery rebuilds the player, and the rebuild has
+    // to come up with the fallback already in force or it fails again on the same frame.
+    private final Set<String> sessionRevokedAudioMimes = new HashSet<>();
     // One-shot guard for recoverByLoweringQuality(). Deliberately not reset by initializePlayer: the
     // downgrade itself rebuilds the player, and a variant that is still beyond the device has to fail
     // once rather than walk the whole list.
     private boolean softwareVideoDowngraded;
     // Loader's throughput estimate — the one stats figure the player itself cannot be asked for.
     private long bandwidthBitrate;
+    /**
+     * The client the media path reads through. OkHttp rather than HttpURLConnection for one reason:
+     * DefaultHttpDataSource calls disconnect() on every close and pools nothing, so each of the four
+     * cold range requests a container re-read costs is a fresh connection — and a torrent backend spawns
+     * a reader and a preload window per connection, then tears it down. A pool holds the socket instead.
+     * Static, so the pool survives the player rebuilds the recovery ladder does.
+     *
+     * <p>Patient on purpose: a torrent backend goes quiet while it fetches pieces from peers, and the old
+     * thirty-second read timeout turned that silence into a source error and a re-read of the whole
+     * container. Nothing is lost by waiting — the load watchdog still stops the player at thirty seconds
+     * of no progress and says so, which is the message the viewer needs; what goes away is the retry
+     * storm behind it. The same figures the reference player uses (dddplayer, PlayerManager.kt).
+     */
+    private static final okhttp3.OkHttpClient MEDIA_HTTP_CLIENT = new okhttp3.OkHttpClient.Builder()
+            .connectTimeout(60, java.util.concurrent.TimeUnit.SECONDS)
+            .readTimeout(120, java.util.concurrent.TimeUnit.SECONDS)
+            .retryOnConnectionFailure(true)
+            .followRedirects(true)
+            .followSslRedirects(true)
+            .build();
     private final AnalyticsListener playbackInfoListener = new AnalyticsListener() {
         @Override
         public void onVideoDecoderInitialized(AnalyticsListener.EventTime eventTime, String decoderName,
@@ -402,6 +421,8 @@ public class PlayerActivity extends Activity {
     // Re-reads spent on network source errors this session (see recoverFromSourceError), reset per player
     // build so a chronically bad stream costs a bounded number of re-prepares instead of one per resume.
     private int sourceRetries;
+    // The stream the budget above was spent on, so a rebuild of the same one does not refill it.
+    private String sourceRetriesUri;
     private static final int MAX_SOURCE_RETRIES = 3;
     // Held in a field (like loadTimeoutRunnable) so releasePlayer can drop a re-read that no longer has a
     // session to belong to.
@@ -605,6 +626,18 @@ public class PlayerActivity extends Activity {
     // the controller timeout to -1) burnt into a panel for as long as the pause lasts. So the hold comes
     // with a black sheet faded over everything once the pause has stood a minute, and is given up
     // altogether once it has stood two hours: whoever fell asleep does not need the television on.
+    /**
+     * How long a pause may hold the source open. Nothing on the pause path closes it: the loader is
+     * blocked at the byte cap with a read half-issued, so the connection stays established and silent —
+     * measured at four minutes and counting, zero bytes, while 144 MB of buffer stays allocated. A
+     * torrent backend has a reader registered for that socket the whole time.
+     *
+     * <p>Long on purpose. player.stop() keeps the timeline and the position but drops the buffer, so
+     * resuming pays a fresh container read (four cold range requests on a 56 GB Matroska) plus the
+     * refill — which for a short pause costs the server more than the idle socket does. Five minutes is
+     * past the point where the viewer is coming straight back.
+     */
+    private static final long PAUSE_RELEASE_MS = 5 * 60 * 1000L;
     private static final long DIM_DELAY_MS = 60_000L;
     private static final long KEEP_AWAKE_MAX_MS = 2 * 60 * 60 * 1000L;
     private static final float DIM_ALPHA = 0.85f;
@@ -612,7 +645,20 @@ public class PlayerActivity extends Activity {
     private static final int DIM_OUT_MS = 300;
     private View dimOverlay;
     private final Runnable dimRunnable = this::dim;
-    private final Runnable keepAwakeGiveUpRunnable = () -> playerView.setKeepScreenOn(false);
+    // Set while the source was let go under a standing pause, so the next play re-prepares rather than
+    // leaving an idle player with a play button that does nothing.
+    private boolean stoppedForPause;
+    private final Runnable pauseReleaseRunnable = () -> {
+        if (player == null || player.getPlayWhenReady() || player.isPlaying()) {
+            return;
+        }
+        Utils.log("pause: releasing the source after " + PAUSE_RELEASE_MS / 1000 + "s");
+        stoppedForPause = true;
+        // Not releasePlayer(): stop() leaves the item, the position and the surface in place, so this
+        // costs one prepare() on resume and nothing else.
+        player.stop();
+    };
+    private final Runnable keepAwakeGiveUpRunnable = () -> holdScreen(false);
     // Set while a Down press is opening the controls, so focus lands on the time bar instead of play/pause.
     private boolean focusTimeBarOnShow;
     // The page shown when there is nothing to play; owns its own views, reveal and pulse.
@@ -1855,6 +1901,17 @@ public class PlayerActivity extends Activity {
 
         controlView = playerView.findViewById(R.id.exo_controller);
 
+        // Media3 scrubbing mode, which PlayerControlView switches on while the time bar is being dragged,
+        // off on TV boxes. It deselects the audio track for the duration of the scrub and suppresses
+        // playback (PLAYBACK_SUPPRESSION_REASON_SCRUBBING, seen as suppress=4 in a field trace), and on a
+        // tunnelled decoder that pair is what puts a picture on screen at all: the report was that
+        // scrubbing the bar with a remote leaves no image, while the key-scrub this app implements itself
+        // (left/right) is fine. The optimisation is for a finger dragging continuously, which is not how a
+        // remote seeks, so a TV loses nothing by asking for plain seeks instead.
+        if (isTvBox) {
+            controlView.setTimeBarScrubbingEnabled(false);
+        }
+
         // The right-hand slot of the bottom bar shows the total duration, or counts down what is left when
         // the setting says so. PlayerControlView writes that TextView itself, so rewrite it after every
         // progress tick — updateTimeline() ends with updateProgress(), so its own value never lingers.
@@ -2464,6 +2521,19 @@ public class PlayerActivity extends Activity {
             displayManager.unregisterDisplayListener(displayListener);
         }
         player.pause();
+        // Give the bitstream output back before leaving. A passthrough AudioTrack holds the receiver's
+        // AC3/DTS route for as long as the player owns it, and that route is exclusive: while it is ours
+        // no other app can open one. Pausing does not release it — MediaCodecAudioRenderer.onStopped only
+        // pauses the sink — so until this screen let the player go, minutes later, every other player on
+        // the box met "AudioTrack init failed" for AC3 and wrote the refusal down as a verdict about the
+        // hardware, which is why clearing their data was what it took to get them bitstreaming again.
+        // stop() keeps the item, the position and the surface, so the return costs one prepare() — the
+        // same trade the standing pause already makes, through the same latch.
+        if (audioSink != null && audioSink.isPassthrough()) {
+            Utils.log("background: releasing the passthrough output");
+            stoppedForPause = true;
+            player.stop();
+        }
         // The load watchdog only ever ran while the activity was on screen by accident: nothing cancelled it
         // on this path, so an item still buffering when the user left would time out in the background —
         // stopping a session they may come straight back to, and posting a snackbar nobody can see. onStart
@@ -5083,7 +5153,7 @@ public class PlayerActivity extends Activity {
         // reading. On a local file this is always full, which is itself the answer.
         final long bufferedMs = player.getTotalBufferedDuration();
         text.append(getString(R.string.stats_buffer, bufferedMs / 1000,
-                (int) Math.min(100, bufferedMs * 100 / DefaultLoadControl.DEFAULT_MAX_BUFFER_MS)));
+                (int) Math.min(100, bufferedMs * 100 / bufferCeilingMs())));
         if (bandwidthBitrate > 0) {
             text.append('\n').append(getString(R.string.stats_network,
                     getString(R.string.quality_bitrate, bandwidthBitrate / 1_000_000f)));
@@ -5151,6 +5221,24 @@ public class PlayerActivity extends Activity {
     }
 
     /** The whole file's average bitrate in Mbit/s, or 0 while either its length or duration is unknown. */
+    /**
+     * The most the buffer can hold for what is playing, in milliseconds. The load control stops on
+     * whichever comes first, fifty seconds or its byte budget, and on a high-bitrate file the bytes come
+     * first by a long way: 144 MB is about 21 s of a 53 Mbps remux. Reporting the fill against the fifty
+     * seconds it can never reach is what made a full buffer read as "50 % and not growing", and had
+     * viewers reporting a download that never finishes.
+     */
+    private long bufferCeilingMs() {
+        final float overall = overallBitrate();
+        if (overall <= 0f) {
+            return DefaultLoadControl.DEFAULT_MAX_BUFFER_MS;
+        }
+        // Bytes to milliseconds at this bitrate: bytes * 8 / (Mbit/s * 1e6) * 1000.
+        final long byteCeilingMs = (long) ((DefaultLoadControl.DEFAULT_VIDEO_BUFFER_SIZE
+                + DefaultLoadControl.DEFAULT_AUDIO_BUFFER_SIZE) * 8L / (overall * 1000f));
+        return Math.max(1_000L, Math.min(DefaultLoadControl.DEFAULT_MAX_BUFFER_MS, byteCeilingMs));
+    }
+
     private float overallBitrate() {
         final long durationMs = player.getDuration();
         if (durationMs <= 0 || mPrefs.mediaUri == null) {
@@ -9886,11 +9974,23 @@ public class PlayerActivity extends Activity {
             forceHevcForDolbyVision = false;
         }
 
-        // Fresh player — the source re-read budget starts over.
-        sourceRetries = 0;
-        decoderRetries = 0;
+        // A fresh player, but not a fresh budget when it is the same stream: the rebuild rungs
+        // (tunneling, Dolby Vision, an audio mime) go through here, and each one used to hand the source
+        // three more re-reads. Every re-read costs the server a container re-parse — four cold range
+        // requests on a big Matroska, one of them at the file tail — so a cascade could spend fifteen
+        // connections on a stream that was never going to answer. Keyed by URI, so the next film starts
+        // clean; the same one keeps whatever it has spent until it actually plays, which is where the
+        // budget is refilled (STATE_READY, below).
+        // Same for the decoder re-reads and the freeze recoveries: both end in prepare() on the same
+        // stream, and both used to be handed a full budget again by every rebuild rung.
+        final String retryUri = mPrefs.mediaUri != null ? mPrefs.mediaUri.toString() : null;
+        if (retryUri == null || !retryUri.equals(sourceRetriesUri)) {
+            sourceRetriesUri = retryUri;
+            sourceRetries = 0;
+            decoderRetries = 0;
+            videoFreezeRecoveries = 0;
+        }
         liveStallRecoveries = 0;
-        videoFreezeRecoveries = 0;
         frameOutputSeen = -1;
         playerStartPositionMs = C.TIME_UNSET;
         videoDecoderName = null;
@@ -9964,7 +10064,10 @@ public class PlayerActivity extends Activity {
         // Audio sample mimes this device has already proven cannot passthrough (see
         // recoverByRevokingAudioMime()) — denied at the sink only; the platform decoder for the same
         // mime is left alone since it is an independent subsystem that may work fine.
-        final Set<String> revokedAudioMimes = mPrefs.revokedAudioMimes;
+        // The persisted list plus whatever this run has already fallen back on: a rebuild must not hand
+        // passthrough back to a mime that just failed, or the failure repeats on the same frame.
+        final Set<String> revokedAudioMimes = new HashSet<>(mPrefs.revokedAudioMimes);
+        revokedAudioMimes.addAll(sessionRevokedAudioMimes);
         // Always subclassed (not only for blockHeavyMkvAudio/an existing revocation) so buildAudioSink
         // below can install the live AudioPassthroughDenylistSink from a device's very first play —
         // it needs to be present before any revocation exists, so a first stall can revoke into it
@@ -10097,14 +10200,6 @@ public class PlayerActivity extends Activity {
                 headers.put("Authorization", "Basic " + Base64.encodeToString(userInfo.getBytes(), Base64.NO_WRAP));
             }
 
-            // Some proxies (Telegram-stream bridges among them) answer range requests only: a GET with
-            // no Range header gets no response at all, not even headers, so nothing is ever transferred
-            // and the load watchdog reports a timeout on a stream that is working. Media3 is the client
-            // that opens without one — HttpUtil.buildRangeRequestHeader returns null at position 0 with
-            // an unbounded length — so seed the whole-file range every browser sends. A default request
-            // property is the lowest priority DefaultHttpDataSource has: it overwrites this whenever it
-            // computes a real range, leaving seeks and byte-range segments alone.
-            headers.put("Range", "bytes=0-");
 
             // Always our own factory, headers or not, for the read timeout. Media3 defaults it to 8 s,
             // which is a verdict a torrent-backed server cannot meet: it answers the range request at
@@ -10114,14 +10209,33 @@ public class PlayerActivity extends Activity {
             // files over a connection that never dropped. Give a read the same patience the load watchdog
             // gives the load: past that, the watchdog stops the player with a message that says what to
             // do, instead of a retry storm ending in a broken-stream error.
-            final DefaultHttpDataSource.Factory defaultHttpDataSourceFactory = new DefaultHttpDataSource.Factory()
-                    .setAllowCrossProtocolRedirects(true)
-                    .setReadTimeoutMs((int) VIDEO_LOAD_TIMEOUT_MS);
+            final OkHttpDataSource.Factory httpDataSourceFactory =
+                    new OkHttpDataSource.Factory(MEDIA_HTTP_CLIENT);
             if (userAgent != null) {
-                defaultHttpDataSourceFactory.setUserAgent(userAgent);
+                httpDataSourceFactory.setUserAgent(userAgent);
             }
-            defaultHttpDataSourceFactory.setDefaultRequestProperties(headers);
-            upstreamFactory = new DefaultDataSource.Factory(this, defaultHttpDataSourceFactory);
+            httpDataSourceFactory.setDefaultRequestProperties(headers);
+            // Some proxies (Telegram-stream bridges among them) answer range requests only: a GET with no
+            // Range header gets no response at all, not even headers, so nothing is ever transferred and
+            // the load watchdog reports a timeout on a stream that is working. Media3 is the client that
+            // opens without one — HttpUtil.buildRangeRequestHeader returns null at position 0 with an
+            // unbounded length — so seed the whole-file range every browser sends.
+            //
+            // Per open, and only for that one case. It used to ride along as a default request property,
+            // which was harmless while DefaultHttpDataSource wrote the computed range with
+            // setRequestProperty (replacing it); OkHttpDataSource uses Request.Builder.addHeader, which
+            // appends, so every seek went out with both "bytes=0-" and its real range and the server
+            // answered the first one. That is what stopped torrent streams from loading when the media path first moved to OkHttp.
+            final androidx.media3.datasource.DataSource.Factory rangeSeeded =
+                    new androidx.media3.datasource.ResolvingDataSource.Factory(
+                            new DefaultDataSource.Factory(this, httpDataSourceFactory),
+                            dataSpec -> dataSpec.position == 0 && dataSpec.length == C.LENGTH_UNSET
+                                    ? dataSpec.withAdditionalHeaders(
+                                            Collections.singletonMap("Range", "bytes=0-"))
+                                    : dataSpec);
+            // The container head and the Cues come off disk on every play after the first, so a
+            // re-prepare asks the network for one range instead of four — see MediaCache.
+            upstreamFactory = MediaCache.wrap(this, rangeSeeded);
         }
 
         final androidx.media3.datasource.DataSource.Factory dataSourceFactory = new TrackNameParsingDataSource.Factory(upstreamFactory, trackNameListener);
@@ -10135,16 +10249,24 @@ public class PlayerActivity extends Activity {
         playerBuilder.setMediaSourceFactory(
                 new DefaultMediaSourceFactory(this, convertDV7 ? dv7Converter : extractorsFactory)
                         .setDataSourceFactory(dataSourceFactory));
-        // Everything but the last figure is Media3's own default; only the wait after a stall changes,
-        // and only for streams (file:// and content:// keep their separate, shorter defaults, where a
-        // stall means a slow disk rather than a source that fills in bursts).
-        playerBuilder.setLoadControl(new DefaultLoadControl.Builder()
-                .setBufferDurationsMsForStreaming(
-                        DefaultLoadControl.DEFAULT_MIN_BUFFER_MS,
-                        DefaultLoadControl.DEFAULT_MAX_BUFFER_MS,
-                        DefaultLoadControl.DEFAULT_BUFFER_FOR_PLAYBACK_MS,
-                        BUFFER_AFTER_REBUFFER_MS)
-                .build());
+        // Bounded by time rather than by bytes, for streams only. On the defaults the byte budget binds
+        // first on anything high-bitrate — 144 MB is about 21 s of a 53 Mbps remux, well short of the 50 s
+        // window — so the loader sits on that ceiling and is switched on and off around it about eleven
+        // times a second (measured: 1070 flips in two minutes), while the buffer costs 144 MB of a 512 MB
+        // heap. prioritizeTimeOverSizeThresholds moves the limit to the fifteen-second minimum and hands
+        // the memory question to Media3's own heap-headroom check, which is what it is for.
+        //
+        // The figures follow the two players that stream the same torrent backends on the same boxes
+        // without knocking them over (dddplayer: 15/50/500/5000 with the same flag; alpac: 30/60/2500/5000)
+        // — and both chose five seconds after a stall, which is the middle ground between Media3's two and
+        // the fifteen that 4c3d62e tried here and had to be reverted for turning every seek out of the
+        // buffered range into a 99 MB haul.
+        //
+        // Streaming only: local playback keeps its own, smaller byte budget, where none of this applies.
+        final DefaultLoadControl.Builder loadControlBuilder = new DefaultLoadControl.Builder()
+                .setBufferDurationsMsForStreaming(15_000, 50_000, 500, 5_000)
+                .setPrioritizeTimeOverSizeThresholdsForStreaming(true);
+        playerBuilder.setLoadControl(loadControlBuilder.build());
 
         player = playerBuilder.build();
 
@@ -10631,6 +10753,8 @@ public class PlayerActivity extends Activity {
             playerView.removeCallbacks(resumeWatchdogRunnable);
             playerView.removeCallbacks(passthroughRestartRunnable);
             playerView.removeCallbacks(rebufferArmRunnable);
+            playerView.removeCallbacks(pauseReleaseRunnable);
+            stoppedForPause = false;
             audioRestartPending = false;
             audioRestartInFlight = false;
             audioRestartSettling = false;
@@ -10978,6 +11102,13 @@ public class PlayerActivity extends Activity {
         // by the sink no longer reporting passthrough.
         @Override
         public void onPlayWhenReadyChanged(boolean playWhenReady, int reason) {
+            if (playWhenReady && stoppedForPause) {
+                stoppedForPause = false;
+                if (player != null && player.getPlaybackState() == Player.STATE_IDLE) {
+                    Utils.log("pause: re-preparing after the source was let go");
+                    player.prepare();
+                }
+            }
             if (playWhenReady) {
                 return;
             }
@@ -11027,6 +11158,13 @@ public class PlayerActivity extends Activity {
                 playerView.postDelayed(rebufferArmRunnable, REBUFFER_ARM_MS);
             }
             resetDim();
+
+            // A pause by the viewer, not a stall: playWhenReady is what separates them, and only the
+            // first should start the clock on letting the source go.
+            playerView.removeCallbacks(pauseReleaseRunnable);
+            if (!isPlaying && player != null && !player.getPlayWhenReady()) {
+                playerView.postDelayed(pauseReleaseRunnable, PAUSE_RELEASE_MS);
+            }
 
             if (Utils.isPiPSupported(PlayerActivity.this)) {
                 if (isPlaying) {
@@ -11330,7 +11468,9 @@ public class PlayerActivity extends Activity {
                     // renderer in for good.
                     final Format stalledAudioFormat = player != null ? player.getAudioFormat() : null;
                     if (audioSink != null && audioSink.isPassthrough()
-                            && recoverByRevokingAudioMime(stalledAudioFormat != null ? stalledAudioFormat.sampleMimeType : null)) {
+                            && recoverByRevokingAudioMime(
+                                    stalledAudioFormat != null ? stalledAudioFormat.sampleMimeType : null,
+                                    false)) {
                         return;
                     }
                 }
@@ -11350,8 +11490,18 @@ public class PlayerActivity extends Activity {
             // The device claims Dolby/DTS passthrough support it doesn't actually have: AudioTrack
             // opening for that mime throws outright instead of just never draining. Same fix, reached
             // from the loud symptom instead of the silent one.
-            if (error.errorCode == PlaybackException.ERROR_CODE_AUDIO_TRACK_INIT_FAILED
-                    && recoverByRevokingAudioMime(audioTrackInitFailureMime(error))) {
+            // ERROR_CODE_AUDIO_TRACK_WRITE_FAILED joins it: a bitstream AudioTrack can die under a
+            // player that has been feeding it for an hour (write returns ERROR_DEAD_OBJECT when the audio
+            // server restarts or the HDMI route drops). That used to fall through to the source re-read
+            // below, and the trace says why it was the wrong answer: the re-read re-opens the container
+            // from four cold offsets of a 56 GB Matroska (header, cues at the far end, 357 KB in, then the
+            // playback position) and arrives 1.2 s later at an AudioTrack that is still dead — four more
+            // init failures, a second re-read, eight seconds of frozen picture. Answering on the audio
+            // path costs one prepare() and the sound comes back decoded.
+            if ((error.errorCode == PlaybackException.ERROR_CODE_AUDIO_TRACK_INIT_FAILED
+                    || error.errorCode == PlaybackException.ERROR_CODE_AUDIO_TRACK_WRITE_FAILED)
+                    && recoverByRevokingAudioMime(audioFailureMime(error),
+                            error.errorCode == PlaybackException.ERROR_CODE_AUDIO_TRACK_INIT_FAILED)) {
                 return;
             }
             // The decoder never opened for a format software decoding was never going to carry — 4K on
@@ -11363,16 +11513,7 @@ public class PlayerActivity extends Activity {
                     && recoverByLoweringQuality()) {
                 return;
             }
-            // A bitstream's AudioTrack can also die under a player that was happily feeding it for an hour
-            // (AudioTrack.write returns ERROR_DEAD_OBJECT: the audio server restarted, or the HDMI route to
-            // the receiver dropped). Media3 calls that recoverable but spends its single attempt at the front
-            // of the message queue — milliseconds after the output died, so it fails again and ends playback.
-            // The same delayed re-read is what this needs: by then the route is usually back, and prepare()
-            // keeps the item, position, surface and track selection. Not a reason to revoke the mime as the
-            // branch above does — this device had been bitstreaming it fine until the output went away, and
-            // if it comes back without passthrough the reselect falls to ffmpeg on its own.
-            if ((isDecoderFailure(error) || isUnexpectedPlaybackError(error)
-                    || error.errorCode == PlaybackException.ERROR_CODE_AUDIO_TRACK_WRITE_FAILED)
+            if ((isDecoderFailure(error) || isUnexpectedPlaybackError(error))
                     && recoverFromDecoderFailure()) {
                 return;
             }
@@ -11553,7 +11694,10 @@ public class PlayerActivity extends Activity {
         }
         sourceRetries++;
         updateLoading(true);
-        playerView.postDelayed(sourceRetryRunnable, 1_000);
+        // Doubling, not a flat second: a server that just failed a read is often a server under load, and
+        // three re-reads a second apart are three container re-parses inside the window it needed to
+        // recover. 1 s, 2 s, 4 s gives it that room and still gives up inside eight seconds.
+        playerView.postDelayed(sourceRetryRunnable, 1_000L << (sourceRetries - 1));
         return true;
     }
 
@@ -11855,14 +11999,26 @@ public class PlayerActivity extends Activity {
     // so the player is always STATE_IDLE here: prepare() re-reads the source keeping the media item,
     // the position, the surface and the track selection (same as recoverFromSourceError), and the
     // already-installed sink now denies the mime, so the track falls back to decoding. No player
-    // rebuild, so it does not read as a restart. One-way (until the user resets it in Settings),
+    // rebuild, so it does not read as a restart. One-way for as long as the verdict lasts,
     // guarded by mPrefs.revokedAudioMimes itself, so a repeat failure on the same mime after the
     // switch falls through to the normal error screen instead of looping.
-    private boolean recoverByRevokingAudioMime(String mime) {
-        if (mime == null || mPrefs.revokedAudioMimes.contains(mime) || player == null || audioSink == null) {
+    private boolean recoverByRevokingAudioMime(String mime, boolean persist) {
+        if (mime == null || player == null || audioSink == null
+                || mPrefs.revokedAudioMimes.contains(mime) || sessionRevokedAudioMimes.contains(mime)) {
             return false;
         }
-        mPrefs.revokeAudioMime(mime);
+        // Remembered across runs only when the AudioTrack refused to open — that is a property of the
+        // route and does not change between films, so paying the failure again on every launch buys
+        // nothing. A track that died mid-playback is the opposite, and a field trace from a Google TV
+        // Streamer shows why it may not be written down: AudioTrack.write returned -6 (ERROR_DEAD_OBJECT)
+        // after five clean minutes of bitstreaming AC-3, the route was back seconds later, and the
+        // verdict would have stayed for good — the box would decode AC-3 in software in every film after
+        // one dropped HDMI route. Those keep to their own run, and the user can clear the remembered ones
+        // from Settings.
+        sessionRevokedAudioMimes.add(mime);
+        if (persist) {
+            mPrefs.revokeAudioMime(mime);
+        }
         audioSink.revoke(mime);
         if (mPrefs.decoderPriority == DefaultRenderersFactory.EXTENSION_RENDERER_MODE_OFF) {
             // "Device decoders only", and this is the first revocation: the ffmpeg audio renderer the
@@ -11925,15 +12081,27 @@ public class PlayerActivity extends Activity {
         playerView.post(passthroughRestartRunnable);
     }
 
-    // AudioSink.InitializationException.format is a public field in this build — no reflection needed.
-    private static String audioTrackInitFailureMime(PlaybackException error) {
-        if (error.errorCode != PlaybackException.ERROR_CODE_AUDIO_TRACK_INIT_FAILED) {
+    /**
+     * The audio sample mime behind an AudioTrack failure, or null when the error is not one.
+     * AudioSink.InitializationException.format is a public field in this build — no reflection needed —
+     * and a write failure carries no such cause, so it is read from the renderer format the exception was
+     * raised for instead.
+     */
+    private static String audioFailureMime(PlaybackException error) {
+        if (error.errorCode != PlaybackException.ERROR_CODE_AUDIO_TRACK_INIT_FAILED
+                && error.errorCode != PlaybackException.ERROR_CODE_AUDIO_TRACK_WRITE_FAILED) {
             return null;
         }
         for (Throwable cause = error.getCause(); cause != null; cause = cause.getCause()) {
             if (cause instanceof AudioSink.InitializationException) {
                 Format format = ((AudioSink.InitializationException) cause).format;
                 return format != null ? format.sampleMimeType : null;
+            }
+        }
+        if (error instanceof ExoPlaybackException) {
+            final Format format = ((ExoPlaybackException) error).rendererFormat;
+            if (format != null && MimeTypes.isAudio(format.sampleMimeType)) {
+                return format.sampleMimeType;
             }
         }
         return null;
@@ -12461,6 +12629,23 @@ public class PlayerActivity extends Activity {
         return false;
     }
 
+    /**
+     * Holds or releases the screen, on the window rather than on the player view. A view flag reaches the
+     * same wake lock through ViewRootImpl, but only while that view is attached and drawing — and a box
+     * was reported going to sleep a quarter of an hour into a film, which is what an unheld screen looks
+     * like on Android TV, where the inactivity timeout is of that order. Both reference players set the
+     * window flag (dddplayer in onCreate, alpac on the view for the whole session) and neither ties it to
+     * anything; here it stays tied to playback, which is what the give-up above needs, but the flag now
+     * sits where nothing about the view hierarchy can silently drop it.
+     */
+    private void holdScreen(final boolean hold) {
+        if (hold) {
+            getWindow().addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
+        } else {
+            getWindow().clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
+        }
+    }
+
     /** Whether a pause is currently entitled to hold the screen awake. */
     private boolean keepAwakeOnPause() {
         return mPrefs != null && mPrefs.keepAwakeOnPause && isTvBox && haveMedia && !isInPip();
@@ -12472,25 +12657,33 @@ public class PlayerActivity extends Activity {
      * wake the screen, so it can be swallowed — Back on a dimmed screen would otherwise leave the player.
      */
     private boolean resetDim() {
-        if (dimOverlay == null) {
-            return false;
-        }
         playerView.removeCallbacks(dimRunnable);
         playerView.removeCallbacks(keepAwakeGiveUpRunnable);
 
+        // Before anything to do with the sheet, and never behind a null check on it. The dim overlay only
+        // exists in the ordinary layout; a Mi Box on Android 9 is served activity_player_textureview,
+        // which has no such view — so with the hold below sitting after that null check, the screen was
+        // never held there at all and the box took its own sleep timeout mid-film, fifteen minutes in.
+        // Holding the screen is not a detail of the dim sheet; it is the one thing this method owes the
+        // playback.
+        final boolean playing = player != null && player.isPlaying();
+        final boolean holding = keepAwakeOnPause();
+        holdScreen(playing || holding);
+        if (holding && !playing) {
+            playerView.postDelayed(keepAwakeGiveUpRunnable, KEEP_AWAKE_MAX_MS);
+        }
+
+        if (dimOverlay == null) {
+            return false;
+        }
         final boolean wasDim = dimOverlay.getVisibility() == View.VISIBLE;
         if (wasDim) {
             dimOverlay.animate().cancel();
             dimOverlay.animate().alpha(0f).setDuration(DIM_OUT_MS)
                     .withEndAction(() -> dimOverlay.setVisibility(View.GONE));
         }
-
-        final boolean playing = player != null && player.isPlaying();
-        final boolean holding = keepAwakeOnPause();
-        playerView.setKeepScreenOn(playing || holding);
         if (holding && !playing) {
             playerView.postDelayed(dimRunnable, DIM_DELAY_MS);
-            playerView.postDelayed(keepAwakeGiveUpRunnable, KEEP_AWAKE_MAX_MS);
         }
         return wasDim;
     }

--- a/app/src/main/java/com/brouken/player/Prefs.java
+++ b/app/src/main/java/com/brouken/player/Prefs.java
@@ -119,7 +119,7 @@ class Prefs {
     private static final String PREF_KEY_UPDATE_SKIPPED = "updateSkippedVersionCode";
     private static final String PREF_KEY_UPDATE_PENDING = "updatePending";
     private static final String PREF_KEY_REVOKED_AUDIO_MIMES = "revokedAudioMimes";
-    private static final String PREF_KEY_REVOKED_AUDIO_MIMES_RELEARNED = "revokedAudioMimesRelearned";
+    private static final String PREF_KEY_REVOKED_AUDIO_MIMES_RELEARNED = "revokedAudioMimesRelearned3";
 
     // How a skippable segment is offered. BRIEF shows the Skip button for PlayerActivity.SKIP_NOTICE_MS and
     // then leaves the picture alone; the option's name says "5 seconds", so that constant and the
@@ -301,7 +301,11 @@ class Prefs {
 
     /**
      * Clears the learned passthrough denylist once, so entries left by builds whose stall recovery blamed
-     * whichever mime happened to be playing do not stay for good. Those entries deny nothing (the track was
+     * whichever mime happened to be playing do not stay for good. Nothing writes the list any more — a
+     * failed AudioTrack now falls back for the current run only (PlayerActivity.recoverByRevokingAudioMime),
+     * because a field trace showed a transient HDMI route loss taking AC-3 bitstreaming away from a box for
+     * good. The key this one-shot is remembered under was bumped with that change, so every device gets one
+     * clean slate; after it the list stays empty unless an older build filled it. Those entries deny nothing (the track was
      * being decoded, not bitstreamed) but keep the set non-empty, which forces the ffmpeg audio renderer in
      * for "device decoders only" and puts a misleading line in every error report.
      *
@@ -756,13 +760,18 @@ class Prefs {
         mSharedPreferences.edit().putBoolean(PREF_KEY_TUNNELING, false).apply();
     }
 
+    /**
+     * Remembers that this device cannot bitstream {@code mime}, so the next run does not pay the failure
+     * again. Only written for an AudioTrack that refused to open at all — see
+     * PlayerActivity.recoverByRevokingAudioMime, which keeps a track that died mid-playback to its own run.
+     */
     public void revokeAudioMime(final String mime) {
         final Set<String> updated = new HashSet<>(revokedAudioMimes);
         updated.add(mime);
         revokedAudioMimes = updated;
-        final SharedPreferences.Editor sharedPreferencesEditor = mSharedPreferences.edit();
-        sharedPreferencesEditor.putStringSet(PREF_KEY_REVOKED_AUDIO_MIMES, updated);
-        sharedPreferencesEditor.apply();
+        mSharedPreferences.edit()
+                .putStringSet(PREF_KEY_REVOKED_AUDIO_MIMES, updated)
+                .apply();
     }
 
     public static void resetRevokedAudioMimes(final Context context) {

--- a/app/src/main/java/com/brouken/player/SubtitleFetcher.java
+++ b/app/src/main/java/com/brouken/player/SubtitleFetcher.java
@@ -5,9 +5,11 @@ import android.net.Uri;
 import androidx.media3.common.C;
 
 import java.io.File;
+import java.io.FilterInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Collections;
+import java.util.Collection;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -34,7 +36,7 @@ import okhttp3.ResponseBody;
 class SubtitleFetcher {
 
     private final PlayerActivity activity;
-    private final List<Uri> urls;
+    private final Collection<Uri> urls;
     private final String cacheName;
     /** Length of what is playing, or {@link C#TIME_UNSET} when it is not known — see {@link #fitsMedia}. */
     private final long durationMs;
@@ -74,7 +76,7 @@ class SubtitleFetcher {
     /** The name the file was uploaded under, out of {@code attachment; filename="…"}. */
     private static final Pattern ATTACHMENT_NAME = Pattern.compile("filename[^=]*=\"?([^\";]+)");
 
-    public SubtitleFetcher(PlayerActivity activity, List<Uri> urls) {
+    public SubtitleFetcher(PlayerActivity activity, Collection<Uri> urls) {
         this(activity, urls, null, C.TIME_UNSET);
     }
 
@@ -86,7 +88,7 @@ class SubtitleFetcher {
      *                   Read on the caller's thread and passed in, because this runs on a worker and
      *                   the player is not its to ask.
      */
-    public SubtitleFetcher(PlayerActivity activity, List<Uri> urls, String cacheName,
+    public SubtitleFetcher(PlayerActivity activity, Collection<Uri> urls, String cacheName,
                            long durationMs) {
         this.activity = activity;
         this.urls = urls;
@@ -133,6 +135,35 @@ class SubtitleFetcher {
         return null;
     }
 
+    /**
+     * The stream, failing once more than {@code max} bytes have been read. An IOException rather than a
+     * silent end of stream: a truncated subtitle file is worse than none, and the caller already treats
+     * a failed read as "try the next candidate".
+     */
+    private static InputStream limited(final InputStream stream, final long max) {
+        return new FilterInputStream(stream) {
+            private long read;
+
+            @Override
+            public int read() throws IOException {
+                final int b = super.read();
+                if (b != -1 && ++read > max) {
+                    throw new IOException("subtitle candidate larger than " + max + " bytes");
+                }
+                return b;
+            }
+
+            @Override
+            public int read(byte[] buffer, int offset, int length) throws IOException {
+                final int count = super.read(buffer, offset, length);
+                if (count > 0 && (read += count) > max) {
+                    throw new IOException("subtitle candidate larger than " + max + " bytes");
+                }
+                return count;
+            }
+        };
+    }
+
     /** @return the local copy, or null to try the next candidate. */
     private Uri fetch(OkHttpClient client, Uri url) {
         // Prevents IllegalArgumentException in okhttp3.Request.Builder.
@@ -158,7 +189,11 @@ class SubtitleFetcher {
                 Utils.log("subtitle download: forced track, skipping " + name);
                 return null;
             }
-            InputStream stream = body.byteStream();
+            // Bounded by what arrives, because contentLength() is -1 for a chunked response and -1 is
+            // not greater than MAX_BYTES: the guard above lets such a body through, and the reader below
+            // takes it to the end of the stream. A host that answers a guessed subtitle name with the
+            // film itself would have been downloaded whole, into a String.
+            InputStream stream = limited(body.byteStream(), MAX_BYTES);
             // The legacy OpenSubtitles API hands back a gzipped file rather than a gzipped response,
             // so nothing below the socket unpacks it for us.
             if (url.getPath() != null && url.getPath().endsWith(".gz")) {

--- a/app/src/main/java/com/brouken/player/SubtitleFinder.java
+++ b/app/src/main/java/com/brouken/player/SubtitleFinder.java
@@ -4,8 +4,8 @@ import android.net.Uri;
 
 import androidx.media3.common.util.Util;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.util.LinkedHashSet;
+import java.util.Set;
 
 import okhttp3.HttpUrl;
 
@@ -14,20 +14,40 @@ public class SubtitleFinder {
     private PlayerActivity activity;
     private Uri baseUri;
     private String path;
-    private final List<Uri> urls;
+    private final Set<Uri> urls;
 
     public SubtitleFinder(PlayerActivity activity, Uri uri) {
         this.activity = activity;
         path = uri.getPath();
         path = path.substring(0, path.lastIndexOf('.'));
         baseUri = uri;
-        urls = new ArrayList<>();
+        urls = new LinkedHashSet<>();
     }
 
     public static boolean isUriCompatible(Uri uri) {
         String pth = uri.getPath();
-        if (pth != null) {
-            return pth.lastIndexOf('.') > -1;
+        if (pth == null || pth.lastIndexOf('.') <= -1) {
+            return false;
+        }
+        return !isStreamEndpoint(pth);
+    }
+
+    /**
+     * Whether the path is a streaming endpoint rather than a file on a server. Guessing sidecar names
+     * only makes sense next to a real file: an endpoint serves one blob, so every guess is a miss that
+     * the backend still pays for. A torrent backend pays the most — TorrServe resolves the path inside
+     * the raddish and spawns a reader per connection — and one was reported falling over under a player
+     * that asked it ten to twenty times per opened film, for names that could not exist.
+     *
+     * <p>Matched on a whole path segment, so a film actually called "stream.mkv" on a file server is
+     * left alone. Deliberately narrow: the point is to stop a known-pointless volley, not to guess at
+     * which hosts deserve one.
+     */
+    private static boolean isStreamEndpoint(final String path) {
+        for (final String segment : path.split("/")) {
+            if (segment.equalsIgnoreCase("stream") || segment.equalsIgnoreCase("play")) {
+                return true;
+            }
         }
         return false;
     }


### PR DESCRIPTION
Playback of a high-bitrate remux over a torrent backend (TorrServe and the Lampa proxies) went wrong in several places at once, all of which reached the viewer as one endless load with no error behind it. Field traces from the reporting boxes drove every figure here.

## Buffering

The stream buffer was bounded by bytes, so 144 MB of a 512 MB heap bought about 21 seconds of a 53 Mbps file — well short of the 50-second window it was supposed to fill — and the loader was switched on and off around that ceiling about eleven times a second. It is bounded by time now (15/50/0.5/5 s for streams, with `prioritizeTimeOverSizeThresholds`), which is what the two players that stream the same backends on the same hardware do. The buffer percentage is reported against the ceiling it can actually reach, instead of against a window it could never get to.

## Load on the media host

* Media reads go through a pooled OkHttp client (60 s connect / 120 s read, `retryOnConnectionFailure`). `DefaultHttpDataSource` disconnects on every close and pools nothing, so each of the four cold range requests a container re-read costs was a fresh connection — and a torrent backend spawns a reader and a preload window per connection.
* The first megabyte of each opened range is kept in a small on-disk cache, so the Matroska header and the cues come off flash from the second play of a file onward rather than off the swarm.
* The whole-file range some proxies require is attached per open, and only where Media3 would otherwise send no range at all.
* Sidecar subtitle names are no longer guessed at a `/stream` or `/play` endpoint — those files exist nowhere, and it was ten to twenty-two requests per media intent. The subtitle download is bounded by the bytes actually read, so a chunked answer can no longer be pulled in whole.
* Retry budgets are keyed by URI, so rebuilding the player cannot refill them; backoff is 1/2/4 s. A stream that keeps failing now gives up inside eight seconds instead of cascading.
* A pause standing for five minutes lets the source go, instead of holding an idle socket and the whole buffer.

## Audio

A bitstreamed `AudioTrack` owns the receiver's AC3/DTS route exclusively, and pausing does not release it — so a player left in the background kept that route for minutes. Every other player on the box met `AudioTrack init failed` for AC3 in that window and remembered the refusal as a verdict about the hardware, which took a data wipe to undo. The output is handed back on the way out now.

A dead `AudioTrack` (`ERROR_DEAD_OBJECT` after an HDMI route drop) is answered on the audio path rather than by re-preparing the source, and the passthrough fallback it picks lasts for the session instead of for good.

## Screen and TV

The screen is held before the dim sheet is looked for. A Mi Box on Android 9 is served a layout that has no such view, and the hold sat behind the null check on it — so on exactly that hardware nothing held the screen and the box applied its own fifteen-minute inactivity sleep in the middle of a film.

The time bar no longer enters Media3's scrubbing mode on TV: it deselects audio and suppresses playback, which leaves a tunneled decoder with no picture.

## Also

* `PermissionActivity` in the vendored file chooser no longer crashes when its intent carries no permission list — which is what a task restored after a reboot hands it.
* The on-disk media cache is dropped when the version code changes, so an update never plays a file partly from bytes an older build wrote.