### PR TITLE
Say where a remote seek lands, and show the bar while it happens

### DIFF
--- a/app/src/main/java/com/brouken/player/CustomPlayerView.java
+++ b/app/src/main/java/com/brouken/player/CustomPlayerView.java
@@ -99,7 +99,35 @@ public class CustomPlayerView extends PlayerView implements GestureDetector.OnGe
         setCustomErrorMessage(null);
         clearIcon();
         keySeekStart = -1;
+        // The readout going is the end of the seek as far as the screen is concerned, and the bar the
+        // key path raised has no gesture to end it — this is its ACTION_UP.
+        hideSeekProgress();
     };
+
+    /**
+     * Raise the progress bar for the duration of a seek, so the position is visible and the readout only
+     * has to carry the delta. Not when the controls are already up: they are the user's then, not ours.
+     */
+    public void showSeekProgress() {
+        if (!isControllerFullyVisible()) {
+            seekProgress = true;
+            showProgress();
+        }
+    }
+
+    /**
+     * Take the bar down again — but only if it is still ours. A seek can outlast the press that started
+     * it, and in that second the user may open the controls; shutting them under the hand that opened
+     * them is worse than leaving a bar up to time out.
+     */
+    private void hideSeekProgress() {
+        if (seekProgress) {
+            seekProgress = false;
+            if (!isControllerFullyVisible()) {
+                hideControllerImmediately();
+            }
+        }
+    }
 
     private final AudioManager mAudioManager;
     private BrightnessControl brightnessControl;
@@ -193,10 +221,7 @@ public class CustomPlayerView extends PlayerView implements GestureDetector.OnGe
 
                     setControllerAutoShow(true);
 
-                    if (seekProgress) {
-                        seekProgress = false;
-                        hideControllerImmediately();
-                    }
+                    hideSeekProgress();
                     break;
                 }
         }
@@ -325,10 +350,7 @@ public class CustomPlayerView extends PlayerView implements GestureDetector.OnGe
                     seekChange = 0L;
                     seekMax = PlayerActivity.player.getDuration();
 
-                    if (!isControllerFullyVisible()) {
-                        seekProgress = true;
-                        showProgress();
-                    }
+                    showSeekProgress();
                 }
 
                 gestureOrientation = Orientation.HORIZONTAL;
@@ -466,10 +488,7 @@ public class CustomPlayerView extends PlayerView implements GestureDetector.OnGe
         PlayerActivity.player.setSeekParameters(SeekParameters.PREVIOUS_SYNC);
         rewindPosition = PlayerActivity.player.getCurrentPosition();
         rewindLastTime = SystemClock.uptimeMillis();
-        if (!isControllerFullyVisible()) {
-            seekProgress = true;
-            showProgress();
-        }
+        showSeekProgress();
         post(rewindRunnable);
     }
 

--- a/app/src/main/java/com/brouken/player/PlayerActivity.java
+++ b/app/src/main/java/com/brouken/player/PlayerActivity.java
@@ -3061,6 +3061,9 @@ public class PlayerActivity extends Activity {
         if (player == null)
             return false;
         playerView.removeCallbacks(playerView.textClearRunnable);
+        // The bar the touch gestures raise is what lets their readout carry only the delta; the one path
+        // where the readout is all there is got the least of it.
+        playerView.showSeekProgress();
         final long pos = player.getCurrentPosition();
         if (playerView.keySeekStart == -1) {
             playerView.keySeekStart = pos;
@@ -3101,8 +3104,17 @@ public class PlayerActivity extends Activity {
     }
 
     private void showKeySeekMessage(long target) {
+        // The offset answers "how far", not "where in the film" — and against a duration that is not on
+        // screen at that moment, an absolute time is a division done in the head. Checked here rather
+        // than at the call site: the live and unknown-duration branch reaches this too, and there is
+        // nothing to divide by there.
+        final long duration = player != null ? player.getDuration() : C.TIME_UNSET;
+        final StringBuilder position = new StringBuilder(Utils.formatMilis(target));
+        if (duration > 0) {
+            position.append(" · ").append(Math.round(target * 100f / duration)).append('%');
+        }
         playerView.setCustomErrorMessage(Utils.formatMilisSign(target - playerView.keySeekStart)
-                + "\n" + Utils.formatMilis(target));
+                + "\n" + position);
     }
 
     private void commitKeyScrub() {


### PR DESCRIPTION
Closes #127.

Seeking with the remote put a signed offset and an absolute time over the picture. Both answer "how far"; neither answers "where in the film", and the duration to divide against is not on screen at that moment.

Touch seeking never had the problem, and not because of its text: dragging across the picture raises the progress bar for the length of the gesture, so the position is there at a glance. The same seek from the D-pad raised nothing — the one path where the readout is all there is got the least of it.

So both halves, and they are the same fix from two sides:

- the absolute time gains a percentage when the duration is known, checked inside the method because the live and unknown-duration branch reaches it too;
- the bar comes up for a key seek the way it already does for the two touch gestures, whose own copies of that are now folded into the method that does it.

Its teardown carries a guard the touch path did not need: a key seek outlasts the press that started it by a second, and in that second the viewer may open the controls themselves. Shutting them under the hand that opened them is worse than leaving a bar up to time out.

The percentage is not made redundant by the bar. A seek is committed half a second after the last press, so during an accelerating scrub the bar still stands at the old position while the text already names the target.

## Checked on a TV emulator

| | |
|---|---|
| One press of Right | `+00:10` / `01:00 · 2%`, bar up |
| Two seconds later | text and bar gone |
| OK pressed during a seek | controls stay up |
| Eight presses | `+05:10` / `07:50 · 15%`, step accelerates |