### PR TITLE
Hand the bitstream output back when the screen is destroyed from the background

### DIFF
--- a/app/src/main/java/com/brouken/player/PlayerActivity.java
+++ b/app/src/main/java/com/brouken/player/PlayerActivity.java
@@ -2545,14 +2545,23 @@ public class PlayerActivity extends Activity {
     }
 
     /**
-     * The room is anchored to this screen, so it cannot outlive it. onStop only leaves the room when the
-     * activity is finishing, which is the ordinary way out — but a screen destroyed from the background
-     * (low-memory reclaim, or "don't keep activities") is not finishing, and its socket stayed open:
-     * pinging every twenty seconds, reconnecting for ever, and holding the whole player view tree
-     * reachable, while the room went on listing a member whose heartbeats had stopped.
+     * The room and the player are anchored to this screen, so neither can outlive it. onStop only lets
+     * them go when the activity is finishing, which is the ordinary way out — but a screen destroyed
+     * from the background (low-memory reclaim, or "don't keep activities") is not finishing. Its socket
+     * stayed open: pinging every twenty seconds, reconnecting for ever, and holding the whole player
+     * view tree reachable, while the room went on listing a member whose heartbeats had stopped. The
+     * player it kept for a quick return stayed too, and with it a bitstream AudioTrack that owns the
+     * receiver's AC3/DTS route exclusively — the very thing every other player on the box then failed to
+     * open. Nothing was left to hand it back: the five-minute release is posted on a view tree that goes
+     * away with the screen. The position is already saved, by onPause. Not for a screen that handed the
+     * session over: the player behind that static is a newer screen's by now, and releasing it here
+     * would tear down a session that has already started playing.
      */
     @Override
     protected void onDestroy() {
+        if (!handedOver) {
+            releasePlayer(false);
+        }
         if (live == this) {
             live = null;
         }


### PR DESCRIPTION
Follow-up to #147, which fixed the passthrough output being held by a player kept alive in the background. Leaving the player screen already released it — `onStop` sees `isFinishing()` and tears the player down, and with it the `AudioTrack`.

A screen the system destroys from the background is the case that was left: low-memory reclaim or "don't keep activities" is not finishing, so `onStop` keeps the player for a quick return that never comes, and the five-minute release that would have let it go is posted on a view tree that goes away with the screen. Nothing is left to hand the output back, and a passthrough `AudioTrack` owns the receiver's AC3/DTS route exclusively for as long as it lives.

Released in `onDestroy` now, where the Together room is already left for exactly the same reason. Guarded by `handedOver`: `player` is a static, and a screen that handed the session over would otherwise release a player that belongs to a newer screen and has already started playing. The position is saved by `onPause`.

Verified on the `tv_720p` emulator that the ordinary way out still tears down cleanly with the release now running on both paths. The background-destroy path itself could not be forced there — `always_finish_activities` has no effect on API 36 TV, and the emulator has no passthrough route — so that branch rests on the call being the same one the ordinary path already runs.