### PR TITLE
Move the frame rate into the header, and name what became of a Dolby Vision track

### DIFF
--- a/app/src/main/java/com/brouken/player/Dv7Converter.java
+++ b/app/src/main/java/com/brouken/player/Dv7Converter.java
@@ -88,6 +88,14 @@ final class Dv7Converter extends ForwardingExtractorsFactory {
     @Nullable
     private volatile String status;
 
+    /**
+     * The same verdict in the stats panel's words, written wherever {@link #status} is. Kept apart rather
+     * than shortened on read: the dump's phrasing is a sentence and the panel's lines are held short
+     * enough never to wrap, and deriving one from the other would mean parsing prose.
+     */
+    @Nullable
+    private volatile String shortStatus;
+
     /** Cached answer to "does this device list a profile 8 decoder"; see deviceListsProfile8(). */
     @Nullable
     private static volatile Boolean profile8Listed;
@@ -108,6 +116,12 @@ final class Dv7Converter extends ForwardingExtractorsFactory {
     @Nullable
     String status() {
         return status;
+    }
+
+    /** The same, for the stats panel; null until a track decides. */
+    @Nullable
+    String shortStatus() {
+        return shortStatus;
     }
 
     @Override
@@ -333,6 +347,7 @@ final class Dv7Converter extends ForwardingExtractorsFactory {
                         && (transformer = newTransformer()) != null;
                 if (isDolbyVisionProfile7(format) && !converting) {
                     owner.status = "profile 7, unchanged (no profile 8 decoder or no libdovi here)";
+                    owner.shortStatus = "DV 7 → HDR10 · no P8 decoder";
                 }
             }
             publishedFormat = format;
@@ -483,6 +498,7 @@ final class Dv7Converter extends ForwardingExtractorsFactory {
                 owner.status = "profile 7 → 8.1 ("
                         + (dualLayer ? "RPU from the enhancement layer" : "in-band RPU")
                         + (length > base ? ", enhancement layer dropped" : "") + ")";
+                owner.shortStatus = "DV 7 → 8.1 · " + (dualLayer ? "RPU from EL" : "in-band RPU");
             }
             ((Buffer) buffer).position(0);
             copyFrameOut(converted);
@@ -614,6 +630,9 @@ final class Dv7Converter extends ForwardingExtractorsFactory {
             runCount = 0;
             if (!codecsRewritten) {
                 owner.status = reason;
+                // Every reason to stop is one line in the panel: which frame it choked on is a question
+                // for the dump, and what the viewer sees is the same picture either way.
+                owner.shortStatus = "DV 7 → HDR10 · rewrite refused";
             }
         }
     }
@@ -658,7 +677,7 @@ final class Dv7Converter extends ForwardingExtractorsFactory {
         return supported;
     }
 
-    private static boolean isDolbyVisionProfile7(Format format) {
+    static boolean isDolbyVisionProfile7(Format format) {
         return MimeTypes.VIDEO_DOLBY_VISION.equals(format.sampleMimeType)
                 && format.codecs != null
                 && (format.codecs.startsWith("dvhe.07") || format.codecs.startsWith("dvh1.07"));

--- a/app/src/main/java/com/brouken/player/PlayerActivity.java
+++ b/app/src/main/java/com/brouken/player/PlayerActivity.java
@@ -4805,7 +4805,7 @@ public class PlayerActivity extends Activity {
             return;
         }
         final Format video = player.getVideoFormat();
-        setInfoLine(videoInfoView, buildVideoInfo(video));
+        setInfoLine(videoInfoView, buildVideoInfo(video, videoFrameRate()));
         setInfoLine(audioInfoView, buildAudioInfo(getSelectedAudioFormat()));
     }
 
@@ -4821,7 +4821,7 @@ public class PlayerActivity extends Activity {
         }
     }
 
-    private static String buildVideoInfo(Format video) {
+    private static String buildVideoInfo(Format video, float frameRate) {
         if (video == null) {
             return null;
         }
@@ -4829,6 +4829,12 @@ public class PlayerActivity extends Activity {
         appendField(b, resolutionClass(video.width, video.height));
         appendField(b, codecName(video));
         appendField(b, hdrName(video.colorInfo));
+        // Alongside its neighbours rather than in the stats panel: like them it is a property of the file
+        // and does not move during playback, and it is the one the frame-rate matching setting is about —
+        // which made it the only reason to open a panel over the picture.
+        if (frameRate > 0) {
+            appendField(b, String.format(Locale.US, "%.2f fps", frameRate));
+        }
         return b.toString();
     }
 
@@ -5193,6 +5199,12 @@ public class PlayerActivity extends Activity {
      * The stats panel's text. Deliberately only what the header does not already say — it is on screen at
      * the same time, and repeating "1080p H264" there would be noise. What is left is the figures that
      * move and the decoder names the coarse codec label hides.
+     *
+     * <p>Splitting the transfer figures (buffer, network, bitrate) out of here onto a line of their own,
+     * under a second switch, was tried and put back: everything they say is already on this panel, and
+     * the bottom bar has no band wide enough for them — the time is short, the button cluster is not, so
+     * a centred line is capped at twice the narrower side and loses the bitrate to an ellipsis on a TV.
+     * Worth revisiting only if the controls are laid out differently.
      */
     private void updateStats() {
         if (statsView == null) {
@@ -5215,12 +5227,6 @@ public class PlayerActivity extends Activity {
         final Format video = player.getVideoFormat();
         if (video != null) {
             text.append('\n').append(video.width).append('×').append(video.height);
-            // Media3 fills the rate in from MP4 only; for MKV and AVI it reads the container's own figure
-            // for its timing but never publishes it, so the parser we already run picks it up instead.
-            final float frameRate = videoFrameRate();
-            if (frameRate > 0) {
-                text.append(String.format(Locale.US, " · %.2f fps", frameRate));
-            }
             // Its own line rather than a third field: the panel has to stay narrower than the gap to the
             // centred transport buttons, and every line here is kept short enough to never wrap.
             if (video.bitrate != Format.NO_VALUE) {
@@ -5245,12 +5251,41 @@ public class PlayerActivity extends Activity {
         if (audioDecoderName != null) {
             text.append('\n').append(audioDecoderName);
         }
+        final String dolbyVision = dolbyVisionStatus();
+        if (dolbyVision != null) {
+            text.append('\n').append(dolbyVision);
+        }
         final DecoderCounters counters = player.getVideoDecoderCounters();
         if (counters != null) {
             text.append('\n').append(getString(R.string.stats_dropped, counters.droppedBufferCount));
         }
         statsView.setText(text);
         fadeChrome(statsView, true);
+    }
+
+
+    /**
+     * What became of a Dolby Vision track, for the stats panel — null when there is nothing to say, which
+     * is every SDR and ordinary HDR10 file. The header can only ever say "Dolby Vision": that is what the
+     * mime says whether the rewrite worked or not, so a file whose base layer is what actually reaches
+     * the panel is labelled the same as one that converted. This is the line that tells them apart, and
+     * on the two boxes this was chased across it was the only instrument that did.
+     */
+    @Nullable
+    private String dolbyVisionStatus() {
+        // Outranks the rest: if the recovery fired there was no conversion by definition, and the whole
+        // session past it is the base layer whatever the converter had decided before.
+        if (forceHevcForDolbyVision) {
+            return "DV → HDR10 · decoder failed";
+        }
+        if (dv7Converter != null) {
+            return dv7Converter.shortStatus();
+        }
+        // No converter built at all: the setting hands profile 7 to the decoder as its base layer. Read
+        // from the format, since nothing parsed the profile this time round.
+        final Format video = player != null ? player.getVideoFormat() : null;
+        return video != null && Dv7Converter.isDolbyVisionProfile7(video)
+                ? "DV 7 → HDR10 · by setting" : null;
     }
 
     /**

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -205,7 +205,7 @@
     <string name="stats_dropped">Пропущенные кадры: %1$d</string>
     <string name="stats_network">Сеть: %1$s</string>
     <string name="stats_stream">Поток: %1$s</string>
-    <string name="stats_overall">Всего: %1$s</string>
+    <string name="stats_overall">Средний: %1$s</string>
     <string name="stats_report_title">Отчёт о воспроизведении</string>
     <string name="stats_report_message">Отправьте эти подробности воспроизведения, сообщая о проблеме с изображением или звуком.</string>
     <string name="pref_show_stats_on">Буфер, декодеры и пропущенные кадры показываются с элементами управления</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -212,7 +212,7 @@
     <string name="stats_dropped">Пропущені кадри: %1$d</string>
     <string name="stats_network">Мережа: %1$s</string>
     <string name="stats_stream">Потік: %1$s</string>
-    <string name="stats_overall">Загалом: %1$s</string>
+    <string name="stats_overall">Середній: %1$s</string>
     <string name="stats_report_title">Звіт про відтворення</string>
     <string name="stats_report_message">Надішліть ці подробиці відтворення, повідомляючи про проблему із зображенням чи звуком.</string>
     <string name="pref_show_stats_on">Буфер, декодери та пропущені кадри показуються з елементами керування</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -233,7 +233,7 @@
     <string name="stats_dropped">Dropped frames: %1$d</string>
     <string name="stats_network">Network: %1$s</string>
     <string name="stats_stream">Stream: %1$s</string>
-    <string name="stats_overall">Overall: %1$s</string>
+    <string name="stats_overall">Average: %1$s</string>
     <string name="stats_report_title">Playback report</string>
     <string name="stats_report_message">Send these playback details when reporting a problem with picture or sound.</string>
     <string name="pref_show_stats_on">Buffer, decoders and dropped frames are shown with the player controls</string>


### PR DESCRIPTION
Three of the four readouts raised in #126. The transfer line under a second switch is **not** here — see below.

**The frame rate moves from the panel to the header.** It was visible only with the whole stats panel open, which means a block over the left of the picture. It is a property of the file, like the resolution, the codec and the HDR label already beside it, and it does not move during playback. Nothing is shown twice. The late arrival on Matroska needs nothing extra: `onContainerMetadata` already refreshes the header when the parse lands.

**The panel says what became of a Dolby Vision track.** The header could state the wrong dynamic range with nothing on screen to contradict it: `codecName` reads `sampleMimeType`, which stays `video/dolby-vision` whether the profile 7 rewrite worked or not, and `hdrName` only ever returns `HDR10` or `HLG`. One line, only when there is something to say:

| Case | Line |
|---|---|
| profile 7 converted, RPU in band | `DV 7 → 8.1 · in-band RPU` |
| profile 7 converted, RPU from the enhancement layer | `DV 7 → 8.1 · RPU from EL` |
| profile 7, no profile 8 decoder here | `DV 7 → HDR10 · no P8 decoder` |
| profile 7, the rewrite refused the frame | `DV 7 → HDR10 · rewrite refused` |
| profile 7, conversion off by the setting | `DV 7 → HDR10 · by setting` |
| the Dolby Vision decoder failed, playing HEVC | `DV → HDR10 · decoder failed` |

The last outranks the others: if the recovery fired there was no conversion by definition. On SDR and on ordinary HDR10 the panel does not grow at all.

Contrary to what the issue assumed, this needed more than plumbing. `Dv7Converter.status()` is a sentence written for the dump, and six short labels cannot be derived from prose without parsing it, so the converter gains a second field written at the same three places. The dump keeps the long form.

**`Overall` becomes `Average`.** It reads as neither a bitrate nor as anything distinct from `Stream`; it is the whole file over its duration, audio and subtitles included. The resource key stays, so the other languages keep their translations rather than falling back to English; uk and ru are updated by hand.

## Not done: the transfer line and its second switch

Tried and put back, with the reasoning left in the javadoc of `updateStats`. Everything that line would say is already on the panel it was to be split from, and the bottom bar has no band wide enough for it: the time is short, the button cluster is not, so a centred line is capped at twice the narrower side and loses the bitrate to an ellipsis on a TV. The placement the issue proposes — above the progress bar, `bottom|start` — collides with the room pill, which sits at the same gravity roughly 75dp up, and its `48+51` offset ignores the runtime inset adjustment `exo_progress` itself receives. Worth revisiting only if the controls are laid out differently, so #126 stays open.

## Checked

- MP4, MKV, HLS and a Dolby Vision file: frame rate in the header in all four, gone from the panel, `Average` on the containers that state no track bitrate.
- Dolby Vision line: integration confirmed on a profile 8 file, where it correctly says nothing. **The six labels themselves are unverified on hardware** — no profile 7 file was available to test with.