### PR TITLE
Keep a live channel playing, and stop searching for its subtitles

### DIFF
--- a/app/src/main/java/com/brouken/player/MediaCache.java
+++ b/app/src/main/java/com/brouken/player/MediaCache.java
@@ -13,6 +13,7 @@ import androidx.media3.datasource.cache.SimpleCache;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.ArrayList;
 
 /**
  * A small on-disk cache in front of the network, sized for one thing: the parts of a container that are
@@ -37,6 +38,8 @@ import java.io.IOException;
  */
 final class MediaCache {
 
+    /** Under the app's cache directory, which is what makes it the system's to reclaim as well. */
+    private static final String DIRECTORY = "media";
     /** Enough for the container heads of a good few films; evicted least-recently-used. */
     private static final long MAX_BYTES = 16 * 1024 * 1024;
     /** How much of each opened range may be written. See the class comment. */
@@ -71,7 +74,7 @@ final class MediaCache {
     private static synchronized SimpleCache get(final Context context) {
         if (cache == null && !unavailable) {
             try {
-                final File directory = new File(context.getCacheDir(), "media");
+                final File directory = new File(context.getCacheDir(), DIRECTORY);
                 clearOnNewBuild(context, directory);
                 cache = new SimpleCache(directory,
                         new LeastRecentlyUsedCacheEvictor(MAX_BYTES),
@@ -83,6 +86,39 @@ final class MediaCache {
             }
         }
         return cache;
+    }
+
+    /**
+     * Drops everything cached for any media but {@code key}, called as the player is built for it.
+     *
+     * <p>Nothing in here expires by itself. There is no TTL, and no HTTP freshness either — a
+     * {@link CacheDataSource} does not read Cache-Control, ETag or Expires — so without this a span
+     * would live until the cache filled its sixteen megabytes, and even then reading one refreshes it:
+     * SimpleCache touches a span it serves and the least-recently-used evictor treats that as new. In
+     * practice that meant until the next app update, across restarts and reboots.
+     *
+     * <p>What this cache is actually for is the re-prepares of the media being played — the recovery
+     * ladder, the re-read after a pause let the source go, a rebuild — and those all ask for the same
+     * key, which is why they still cost nothing. The head of something watched yesterday has no reader
+     * left, so it goes. Between sessions the cache therefore holds at most one item's head, and that
+     * one only until something else is opened.
+     */
+    static synchronized void keepOnly(final Context context, final String key) {
+        // Nothing has ever been cached on this device — do not build a cache just to empty it. (This is
+        // the path of every viewer who only ever plays HLS, where the cache is not used at all.)
+        if (cache == null && !new File(context.getCacheDir(), DIRECTORY).exists()) {
+            return;
+        }
+        final SimpleCache simpleCache = get(context);
+        if (simpleCache == null) {
+            return;
+        }
+        // Over a copy: removing a resource writes through to the very set getKeys() hands out.
+        for (final String cached : new ArrayList<>(simpleCache.getKeys())) {
+            if (!cached.equals(key)) {
+                simpleCache.removeResource(cached);
+            }
+        }
     }
 
     /**
@@ -104,38 +140,125 @@ final class MediaCache {
         prefs.edit().putInt(PREF_KEY_CACHE_BUILD, BuildConfig.VERSION_CODE).apply();
     }
 
+    /** Enough of the start of a response to tell a text manifest from a container. */
+    private static final int SNIFF_BYTES = 8;
+
+    /**
+     * Whether a response that begins with these bytes is text rather than a media container: '#' opens an
+     * HLS playlist (#EXTM3U), '<' a DASH or SmoothStreaming manifest and an HTML error page with it, after
+     * a UTF-8 BOM and any leading whitespace. No container this cache is for starts with either — Matroska
+     * opens 1A 45 DF A3, MPEG-TS 0x47, MP4 carries "ftyp" at offset four, AVI "RIFF".
+     *
+     * <p>Sniffed from the bytes rather than decided from the URL because the URL is exactly what does not
+     * say. A launcher that sends video/* for everything over a link with no telling extension — Lampa does
+     * both — leaves a live HLS stream looking progressive until its first response arrives, and the wrong
+     * guess here is the worst one there is: a live playlist lists only its current window, so a copy kept
+     * on disk and served back on every reload stops playback at the end of that window for good, with the
+     * player waiting for a playlist that can no longer change.
+     */
+    private static boolean isTextManifest(final byte[] head, final int length) {
+        int i = 0;
+        if (length >= 3 && (head[0] & 0xFF) == 0xEF && (head[1] & 0xFF) == 0xBB && (head[2] & 0xFF) == 0xBF) {
+            i = 3; // UTF-8 BOM, which both kinds of manifest are allowed to carry
+        }
+        while (i < length && (head[i] == ' ' || head[i] == '\n'
+                || head[i] == '\r' || head[i] == '\t')) {
+            i++;
+        }
+        return i < length && (head[i] == '#' || head[i] == '<');
+    }
+
     /**
      * Writes through to the real cache sink until the byte cap for this open is reached, then swallows
      * the rest. Swallowing rather than failing: the write is the cache's business, not the playback's,
      * and {@link CacheDataSink} commits the part it did receive when it is closed.
+     *
+     * <p>A response that turns out to be a manifest is refused whole (see {@link #isTextManifest}), which
+     * is why the sink below it is opened lazily: nothing must reach it before there are enough bytes to
+     * judge, and a refused response must leave no file behind at all.
      */
     private static final class HeadSink implements DataSink {
 
         private final DataSink delegate;
         private long written;
+        /** The spec of an open the delegate has not been given yet; null once it has, or after close. */
+        private DataSpec pendingOpen;
+        /** The first bytes of this open, held back until there are SNIFF_BYTES of them to judge. */
+        private final byte[] head = new byte[SNIFF_BYTES];
+        private int headLength;
+        private boolean judged;
+        private boolean refused;
 
         HeadSink(final SimpleCache cache) {
             delegate = new CacheDataSink(cache, PER_OPEN_BYTES);
         }
 
         @Override
-        public void open(final DataSpec dataSpec) throws IOException {
+        public void open(final DataSpec dataSpec) {
             written = 0;
-            delegate.open(dataSpec);
+            headLength = 0;
+            // Only a read from the start of a resource can be a whole manifest, and only there do the
+            // first bytes mean what isTextManifest reads them as. Mid-file bytes are judged by nobody.
+            judged = dataSpec.position != 0;
+            refused = false;
+            pendingOpen = dataSpec;
         }
 
         @Override
         public void write(final byte[] buffer, final int offset, final int length) throws IOException {
-            if (written >= PER_OPEN_BYTES) {
+            if (refused || written >= PER_OPEN_BYTES) {
                 return;
             }
+            if (!judged) {
+                final int take = Math.min(length, SNIFF_BYTES - headLength);
+                System.arraycopy(buffer, offset, head, headLength, take);
+                headLength += take;
+                if (headLength < SNIFF_BYTES) {
+                    return; // not enough to tell yet; close() flushes what there is
+                }
+                judged = true;
+                refused = isTextManifest(head, headLength);
+                if (refused) {
+                    return;
+                }
+                writeThrough(head, 0, headLength);
+                headLength = 0;
+                if (take == length) {
+                    return;
+                }
+                writeThrough(buffer, offset + take, length - take);
+                return;
+            }
+            writeThrough(buffer, offset, length);
+        }
+
+        private void writeThrough(final byte[] buffer, final int offset, final int length)
+                throws IOException {
             final int allowed = (int) Math.min(length, PER_OPEN_BYTES - written);
+            if (allowed <= 0) {
+                return;
+            }
+            if (pendingOpen != null) {
+                delegate.open(pendingOpen);
+                pendingOpen = null;
+            }
             delegate.write(buffer, offset, allowed);
             written += allowed;
         }
 
         @Override
         public void close() throws IOException {
+            // A response too short to judge is too short to be a container head worth keeping either, but
+            // it is written rather than dropped: it is also what a bounded read of a few bytes looks like.
+            if (!judged && headLength > 0) {
+                judged = true;
+                writeThrough(head, 0, headLength);
+                headLength = 0;
+            }
+            if (pendingOpen != null) {
+                pendingOpen = null; // nothing was ever written, so there is nothing to close
+                return;
+            }
             delegate.close();
         }
     }

--- a/app/src/main/java/com/brouken/player/PlayerActivity.java
+++ b/app/src/main/java/com/brouken/player/PlayerActivity.java
@@ -229,6 +229,11 @@ public class PlayerActivity extends Activity {
     // whose request URL had no telling extension. Keyed by the requested URI (== MediaItem URI).
     // Written from a load thread, read on the player thread — hence concurrent.
     private final java.util.Map<String, String> resolvedMediaTypes = new java.util.concurrent.ConcurrentHashMap<>();
+    // The source factory of the live player, and the same data source chain without MediaCache in it —
+    // null when the chain never had it. Both only so dropMediaCache() can correct the chain of a player
+    // that is already built.
+    private DefaultMediaSourceFactory mediaSourceFactory;
+    private androidx.media3.datasource.DataSource.Factory uncachedUpstream;
     // Byte length of each media item as its data source reported it, keyed the same way. Feeds the
     // stats panel's average bitrate for the containers that state no bitrate at all.
     private final java.util.Map<String, Long> contentLengths = new java.util.concurrent.ConcurrentHashMap<>();
@@ -575,6 +580,12 @@ public class PlayerActivity extends Activity {
     private TextView videoInfoView;
     private TextView audioInfoView;
     private TextView endsAtView;
+    // Longest window still read as a live broadcast rather than a recording — see isLiveStream().
+    private static final long LIVE_WINDOW_MAX_MS = 10 * 60_000L;
+    // The end time is a qualifier beside the clock, so it is written a step down from white. The live
+    // label takes the brand colour instead: it is a state, not a reading, and the only one this row ever
+    // reports — see updateEndsAt.
+    private static final int ENDS_AT_COLOR = 0xB3FFFFFF;
     private TextView roomPill;
     private TextView statsView;
     private OutlineTextClock overlayClock;
@@ -979,6 +990,9 @@ public class PlayerActivity extends Activity {
     DisplayManager displayManager;
     DisplayManager.DisplayListener displayListener;
     SubtitleFinder subtitleFinder;
+    // The media whose neighbouring subtitle names are still to be guessed, or null when there is nothing
+    // waiting. Set while the intent is read, spent on the first track change — see startSubtitleGuess().
+    private Uri pendingSubtitleGuessUri;
 
     Runnable barsHider = () -> {
         if (playerView != null && !controllerVisible) {
@@ -1554,7 +1568,7 @@ public class PlayerActivity extends Activity {
         timeRow.setLayoutParams(timeRowLp);
 
         endsAtView = new TextView(this);
-        endsAtView.setTextColor(0xB3FFFFFF);
+        endsAtView.setTextColor(ENDS_AT_COLOR);
         // A step below the clock: the clock is the anchor, the end time is the qualifier next to it.
         endsAtView.setTextSize(TypedValue.COMPLEX_UNIT_SP, ui.textEndsAt());
         endsAtView.setVisibility(View.GONE);
@@ -5006,12 +5020,43 @@ public class PlayerActivity extends Activity {
         return language;
     }
 
+    /**
+     * Whether what is playing is a broadcast rather than a recording. Media3's own flag cannot be taken
+     * on its own: {@code isCurrentMediaItemLive()} is true for any HLS playlist without an
+     * {@code #EXT-X-ENDLIST}, and the proxy and torrent remuxes this app plays are served exactly like
+     * that (the same trap {@link #recoverFromSourceError} documents), so it says yes to ordinary films
+     * too. What separates them is the window: a broadcast offers the few segments it has to hand — 24 s
+     * on the stream this was written for — while a remux offers the whole film. Ten minutes sits well
+     * above any live window and well below any feature; a genuinely short recording served without an
+     * end tag is the one thing this reads wrongly, and all it costs there is a label.
+     */
+    private boolean isLiveStream() {
+        if (player == null || !player.isCurrentMediaItemLive()) {
+            return false;
+        }
+        final long duration = player.getDuration();
+        return duration == C.TIME_UNSET || duration < LIVE_WINDOW_MAX_MS;
+    }
+
     void updateEndsAt() {
         if (player == null || endsAtView == null) {
             return;
         }
+        if (!controllerVisible) {
+            endsAtView.setVisibility(View.GONE);
+            return;
+        }
+        // A broadcast has no end to name. The clock time computed below would be the end of whatever
+        // window the stream is offering right now — a minute from now, and about nothing.
+        if (isLiveStream()) {
+            endsAtView.setText(R.string.time_live);
+            endsAtView.setTextColor(brandColor());
+            endsAtView.setVisibility(View.VISIBLE);
+            return;
+        }
+        endsAtView.setTextColor(ENDS_AT_COLOR);
         final long duration = player.getDuration();
-        if (!controllerVisible || duration == C.TIME_UNSET || duration <= 0) {
+        if (duration == C.TIME_UNSET || duration <= 0) {
             endsAtView.setVisibility(View.GONE);
             return;
         }
@@ -6555,6 +6600,15 @@ public class PlayerActivity extends Activity {
         // read. Searching then asks the internet for subtitles the file is about to expose by itself.
         if (player == null || tracks.getGroups().isEmpty()
                 || player.getPlaybackState() == Player.STATE_IDLE) {
+            return;
+        }
+        // Nothing to look for over a broadcast: there is no release to match, and an id arriving with a
+        // channel says nothing about what is on air — Lampa fills imdb_id/id from whatever card its
+        // screen was showing (getCardFromActivity), so a channel opened from a series page arrives
+        // labelled as that series and would be given its subtitles. Asked for by name it still runs:
+        // somebody typing a title is saying they know better than this.
+        if (!manual && isLiveStream()) {
+            Utils.log("subtitles: live stream, not searching");
             return;
         }
         // With the search switched off this still runs, and stops at the cache: a copy downloaded for
@@ -10228,6 +10282,7 @@ public class PlayerActivity extends Activity {
         // launch-intent HTTP headers/User-Agent, then wrap it so we can tap the byte stream and
         // read rich track names straight from the container (see TrackNameParsingDataSource).
         androidx.media3.datasource.DataSource.Factory upstreamFactory = new DefaultDataSource.Factory(this);
+        uncachedUpstream = null;
 
         if (haveMedia && isNetworkUri && mPrefs.mediaUri.getScheme().toLowerCase().startsWith("http")) {
             HashMap<String, String> headers = new HashMap<>();
@@ -10300,13 +10355,21 @@ public class PlayerActivity extends Activity {
             final String mediaMime = mPrefs.mediaType != null
                     ? mPrefs.mediaType : resolvedMediaTypes.get(mPrefs.mediaUri.toString());
             // Either signal is enough. A .m3u8 carrying a video/* mime is still HLS — that mime only
-            // sends it down the progressive path first, where it fails and is recovered as HLS
-            // (recoverFromContainerError) without this factory being rebuilt.
+            // sends it down the progressive path first, where it fails and is recovered as HLS.
             final boolean adaptive =
                     Util.inferContentType(mPrefs.mediaUri) != C.CONTENT_TYPE_OTHER
                             || Util.inferContentTypeForUriAndMimeType(mPrefs.mediaUri, mediaMime)
                                     != C.CONTENT_TYPE_OTHER;
+            // Whatever was cached for other media is of no use to anyone now, and nothing in that cache
+            // expires on its own — see MediaCache.keepOnly. Also for an adaptive stream, which keeps
+            // nothing itself but is just as good a moment to sweep.
+            MediaCache.keepOnly(this, mPrefs.mediaUri.toString());
             upstreamFactory = adaptive ? rangeSeeded : MediaCache.wrap(this, rangeSeeded);
+            // Neither signal has to be there at all: a launcher that sends video/* for everything (Lampa
+            // does) over a URL with no telling extension leaves a live HLS stream looking progressive
+            // until its first response arrives, and only recoverFromContainerError finds out otherwise.
+            // Kept so that recovery can take the cache back out — see dropMediaCache().
+            uncachedUpstream = adaptive ? null : rangeSeeded;
         }
 
         final androidx.media3.datasource.DataSource.Factory dataSourceFactory = new TrackNameParsingDataSource.Factory(upstreamFactory, trackNameListener);
@@ -10317,9 +10380,9 @@ public class PlayerActivity extends Activity {
         // Dolby Vision decoder altogether.
         final boolean convertDV7 = !mPrefs.mapDV7ToHevc && !forceHevcForDolbyVision;
         dv7Converter = convertDV7 ? new Dv7Converter(extractorsFactory, subtitleParserFactory) : null;
-        playerBuilder.setMediaSourceFactory(
-                new DefaultMediaSourceFactory(this, convertDV7 ? dv7Converter : extractorsFactory)
-                        .setDataSourceFactory(dataSourceFactory));
+        mediaSourceFactory = new DefaultMediaSourceFactory(this, convertDV7 ? dv7Converter : extractorsFactory)
+                .setDataSourceFactory(dataSourceFactory);
+        playerBuilder.setMediaSourceFactory(mediaSourceFactory);
         // Bounded by time rather than by bytes, for streams only. On the defaults the byte budget binds
         // first on anything high-bitrate — 144 MB is about 21 s of a 53 Mbps remux, well short of the 50 s
         // window — so the loader sits on that ceiling and is switched on and off around it about eleven
@@ -11152,6 +11215,10 @@ public class PlayerActivity extends Activity {
             // A file the second line wants may have arrived with this very change — the search attaches
             // one as a track. Before the search, so a file already here is used instead of fetched.
             autoFillSecondarySubtitle();
+            // Both searches wait for this moment, and the cheap one goes first: a file lying next to the
+            // media costs one request and no quota, and finding it can leave the online search with
+            // nothing to look for.
+            startSubtitleGuess();
             // The track list is what decides whether anything is missing, so this is the first moment
             // the question can be asked at all.
             maybeSearchSubtitlesOnline(tracks);
@@ -11718,6 +11785,7 @@ public class PlayerActivity extends Activity {
             return false;
         }
 
+        dropMediaCache();
         final long position = player.getCurrentPosition();
         final List<MediaItem> items = new ArrayList<>(count);
         for (int i = 0; i < count; i++) {
@@ -11732,6 +11800,27 @@ public class PlayerActivity extends Activity {
         // recovery override every reason not to: the pause of a room holding for somebody who has just
         // joined, and the viewer's own pause during a load.
         return true;
+    }
+
+    /**
+     * Takes the disk cache back out of the data source chain of a player that is already built, for a
+     * stream that has just turned out to be a manifest after all. The cache is chosen from the URL, and
+     * a URL that says nothing chooses it wrongly: every segment of an adaptive stream would then have its
+     * first megabyte written to the box's flash for nothing — segments are read once and never re-read —
+     * and a channel left running would evict the container heads the cache exists for, over and over.
+     * (Keeping a live playlist, the far worse half of that mistake, MediaCache now refuses on its own.)
+     *
+     * <p>Correcting the factory in place rather than rebuilding the player, because the caller re-prepares
+     * on the same instance: setDataSourceFactory drops the sources DefaultMediaSourceFactory has already
+     * made, so the next setMediaItems builds them through the new chain.
+     */
+    private void dropMediaCache() {
+        if (uncachedUpstream == null || mediaSourceFactory == null) {
+            return;
+        }
+        mediaSourceFactory.setDataSourceFactory(
+                new TrackNameParsingDataSource.Factory(uncachedUpstream, trackNameListener));
+        uncachedUpstream = null;
     }
 
     // Re-read after a source error on network media. A streaming server can hand back bytes that are not
@@ -13206,11 +13295,9 @@ public class PlayerActivity extends Activity {
             return;
 
         if (Utils.isSupportedNetworkUri(mPrefs.mediaUri) && Utils.isProgressiveContainerUri(mPrefs.mediaUri)) {
-            SubtitleUtils.clearCache(this);
-            if (SubtitleFinder.isUriCompatible(mPrefs.mediaUri)) {
-                subtitleFinder = new SubtitleFinder(PlayerActivity.this, mPrefs.mediaUri);
-                subtitleFinder.start();
-            }
+            // Armed rather than fired: this runs while the intent is being read, when there is no player
+            // to ask what the URL actually leads to. See startSubtitleGuess().
+            pendingSubtitleGuessUri = mPrefs.mediaUri;
             return;
         }
 
@@ -13251,6 +13338,37 @@ public class PlayerActivity extends Activity {
                 }
             }
         }
+    }
+
+    /**
+     * The volley of guessed sidecar names armed by {@link #searchSubtitles()}, now that the player can say
+     * what it is playing. Deferred to here for one reason: a broadcast has no file to sit next to, and an
+     * IPTV endpoint whose path ends in .ts looks exactly like a file to the URL test that arms this — so
+     * the guesses used to go out anyway, twenty misses per opened channel that the provider still pays
+     * for. The same argument SubtitleFinder.isStreamEndpoint already makes for torrent backends, applied
+     * to the one case only the timeline can name.
+     *
+     * <p>Once per opened item, whatever the outcome: the trigger fires on every track change.
+     */
+    private void startSubtitleGuess() {
+        final Uri uri = pendingSubtitleGuessUri;
+        if (uri == null || player == null) {
+            return;
+        }
+        pendingSubtitleGuessUri = null;
+        // The janitor runs for every network media opened, as it did when this was the first thing the
+        // branch did: it clears the temporary files of earlier downloads, which is nobody's business but
+        // its own, and the guesses below may well not happen at all.
+        SubtitleUtils.clearCache(this);
+        if (isLiveStream()) {
+            Utils.log("subtitles: live stream, not guessing sidecar names");
+            return;
+        }
+        if (!SubtitleFinder.isUriCompatible(uri)) {
+            return;
+        }
+        subtitleFinder = new SubtitleFinder(PlayerActivity.this, uri);
+        subtitleFinder.start();
     }
 
     Uri findNext() {

--- a/app/src/main/java/com/brouken/player/SubtitleSearch.java
+++ b/app/src/main/java/com/brouken/player/SubtitleSearch.java
@@ -104,12 +104,24 @@ final class SubtitleSearch {
          * here means "not known to be", not "human".
          */
         final boolean machine;
+        /**
+         * OpenSubtitles' file id, or 0 when {@link #urls} is already the whole answer. That index hands
+         * out a download link rather than a URL, and asking for one is the metered call — one of the
+         * hundred a day, spent even when it fails. So this source alone answers with an id, and
+         * {@link #delivered} turns it into a link at the moment the file is about to be taken.
+         */
+        final long fileId;
 
         Result(String source, String language, List<String> urls, boolean machine) {
+            this(source, language, urls, machine, 0L);
+        }
+
+        Result(String source, String language, List<String> urls, boolean machine, long fileId) {
             this.source = source;
             this.language = language;
             this.urls = urls;
             this.machine = machine;
+            this.fileId = fileId;
         }
     }
 
@@ -432,7 +444,19 @@ final class SubtitleSearch {
         if (result == null || cancelled()) {
             return false;
         }
-        if (sink.accept(result)) {
+        Result taken = result;
+        if (result.fileId != 0) {
+            // The metered call, and the only place it is made: this result is the one about to be used.
+            final String link = OpenSubtitles.link(result.fileId);
+            if (link == null) {
+                Utils.log("subtitles: " + result.source + " picked " + result.language
+                        + " but the download link was refused");
+                return false;
+            }
+            taken = new Result(result.source, result.language,
+                    Collections.singletonList(link), result.machine);
+        }
+        if (sink.accept(taken)) {
             return true;
         }
         Utils.log("subtitles: " + result.source + " listed but would not download");
@@ -501,16 +525,14 @@ final class SubtitleSearch {
                     + " file(s), none taken" + (allowMachine ? "" : " (machine translations refused)"));
             return null;
         }
-        final String link = OpenSubtitles.link(best.fileId);
-        if (link == null) {
-            Utils.log("subtitles: " + SOURCE_OPENSUBTITLES + " picked " + best.language
-                    + " but the download link was refused");
-            return null;
-        }
         Utils.log("subtitles: " + SOURCE_OPENSUBTITLES + " has 1 " + best.language
                 + (best.machine ? " machine-translated" : "") + " of " + found.size());
+        // The id, not a link: see Result.fileId. Every other source is asked and answered for free, and
+        // this one used to spend a download here, inside the parallel sweep — so a search that stremio
+        // or shegu.st went on to win still cost one of the hundred, as did a hit in a language that was
+        // held back and never taken.
         return new Result(SOURCE_OPENSUBTITLES, Utils.toIso3Language(best.language),
-                Collections.singletonList(link), best.machine);
+                Collections.<String>emptyList(), best.machine, best.fileId);
     }
 
     /**

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -156,6 +156,7 @@
     <string name="pref_crash_reporting_off">Данные о сбоях и ошибках не покидают устройство</string>
     <string name="time_ends_at">Закончится в %s</string>
     <string name="time_ends_at_inline">до %1$s</string>
+    <string name="time_live">● ЭФИР</string>
     <string name="playlist">Плейлист</string>
     <string name="shortcut_videos">Видео</string>
     <string name="button_open">Открыть</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -157,6 +157,7 @@
     <string name="pref_crash_reporting_off">Дані про збої та помилки не залишають пристрій</string>
     <string name="time_ends_at">Закінчиться о %s</string>
     <string name="time_ends_at_inline">до %1$s</string>
+    <string name="time_live">● ЕФІР</string>
     <string name="playlist">Список відтворення</string>
     <string name="pref_map_dv7">Резервний варіант Dolby Vision profile 7</string>
     <string name="pref_map_dv7_on">Відтворення контенту Dolby Vision profile 7 на дисплеях HDR</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -179,6 +179,7 @@
     <string name="update_stops_playback">The player will close to install — your position is saved.</string>
     <string name="time_ends_at">Ends at %s</string>
     <string name="time_ends_at_inline">until %1$s</string>
+    <string name="time_live">● LIVE</string>
     <string name="playlist">Playlist</string>
     <string name="pref_map_dv7">Dolby Vision profile 7 fallback</string>
     <string name="pref_map_dv7_on">Play Dolby Vision profile 7 content on HDR displays</string>


### PR DESCRIPTION
A live IPTV channel started from Lampa stopped after a few seconds, the same way a live m3u8 did before the disk cache was kept away from manifests — the cache was in front of the playlist again, because that choice is made from the URL and this URL says nothing (no telling extension, and `video/*` from the launcher for everything).

- **The cache can no longer keep a manifest.** Its sink holds back the first bytes of a response read from the start and refuses anything opening with `#` or `<`; the sink below is opened lazily, so a refused response leaves no file at all.
- **The recovery takes the cache out of the chain** once the stream is known to be adaptive, so a channel does not write a megabyte of every segment to flash.
- **The cache has a lifetime now.** Nothing in it expired — no TTL, no HTTP freshness, and reading a span refreshes its LRU place — so an entry lived until the next app update. Everything cached for other media is dropped as the player is built for this one.
- **`LIVE` in the brand colour** replaces "until HH:MM" for a broadcast. `isCurrentMediaItemLive()` alone will not do (true for any HLS without `EXT-X-ENDLIST`, remuxes of films included), so a short window is required as well.
- **Neither subtitle search runs for a broadcast.** The online one because a launcher's id belongs to the card its screen was showing, not to what is on air; the name guessing because an IPTV path ending in `.ts` looks like a file and cost the provider twenty misses per channel. Guessing moved from intent-reading time to the first track change, where the answer is known. A search asked for by name still runs.
- **OpenSubtitles' metered call** is made only for the file actually taken, not inside the parallel sweep — a search another source won no longer spends one of the hundred a day.

Checked against the reported channel from Lampa on the phone: the row reads LIVE and the trace shows both searches standing down, while a series in the same session searches and is given its subtitles as before.