### PR TITLE
Read the container from the stream when the URL will not say

### DIFF
--- a/app/src/main/java/com/brouken/player/ContainerMetadataReader.java
+++ b/app/src/main/java/com/brouken/player/ContainerMetadataReader.java
@@ -68,6 +68,11 @@ final class ContainerMetadataReader {
         return null;
     }
 
+    /** Whether the first {@link #SIGNATURE_BYTES} bytes announce a Matroska container. */
+    static boolean isMatroska(byte[] header) {
+        return signature(header) == Container.MATROSKA;
+    }
+
     /**
      * Bytes of the front of the stream worth collecting for the matching parser, or 0 for a container
      * this does not parse — an HLS manifest, an MPEG-TS segment, anything whose header is not at offset

--- a/app/src/main/java/com/brouken/player/PlayerActivity.java
+++ b/app/src/main/java/com/brouken/player/PlayerActivity.java
@@ -752,7 +752,7 @@ public class PlayerActivity extends Activity {
     // this the trigger feeds itself: the reselect stops the audio renderer, playback stops, that arms the
     // latch, and the next start recreates again — forever. Causal rather than timed on purpose. A window
     // measured from when the reselect was requested only holds while the playback thread answers promptly,
-    // and the boxes this feature is for are the ones that do not (see blockHeavyMkvAudio); this is cleared by
+    // and the boxes this feature is for are the ones that do not (see the heavy-audio block); this is cleared by
     // the return to playing itself, however late that is.
     private boolean audioRestartSettling;
     // Whether the current item has ever actually played. The first start of an item opens its own fresh
@@ -9907,18 +9907,26 @@ public class PlayerActivity extends Activity {
         addSubtitleTrack(uri);
     }
 
-    // Whether the current media is a Matroska container, detected from the resolved MIME type or the
-    // URI extension. Extensionless streams that never reveal a matroska type are not matched.
-    private boolean isMatroskaMedia() {
-        if (MimeTypes.VIDEO_MATROSKA.equals(mPrefs.mediaType)) {
+    // Whether the current media is a Matroska container: the resolved MIME type, the URI extension, or
+    // the stream's own first bytes. The last one is what covers a resolver URL, which carries neither —
+    // a hashed path with no extension and no mime, answered by a real Matroska remux.
+    private static boolean isMatroskaMedia(final Uri uri, final String mediaType) {
+        if (MimeTypes.VIDEO_MATROSKA.equals(mediaType)) {
             return true;
         }
-        if (mPrefs.mediaUri == null) {
+        if (uri == null) {
             return false;
         }
-        final String path = mPrefs.mediaUri.getPath();
+        if (TrackNameParsingDataSource.isMatroska(uri)) {
+            return true;
+        }
+        final String path = uri.getPath();
         // Case-insensitive ".mkv" suffix test without allocating a lower-cased copy of the path.
         return path != null && path.regionMatches(true, path.length() - 4, ".mkv", 0, 4);
+    }
+
+    private boolean isMatroskaMedia() {
+        return isMatroskaMedia(mPrefs.mediaUri, mPrefs.mediaType);
     }
 
     // Denies passthrough only for mimes this device has already proven broken (see
@@ -10088,13 +10096,22 @@ public class PlayerActivity extends Activity {
                 .setTsExtractorTimestampSearchBytes(1500 * TsExtractor.TS_PACKET_SIZE);
         // On TV boxes the platform MediaCodec decoder for the heavy codecs common in MKV remuxes
         // (DTS/EAC3/TrueHD) can wedge during init on the playback thread — no exception is thrown, so
-        // the load never reaches a ready state (JPP-1005). Instead of blanket-forcing software audio
-        // (which also kills Atmos/passthrough on every TV), hide only those codecs from the platform
-        // decoder via the combined MediaCodecSelector below. MediaCodecAudioRenderer consults the sink
-        // first, so where the receiver advertises passthrough the compressed bitstream still goes out
-        // (Atmos preserved); where it does not, the track falls through to the ffmpeg software
-        // renderer. Only MKV audio on a TV is affected; video keeps the user's decoder priority.
-        final boolean blockHeavyMkvAudio = isTvBox && isMatroskaMedia();
+        // the load never reaches a ready state (JPP-1005) — and where it does run, it is the decoder a
+        // box without the matching Dolby/DTS licence answers with silence. Instead of blanket-forcing
+        // software audio (which also kills Atmos/passthrough on every TV), hide only those codecs from
+        // the platform decoder via the combined MediaCodecSelector below. MediaCodecAudioRenderer
+        // consults the sink first, so where the receiver advertises passthrough the compressed bitstream
+        // still goes out (Atmos preserved); where it does not, the track falls through to the ffmpeg
+        // software renderer. Only MKV audio on a TV is affected; video keeps the user's decoder priority.
+        //
+        // Decided inside the selector rather than here, because here it cannot be known yet: a stream
+        // whose URL carries no extension and no mime only reveals its container when its first bytes are
+        // read, which happens while this player prepares. That is after the factory is built, but still
+        // before any track exists — so before the selector is ever consulted. Freezing the answer at
+        // build time is what let a Matroska remux behind a hashed resolver URL reach the platform
+        // decoder (JPP-B: a TV box played the picture in silence, its own eac3 decoder in the report).
+        final Uri mediaUri = mPrefs.mediaUri;
+        final String mediaType = mPrefs.mediaType;
         // Audio sample mimes this device has already proven cannot passthrough (see
         // recoverByRevokingAudioMime()) — denied at the sink only; the platform decoder for the same
         // mime is left alone since it is an independent subsystem that may work fine.
@@ -10102,7 +10119,7 @@ public class PlayerActivity extends Activity {
         // passthrough back to a mime that just failed, or the failure repeats on the same frame.
         final Set<String> revokedAudioMimes = new HashSet<>(mPrefs.revokedAudioMimes);
         revokedAudioMimes.addAll(sessionRevokedAudioMimes);
-        // Always subclassed (not only for blockHeavyMkvAudio/an existing revocation) so buildAudioSink
+        // Always subclassed (not only for the heavy-audio block/an existing revocation) so buildAudioSink
         // below can install the live AudioPassthroughDenylistSink from a device's very first play —
         // it needs to be present before any revocation exists, so a first stall can revoke into it
         // without a player rebuild (see recoverByRevokingAudioMime()).
@@ -10118,8 +10135,11 @@ public class PlayerActivity extends Activity {
                 // hidden from the platform decoder or a mime has been revoked — even when the user
                 // chose "device decoders only". Keep it behind the platform renderer (ON, not PREFER)
                 // so passthrough/decode still wins when available. An explicit PREFER stands.
+                // isTvBox rather than the block itself: that is decided per mime while the player runs
+                // (see mediaUri above), and by then this list is fixed — so on a TV the fallback has to
+                // be in it already or a hidden platform decoder would leave the track with nothing.
                 super.buildAudioRenderers(context,
-                        (blockHeavyMkvAudio || !revokedAudioMimes.isEmpty())
+                        (isTvBox || !revokedAudioMimes.isEmpty())
                                 && extensionRendererMode == EXTENSION_RENDERER_MODE_OFF
                                 ? EXTENSION_RENDERER_MODE_ON : extensionRendererMode,
                         mediaCodecSelector, enableDecoderFallback, audioSink, eventHandler,
@@ -10182,15 +10202,16 @@ public class PlayerActivity extends Activity {
                 // of letting the next candidate try.
                 .setEnableDecoderFallback(true)
                 .setMapDV7ToHevc(mPrefs.mapDV7ToHevc);
-        if (forceHevcForDolbyVision || blockHeavyMkvAudio) {
+        if (forceHevcForDolbyVision || isTvBox) {
             // One combined codec selector for two independent needs:
-            // - blockHeavyMkvAudio: no platform decoder for the heavy MKV audio codecs, so they
-            //   passthrough (if the sink supports it) or fall back to ffmpeg (see above).
+            // - heavy MKV audio on a TV: no platform decoder for those codecs, so they passthrough (if
+            //   the sink supports it) or fall back to ffmpeg (see above).
             // - forceHevcForDolbyVision: route a Dolby Vision track to the plain HEVC decoder (its base
             //   layer is HEVC), bypassing a device DV decoder that wedged or failed while decoding.
             //   Picture stays HDR10.
             renderersFactory.setMediaCodecSelector((mimeType, requiresSecureDecoder, requiresTunnelingDecoder) -> {
-                if (blockHeavyMkvAudio && HEAVY_MKV_AUDIO_MIMES.contains(mimeType)) {
+                if (isTvBox && HEAVY_MKV_AUDIO_MIMES.contains(mimeType)
+                        && isMatroskaMedia(mediaUri, mediaType)) {
                     return Collections.emptyList();
                 }
                 return MediaCodecSelector.DEFAULT.getDecoderInfos(

--- a/app/src/main/java/com/brouken/player/TrackNameParsingDataSource.java
+++ b/app/src/main/java/com/brouken/player/TrackNameParsingDataSource.java
@@ -48,6 +48,22 @@ final class TrackNameParsingDataSource implements DataSource {
      */
     static final AtomicLong bytesRead = new AtomicLong();
 
