### PR TITLE
Drop Intel from the release APK and publish a name that stays put

### DIFF
--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -32,9 +32,16 @@ jobs:
           -Pandroid.injected.signing.key.alias=key
           -Pandroid.injected.signing.key.password=${{ secrets.KEYSTORE_PASSWORD }}
 
+      # A second copy under a name that never changes. It is what makes
+      # releases/latest/download/JustPlus.Player.apk resolve after every release — the fixed URL a
+      # Downloader short code points at, since GitHub can only redirect to an exact asset name. Same
+      # build as the versioned asset beside it, so whichever one anything picks is the same file.
+      - run: cp app/build/outputs/apk/latestUniversal/release/*.apk JustPlus.Player.apk
+
       - uses: softprops/action-gh-release@v2
         with:
           files: |
             app/build/outputs/apk/latestUniversal/release/*.apk
+            JustPlus.Player.apk
           prerelease: true
           draft: true

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -66,6 +66,17 @@ android {
         release {
             minifyEnabled false
             //proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
+            // The two Intel ABIs are 23 of the 54 MB this APK used to weigh, and nothing that plays video
+            // runs on them: every phone, tablet and TV box is ARM, and the x86 Chromebooks that exist
+            // translate ARM anyway. Release only, so a debug build still installs on the x86_64 emulator
+            // that local checks run on. A whitelist, so what stays is stated rather than inferred.
+            // Not the same thing as -PabiFilter above: this is still one universal APK with the plain
+            // versionCode, which is what keeps updates working for everyone already on one.
+            if (!project.hasProperty('abiFilter')) {
+                ndk {
+                    abiFilters 'arm64-v8a', 'armeabi-v7a'
+                }
+            }
         }
     }
     flavorDimensions "targetSdk", "distribution"


### PR DESCRIPTION
Two independent changes to what a release ships, measured on a local signed build.

## 1. The release APK loses its two Intel ABIs — 54 MB → 31 MB

Measured breakdown of the old universal APK:

| Part | Size |
|---|---|
| dex + resources + assets | 10.2 MB |
| `lib/x86_64` | 12.1 MB |
| `lib/x86` | 11.1 MB |
| `lib/arm64-v8a` | 11.0 MB |
| `lib/armeabi-v7a` | 9.4 MB |

23.2 MB of a 54 MB download — 43 % — is native code for architectures nothing here runs on. Every device reporting in is ARM, and the x86 Chromebooks that exist translate ARM anyway.

Scoped to the `release` build type, so a debug build keeps all four ABIs and still installs on the x86_64 emulator local checks run on. Verified after the change:

```
release : {'arm64-v8a': 11.0, 'armeabi-v7a': 9.4}    → 30.8 MB
debug   : {'x86_64': 12.1, 'x86': 11.1, 'arm64-v8a': 11.0, 'armeabi-v7a': 9.4}
```

**Updates are unaffected.** This is a plain `abiFilters` whitelist, not the `-PabiFilter` path above it: the output is still one universal APK with the ordinary versionCode (no `× 10` mangling), same package and same signing key, so anyone already on a universal build updates to it normally. The guard keeps the two apart — `-PabiFilter=arm64-v8a` still produces a genuine single-ABI APK, verified: `{'arm64-v8a': 11.0}`.

The only install left behind is one genuinely running on Intel without ARM translation, and it fails safely: the install is refused with `INSTALL_FAILED_NO_MATCHING_ABIS` and the version already on the device keeps working.

## 2. A release asset whose name never changes

GitHub can only redirect to an exact asset name — `releases/latest/download/<name>` takes no patterns, and there is no other GitHub-native way to reach "the APK of the newest release". So the workflow now attaches a second copy of the same build as `JustPlus.Player.apk`, giving one permanent URL:

```
https://github.com/just-plus-player/just-plus-player/releases/latest/download/JustPlus.Player.apk
```

That is what a Downloader short code (aftv.news) can point at once and never revisit. The versioned asset stays beside it so a downloaded file still says which build it is. Both assets are the same file, so it does not matter which one anything picks — including `Updater.firstApkAsset()`, which takes the first `.apk` it finds.

Note that the workflow still drafts the release as a pre-release, so the fixed URL keeps resolving to the last *published* release until both flags are cleared by hand — a draft is never handed to users.