### PR TITLE
Keep the disk cache away from HLS and DASH manifests

### DIFF
--- a/app/src/main/java/com/brouken/player/PlayerActivity.java
+++ b/app/src/main/java/com/brouken/player/PlayerActivity.java
@@ -10269,7 +10269,23 @@ public class PlayerActivity extends Activity {
                                     : dataSpec);
             // The container head and the Cues come off disk on every play after the first, so a
             // re-prepare asks the network for one range instead of four — see MediaCache.
-            upstreamFactory = MediaCache.wrap(this, rangeSeeded);
+            //
+            // Progressive media only. A manifest is read through this same factory, and the cache knows
+            // nothing of HTTP freshness: the first copy of a playlist is kept and served from disk on
+            // every reload after it. A live playlist lists only its current window — three two-second
+            // segments on the stream this was reported on — so the player played those six seconds and
+            // then waited forever for a playlist that could no longer change. Nothing is lost by staying
+            // out of the way: HLS and DASH read each segment once and never re-read a container head.
+            final String mediaMime = mPrefs.mediaType != null
+                    ? mPrefs.mediaType : resolvedMediaTypes.get(mPrefs.mediaUri.toString());
+            // Either signal is enough. A .m3u8 carrying a video/* mime is still HLS — that mime only
+            // sends it down the progressive path first, where it fails and is recovered as HLS
+            // (recoverFromContainerError) without this factory being rebuilt.
+            final boolean adaptive =
+                    Util.inferContentType(mPrefs.mediaUri) != C.CONTENT_TYPE_OTHER
+                            || Util.inferContentTypeForUriAndMimeType(mPrefs.mediaUri, mediaMime)
+                                    != C.CONTENT_TYPE_OTHER;
+            upstreamFactory = adaptive ? rangeSeeded : MediaCache.wrap(this, rangeSeeded);
         }
 
         final androidx.media3.datasource.DataSource.Factory dataSourceFactory = new TrackNameParsingDataSource.Factory(upstreamFactory, trackNameListener);


### PR DESCRIPTION
A live HLS stream played about six seconds and then stopped loading.

The media cache added in #147 sits in front of every HTTP read, and a manifest goes through the same factory. `CacheDataSource` knows nothing of HTTP freshness, so the first copy of a playlist is kept and answered from disk on every reload after it — `cache-control: no-cache` included. A live playlist lists only its current window (three two-second segments on the reported stream), so the player finished that window and then waited forever for a playlist that could no longer change.

The cache is now put in front of progressive media only. Nothing is lost there: HLS and DASH read each segment once and never re-read a container head. The type is taken from the URI or from the mime, so a `.m3u8` carrying a `video/*` mime is recognised as well — that mime only sends it down the progressive path first, where it fails and is recovered as HLS without the data source factory being rebuilt.

Verified against the reported stream: `#EXT-X-TARGETDURATION:2`, three segments, `content-length: 187`, `cache-control: no-cache` — a fully cacheable six-second window, which matches the symptom exactly.