+    /**
+     * The media URI whose own first bytes announced a Matroska container, or null. Written on a load
+     * thread the moment the signature is read — the tee sits upstream of the extractor, so this is set
+     * before a single track exists and therefore before anything asks which decoder should take the
+     * audio. The URI a stream is served from often says nothing about what it holds (a resolver hands
+     * out a hashed path with no extension and no mime), and that is exactly where the container has to
+     * be read rather than guessed. One slot, not a map: only the item being opened is ever asked about,
+     * and a URI that does not match simply answers no.
+     */
+    private static volatile String matroskaUri;
+
+    /** Whether {@code uri}'s own bytes announced Matroska. */
+    static boolean isMatroska(Uri uri) {
+        return uri != null && uri.toString().equals(matroskaUri);
+    }
+
     /** Receives parsed track metadata (on a load thread) and reports whether it already has it. */
     interface Listener {
         /**
@@ -330,6 +346,9 @@ final class TrackNameParsingDataSource implements DataSource {
                     return;
                 }
                 budget = ContainerMetadataReader.headerBudget(signature);
+                if (uri != null && ContainerMetadataReader.isMatroska(signature)) {
+                    matroskaUri = uri.toString();
+                }
                 if (budget == 0) {
                     // Nothing here any parser reads — an HLS manifest, an MPEG-TS segment. Every segment
                     // of a streaming playback opens at offset 0, and this is what keeps them free: the


### PR DESCRIPTION
## The report

A TV box (Ugoos X3, Amlogic, Android 9) played a Matroska remux with the picture running normally and no sound at all. Nothing in the player looked wrong, and nothing could: ExoPlayer's clock follows the audio renderer, so a picture that keeps moving already proves the AudioTrack is being written and its position is advancing.

A one-off diagnostic build reported the audio path and named the culprit:

- `audio.track_encoding: pcm16` — no passthrough, the app decoded
- `decoder.audio_name: OMX.amlogic.audio.decoder.eac3` — the box's own decoder took the track
- `audio_capabilities: advertised pcm16 pcmFloat ac3 dts` — E-AC3 is **not** in the list

That is a box without the Dolby Digital Plus licence: it advertises AC3 and DTS over HDMI, decodes DD+ to silence, and raises no error doing it. Switching the decoder priority to the app's own decoders restored the sound — which is what the existing TV protection would have done by itself.

## Why the existing protection missed it

The protection keeps the heavy codecs of MKV remuxes (AC3/EAC3/TrueHD/DTS) away from the platform decoder on a TV. It decided "is this Matroska" from the MIME type of the intent and a `.mkv` at the end of the URL. A stream resolver hands out neither: a hashed path, no extension, an `application/octet-stream` content type. Every `Format` the extractor produced said `container=video/x-matroska`, but by then the answer had been frozen at player-build time.

## The change

Take the container from the bytes. The tee that reads container track names already reads the first twelve and matches them against the same signatures; it now writes down when they are EBML. It sits upstream of the extractor, so this is known before a single track exists — and therefore before anything asks which decoder should take the audio.

The block moves into the codec selector, which is consulted at exactly that moment, and the selector is installed on every TV box rather than only where the answer was already yes.

One consequence needs saying: the renderer list is fixed when the player is built, while the block is now decided after. On a TV box the ffmpeg audio renderer therefore goes in even under "device decoders only" — otherwise a hidden platform decoder would leave the track with no decoder at all.

## Verification

On a TV emulator, against an HTTP URL shaped like the reported one (hashed path, no extension, no MIME in the intent), the selector is reached with the container already known:

```
selector mime=video/avc       tv=true matroska=true
selector mime=audio/mp4a-latm tv=true matroska=true
```

The old code answers `false` there: no `.mkv` in the path, and the media type stays null (the response Content-Type resolves to a streaming manifest type only for HLS/DASH/SS). The test clip carries AAC, so it is the container detection that is being measured; with `audio/eac3` the remaining condition is the mime list. Playback of the final build was then replayed clean — `PLAYING`, no errors.

## Still open

The cure is scoped to Matroska. The same empty decoder in this box will be just as silent on E-AC3 inside MP4 or TS. If such reports arrive, the condition has to widen from "Matroska on a TV" to "a TV", which is a noticeable behaviour change for every TV user and wants its own measurement first.