### PR TITLE
Hold a joining player for the room when no display mode changes

### DIFF
--- a/app/src/main/java/com/brouken/player/PlayerActivity.java
+++ b/app/src/main/java/com/brouken/player/PlayerActivity.java
@@ -707,8 +707,9 @@ public class PlayerActivity extends Activity {
     private boolean restoreOrientationLock;
     private boolean restorePlayState;
     private boolean restorePlayStateAllowed;
-    // "Start playing once the player is ready". Read live by Utils.playIfCan, whose frame-rate probe runs on
-    // a background thread: a snapshot taken before it started would still play after onStop cleared this.
+    // "Start playing once the player is ready". Read live by frameRateSettled, which Utils.handleFrameRate
+    // can reach from a frame-rate probe running on a background thread: a snapshot taken before it started
+    // would still play after onStop cleared this.
     boolean play;
     private float subtitlesScale;
     private float secondarySubtitlesScale;
@@ -10614,8 +10615,14 @@ public class PlayerActivity extends Activity {
      * Nothing more to wait for from the display: disarm the listener armed for a mode change and spend
      * the play the loading player is holding. Every path that does not request a new mode ends here, the
      * ones that give up early included — those used to leave the play pending for good.
+     *
+     * <p>Including the one inside {@link Utils#handleFrameRate}, which decided no mode change was needed.
+     * That used to spend the play itself, and its own version of this did not consult the room: a client
+     * joining a room that was standing still played straight through the hold, and was dragged back when
+     * it lifted. Reached whenever the display cannot offer a better mode than the one it is on — a single
+     * mode, which is an emulator and a box with a fixed output, or a phone already at its top rate.
      */
-    private void frameRateSettled() {
+    void frameRateSettled() {
         playerView.removeCallbacks(frameRateGiveUpRunnable);
         if (displayManager != null && displayListener != null) {
             displayManager.unregisterDisplayListener(displayListener);

--- a/app/src/main/java/com/brouken/player/Utils.java
+++ b/app/src/main/java/com/brouken/player/Utils.java
@@ -777,7 +777,7 @@ class Utils {
         activity.runOnUiThread(() -> {
             boolean switchingModes = false;
 
-            // A detached decor view answers null. Falling through to playIfCan rather than returning:
+            // A detached decor view answers null. Falling through to the settled path rather than returning:
             // the caller has already told the player a switch is pending, so bailing out here left the
             // file on its first frame with no spinner and no error. Unreachable until the rate started
             // coming from Format — before that a stream had no rate at all and never entered this block.
@@ -845,25 +845,11 @@ class Utils {
             }
 
             if (!switchingModes) {
-                playIfCan(activity);
+                activity.frameRateSettled();
             }
         });
     }
 
-    // Reads activity.play now rather than a value captured before the frame-rate probe ran: that probe takes
-    // seconds on a network file, and the user may have left in the meantime (onStop clears it).
-    static void playIfCan(final PlayerActivity activity) {
-        if (activity.play) {
-            // Spending it, so mark it spent: the caller waiting for a display mode uses this flag to tell
-            // "playback has not started" from "it started without a mode change", and left set it would
-            // let a later display event start playback a second time, on its own.
-            activity.play = false;
-            if (PlayerActivity.player != null)
-                PlayerActivity.player.play();
-            if (activity.playerView != null)
-                activity.playerView.hideController();
-        }
-    }
 
     public static boolean alternativeChooser(PlayerActivity activity, Uri initialUri, boolean video) {
         String startPath;


### PR DESCRIPTION
`Utils.handleFrameRate` spends the pending play itself once it decides no mode change is needed, through a `playIfCan` of its own that never asked whether the room was holding. A client joining a room that stands still to let everybody fill a buffer therefore played straight through that hold, and had what it played taken back when the hold lifted.

The path is not an exotic one: it is taken whenever the display cannot offer a better mode than the one it is already on — a single-mode display (a box with a fixed output, and any emulator) or a phone already at its top refresh rate. A phone that can still step up takes the other branch, which is why this went unnoticed.

Both branches now end in `frameRateSettled`, which was already the one that asks the room, and which also disarms the give-up timer and unregisters the display listener that the other path left to expire on its own. `playIfCan` is gone.

## Reproduced

Owner paused in a room, member joining with frame rate matching on, on a single-mode display.

| | before | after |
|---|---|---|
| Picture while `Paused — waiting for everyone to buffer` is up | advances | frozen |
| `Dropped frames` over the hold | 0 → 36 | 0 |
| Transport button | hidden, playing | play, standing |
| After `Everyone is ready — carrying on` | falls back to paused, position pulled back | already paused, nothing pulled back |

Buffer fills normally either way (0% → 92% over the hold), so the wait itself is unaffected.