### PR TITLE
Keep the remote inside the empty state's own buttons

### DIFF
--- a/app/src/main/java/com/brouken/player/EmptyState.java
+++ b/app/src/main/java/com/brouken/player/EmptyState.java
@@ -125,6 +125,14 @@ class EmptyState {
                     .setTextSize(TypedValue.COMPLEX_UNIT_SP, ui.sp(15));
         }
 
+        // The controls are still up behind this page: showController() is what keeps the system bars
+        // with them (see the controller visibility listener), and this page is laid out around those
+        // bars. A covered view is still a focusable one, though, so a remote walking down this column
+        // carried on into the control bar's icons and clicked on things nobody could see. Fenced off
+        // rather than hidden, so the bars stay where they are. Before the early return below, because
+        // a page that comes back already visible needs the fence just as much.
+        activity.playerView.setDescendantFocusability(ViewGroup.FOCUS_BLOCK_DESCENDANTS);
+
         final boolean wasVisible = overlay.getVisibility() == View.VISIBLE;
         overlay.setVisibility(View.VISIBLE);
         if (!wasVisible) {
@@ -191,6 +199,9 @@ class EmptyState {
     }
 
     void hide() {
+        // The controls own the remote again. FOCUS_AFTER_DESCENDANTS is the value PlayerView sets on
+        // itself, so this puts back what was there rather than a guess at it.
+        activity.playerView.setDescendantFocusability(ViewGroup.FOCUS_AFTER_DESCENDANTS);
         // Media is taking the screen, so the preferences apply again — including after an empty state
         // relaxed them. No video format yet, so VIDEO lands on landscape and STATE_READY corrects it.
         Utils.setOrientation(activity, activity.mPrefs.orientation);


### PR DESCRIPTION
A viewer on a TV box heard two more focus stops below Settings, with nothing on screen to land on.

The controls are still up behind the branded empty state: the page is drawn over them, and `showController()` is what keeps the system bars showing while it is — the bars the page lays itself out around. A covered view is still a focusable one, so the remote walked out of the column into the control bar. On the 720p TV emulator that is the time bar (y=850) and the gear (y=936), both below the Settings button's own 898.

Fenced rather than hidden, so nothing about the bars or the controls changes:

- `EmptyState.show()` sets the player view to `FOCUS_BLOCK_DESCENDANTS`, before the early return for a page that comes back already visible and before the call to action takes focus;
- `EmptyState.hide()` restores `FOCUS_AFTER_DESCENDANTS` — the value `PlayerView` sets on itself in its constructor.

The page's own buttons are siblings of the player view, so they are untouched.

Verified on the TV emulator both ways: before, the fourth press of Down landed on an `ImageButton` in the hidden control bar; now it leaves focus on Settings, and opening media in the same session hands the controls their focus back.