### PR TITLE
Take the last subtitle off the screen when subtitles are turned off

### DIFF
--- a/app/src/main/java/com/brouken/player/PlayerActivity.java
+++ b/app/src/main/java/com/brouken/player/PlayerActivity.java
@@ -8123,6 +8123,16 @@ public class PlayerActivity extends Activity {
         // subtitles off would leave a lone hint floating at the bottom of a subtitle-free picture.
         chooseSecondarySubtitle(null);
         clearPaintedSubtitle();
+        // Said here rather than left to the renderer to say by going quiet. A disabled renderer does
+        // clear its own output, but that empty group is then held back by a positive offset like any
+        // other, and a subtitle painted from a file has no renderer to go quiet in the first place.
+        // "Off" is an instruction about the screen, so it is given to the screen.
+        if (subtitleOffset != null) {
+            subtitleOffset.hide();
+        }
+        if (secondarySubtitleOffset != null) {
+            secondarySubtitleOffset.hide();
+        }
         mainLineOff = true;
         // Off is this line's renderer, not the whole track type. setTrackTypeDisabled(TEXT) is the
         // selector's last word — applyRendererDisableOverrides runs after every override it applies —

--- a/app/src/main/java/com/brouken/player/SubtitleOffset.java
+++ b/app/src/main/java/com/brouken/player/SubtitleOffset.java
@@ -13,6 +13,7 @@ import androidx.media3.exoplayer.text.TextOutput;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -68,6 +69,8 @@ final class SubtitleOffset implements TextOutput {
     private int next;
     /** The whole subtitle file, when the selected track is one we can hold. Read on the playback thread. */
     private volatile SubtitleTimeline timeline;
+    /** Whether the last group emitted put something on screen — see {@link #hide()}. */
+    private boolean showing;
     /** Blocks of {@link #timeline} currently on screen, or null when what is on screen is unknown. */
     private int[] painted;
 
@@ -96,6 +99,7 @@ final class SubtitleOffset implements TextOutput {
             groups.clear();
             next = 0;
             painted = null;
+            hide();
         }
         release();
     }
@@ -122,7 +126,25 @@ final class SubtitleOffset implements TextOutput {
         groups.clear();
         next = 0;
         painted = null;
+        hide();
         release();
+    }
+
+    /**
+     * Takes off whatever is still on screen, if anything is.
+     *
+     * <p>Nothing downstream of here keeps a clock: a cue stands until another one replaces it. So the
+     * moment this stops having anything to hand out, it has to say so — and it did not. Dropping the
+     * timeline dropped the held groups and the record of what was painted, and then {@link #release}
+     * found nothing to send, which is exactly the shape of sending nothing. Turning subtitles off left
+     * the last line standing over the rest of the film.
+     */
+    void hide() {
+        if (!showing) {
+            return;
+        }
+        final long nowMs = position.currentMs();
+        emit(new CueGroup(Collections.emptyList(), nowMs == C.TIME_UNSET ? 0 : nowMs * 1000));
     }
 
     @Override
@@ -195,6 +217,7 @@ final class SubtitleOffset implements TextOutput {
      */
     private void emit(CueGroup group) {
         final CueGroup uniform = SubtitleUtils.withoutEmbeddedLook(group);
+        showing = !uniform.cues.isEmpty();
         output.onCues(uniform.cues);
         output.onCues(uniform);
     }


### PR DESCRIPTION
Reported: watching with subtitles, turning them off leaves the last line standing while the film plays on.

Everything that reaches the subtitle view goes through one method in `SubtitleOffset`, and that method is only ever called when there is something to show. Nothing downstream keeps a clock — a cue stands until another one replaces it — so when there stops being anything to hand out, the screen is never told.

Turning off a subtitle the app was painting itself did exactly that:

```
setTimeline(null)   // timeline dropped, held groups dropped, painted record dropped
  → release()       // no timeline, no groups: nothing to emit
```

Every piece of internal state is correctly cleared, and that is precisely why the line never comes off: there is nothing left to replace it with.

A track inside the file was never affected — its renderer clears its own output when disabled, and that empty group travels the same road as any other. A file the app paints has no renderer to go quiet, and that is the common case here: a subtitle found beside the film, downloaded by the search, or picked by hand.

`SubtitleOffset` now says when it has nothing, at the two points where content ends: a timeline replaced or dropped, and a discontinuity, where a held cue belongs to the moment it was read at rather than to this one. `disableSubtitles` says it outright as well rather than relying on a renderer falling silent — there is no renderer on the painted path, and a positive subtitle offset would hold that empty group back like any other.

## Checked

- Reporter confirmed on the phone with the subtitle that showed the problem.
- Emulator, embedded track, before and after: unchanged, clears either way — which is what identified the painted path as the broken one.