### PR TITLE
Let the hold gesture be a plain 2x again

### DIFF
--- a/app/src/main/java/com/brouken/player/CustomPlayerView.java
+++ b/app/src/main/java/com/brouken/player/CustomPlayerView.java
@@ -63,7 +63,7 @@ public class CustomPlayerView extends PlayerView implements GestureDetector.OnGe
 
     // Hold-to-speed: a long press during playback jumps to 2x, and dragging sideways without letting go
     // moves along one axis - right for more speed, left down to 1x and then on into rewind. The previous
-    // speed is restored on release.
+    // speed is restored on release. The drag is what the "fixed" mode drops: there the hold is a plain 2x.
     private static final float SPEED_BOOST = 2.f;
     private static final float SPEED_MAX = 4.f;
     private static final float SPEED_REWIND_MIN = 2.f;
@@ -229,7 +229,8 @@ public class CustomPlayerView extends PlayerView implements GestureDetector.OnGe
         // GestureDetector drops every move once it has fired a long press, so the drag of a hold is read
         // straight from here - which also keeps it clear of the seek and volume/brightness scrolls.
         if (speedBoostActive && ev.getActionMasked() == MotionEvent.ACTION_MOVE) {
-            updateHoldSpeed(ev.getX());
+            if (Prefs.HOLD_SPEED_ADJUST.equals(holdSpeedMode()))
+                updateHoldSpeed(ev.getX());
             return true;
         }
 
@@ -290,13 +291,13 @@ public class CustomPlayerView extends PlayerView implements GestureDetector.OnGe
         return prefs != null && prefs.disableVolumeBrightnessGestures;
     }
 
-    // True when the viewer has turned the hold-to-speed gesture off in the settings.
-    private boolean holdSpeedGestureOff() {
+    // What the viewer picked for the hold gesture: off, a fixed 2x, or 2x the finger can drag.
+    private String holdSpeedMode() {
         if (!(getContext() instanceof PlayerActivity)) {
-            return false;
+            return Prefs.HOLD_SPEED_ADJUST;
         }
         final Prefs prefs = ((PlayerActivity) getContext()).mPrefs;
-        return prefs != null && !prefs.holdSpeed;
+        return prefs == null ? Prefs.HOLD_SPEED_ADJUST : prefs.holdSpeedMode;
     }
 
     // One seek in flight at a time, the same gate the time bar scrubs behind. A swipe fires a seek every
@@ -430,7 +431,7 @@ public class CustomPlayerView extends PlayerView implements GestureDetector.OnGe
             return;
         if (!PlayerActivity.haveMedia || PlayerActivity.player == null || !PlayerActivity.player.isPlaying())
             return;
-        if (holdSpeedGestureOff())
+        if (Prefs.HOLD_SPEED_OFF.equals(holdSpeedMode()))
             return;
         speedBeforeBoost = PlayerActivity.player.getPlaybackParameters().speed;
         speedBoostActive = true;

--- a/app/src/main/java/com/brouken/player/Prefs.java
+++ b/app/src/main/java/com/brouken/player/Prefs.java
@@ -57,6 +57,7 @@ class Prefs {
     private static final String PREF_KEY_AUTO_PIP = "autoPiP";
     private static final String PREF_KEY_DISABLE_VOLUME_BRIGHTNESS_GESTURES = "disableVolumeBrightnessGestures";
     private static final String PREF_KEY_HOLD_SPEED = "holdSpeed";
+    private static final String PREF_KEY_HOLD_SPEED_MODE = "holdSpeedMode";
     private static final String PREF_KEY_TUNNELING = "tunneling";
     private static final String PREF_KEY_FRAMERATE_MATCHING = "frameRateMatching";
     private static final String PREF_KEY_ALLOW_SYSTEM_FRAMERATE = "allowSystemFrameRate";
@@ -137,6 +138,10 @@ class Prefs {
     // Which skips offer the "go back" pill afterwards.
     // When the online subtitle search runs. One choice, because the two switches this replaced were
     // not independent: the second meant nothing while the first was off.
+    public static final String HOLD_SPEED_OFF = "off";
+    public static final String HOLD_SPEED_ADJUST = "adjust";
+    public static final String HOLD_SPEED_FIXED = "fixed";
+
     public static final String SEARCH_OFF = "off";
     public static final String SEARCH_FIRST = "first";
     public static final String SEARCH_NONE = "none";
@@ -192,8 +197,9 @@ class Prefs {
     public boolean autoPiP = false;
     // Off means the vertical swipes work as they always have; on takes them away entirely.
     public boolean disableVolumeBrightnessGestures = false;
-    // Off takes the whole hold gesture away: a long press on the picture then does nothing at all.
-    public boolean holdSpeed = true;
+    // What a long press on the picture does: nothing at all, a fixed 2x, or 2x that the same finger
+    // then drags sideways to change.
+    public String holdSpeedMode = HOLD_SPEED_ADJUST;
 
     public boolean tunneling = false;
     public boolean frameRateMatching = false;
@@ -373,7 +379,7 @@ class Prefs {
         autoPiP = mSharedPreferences.getBoolean(PREF_KEY_AUTO_PIP, autoPiP);
         disableVolumeBrightnessGestures = mSharedPreferences.getBoolean(
                 PREF_KEY_DISABLE_VOLUME_BRIGHTNESS_GESTURES, disableVolumeBrightnessGestures);
-        holdSpeed = mSharedPreferences.getBoolean(PREF_KEY_HOLD_SPEED, holdSpeed);
+        holdSpeedMode = getHoldSpeedMode(mContext);
         tunneling = mSharedPreferences.getBoolean(PREF_KEY_TUNNELING, tunneling);
         frameRateMatching = mSharedPreferences.getBoolean(PREF_KEY_FRAMERATE_MATCHING, frameRateMatching);
         allowSystemFrameRate = mSharedPreferences.getBoolean(PREF_KEY_ALLOW_SYSTEM_FRAMERATE, !Utils.isTvBox(mContext));
@@ -541,6 +547,25 @@ class Prefs {
         preferences.edit().putString(PREF_KEY_SUBTITLE_SEARCH_MODE, migrated)
                 .remove(PREF_KEY_SUBTITLE_SEARCH)
                 .remove(PREF_KEY_SUBTITLE_SEARCH_STRICT)
+                .apply();
+        return migrated;
+    }
+
+    /**
+     * What the hold-to-speed gesture does, migrated once from the switch it replaced. Read before the
+     * settings screen inflates as well as on playback, so a viewer who had the gesture off is not shown
+     * it back on.
+     */
+    public static String getHoldSpeedMode(final Context context) {
+        final SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(context);
+        final String stored = preferences.getString(PREF_KEY_HOLD_SPEED_MODE, null);
+        if (stored != null) {
+            return stored;
+        }
+        final String migrated = preferences.getBoolean(PREF_KEY_HOLD_SPEED, true)
+                ? HOLD_SPEED_ADJUST : HOLD_SPEED_OFF;
+        preferences.edit().putString(PREF_KEY_HOLD_SPEED_MODE, migrated)
+                .remove(PREF_KEY_HOLD_SPEED)
                 .apply();
         return migrated;
     }

--- a/app/src/main/java/com/brouken/player/SettingsActivity.java
+++ b/app/src/main/java/com/brouken/player/SettingsActivity.java
@@ -155,6 +155,7 @@ public class SettingsActivity extends AppCompatActivity
 
             // Before inflation: the preferences below read these keys, and either value may still be
             // living in the shape it was stored in two versions ago.
+            Prefs.getHoldSpeedMode(requireContext());
             Prefs.getSubtitleSearchMode(requireContext());
             Prefs.getSubtitleTranslate(requireContext());
 
@@ -238,7 +239,7 @@ public class SettingsActivity extends AppCompatActivity
                 // A remote has no swipes to give up, so there is nothing here to turn off.
                 preferenceDisableGestures.setVisible(false);
             }
-            Preference preferenceHoldSpeed = findPreference("holdSpeed");
+            Preference preferenceHoldSpeed = findPreference("holdSpeedMode");
             if (preferenceHoldSpeed != null && Utils.isTvBox(getContext())) {
                 // Same reason: there is no finger to hold on the picture.
                 preferenceHoldSpeed.setVisible(false);

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -63,8 +63,9 @@
     <string name="pref_disable_volume_brightness_gestures_on">Свайпы вверх и вниз ничего не делают; перемотка, масштаб и кнопки громкости работают</string>
     <string name="pref_disable_volume_brightness_gestures_off">Проведите вверх или вниз, чтобы изменить яркость в левой части экрана и громкость в правой</string>
     <string name="pref_hold_speed">Удержание для ускорения</string>
-    <string name="pref_hold_speed_on">Держите палец на видео для 2×, затем тяните вбок, чтобы менять скорость или перематывать назад</string>
-    <string name="pref_hold_speed_off">Удержание пальца на видео ничего не делает</string>
+    <string name="pref_hold_speed_adjust">2×, тяните, чтобы изменить</string>
+    <string name="pref_hold_speed_fixed">Всегда 2×</string>
+    <string name="pref_hold_speed_none">Выключено</string>
     <string name="pref_skip_header">Пропуск сегментов</string>
     <string name="pref_skip_enabled">Включено</string>
     <string name="pref_skip_enabled_on">Пропускать заставки и рекламные сегменты от запускающего приложения</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -64,8 +64,9 @@
     <string name="pref_disable_volume_brightness_gestures_on">Проведення вгору та вниз нічого не робить; перемотування, масштаб і кнопки гучності працюють</string>
     <string name="pref_disable_volume_brightness_gestures_off">Проведіть вгору або вниз, щоб змінити яскравість у лівій частині екрана та гучність у правій</string>
     <string name="pref_hold_speed">Утримання для прискорення</string>
-    <string name="pref_hold_speed_on">Тримайте палець на відео для 2×, потім тягніть убік, щоб змінити швидкість або відмотати назад</string>
-    <string name="pref_hold_speed_off">Утримання пальця на відео нічого не робить</string>
+    <string name="pref_hold_speed_adjust">2×, тягніть, щоб змінити</string>
+    <string name="pref_hold_speed_fixed">Завжди 2×</string>
+    <string name="pref_hold_speed_none">Вимкнено</string>
     <string name="pref_skip_header">Пропуск сегментів</string>
     <string name="pref_skip_enabled">Увімкнено</string>
     <string name="pref_skip_enabled_on">Пропускати заставки та рекламні сегменти від застосунку</string>

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -1,5 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+  <string-array name="hold_speed_entries">
+    <item>@string/pref_hold_speed_adjust</item>
+    <item>@string/pref_hold_speed_fixed</item>
+    <item>@string/pref_hold_speed_none</item>
+  </string-array>
+
+  <string-array name="hold_speed_values">
+    <item>adjust</item>
+    <item>fixed</item>
+    <item>off</item>
+  </string-array>
+
   <string-array name="file_access_entries">
     <item>@string/pref_file_access_auto</item>
     <item>Storage Access Framework</item>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -65,8 +65,9 @@
     <string name="pref_disable_volume_brightness_gestures_on">Swiping up and down does nothing; seeking, zoom and the volume buttons still work</string>
     <string name="pref_disable_volume_brightness_gestures_off">Swipe up and down to change brightness on the left of the screen and volume on the right</string>
     <string name="pref_hold_speed">Hold to speed up</string>
-    <string name="pref_hold_speed_on">Hold a finger on the video for 2×, then drag sideways to change the speed or rewind</string>
-    <string name="pref_hold_speed_off">Holding a finger on the video does nothing</string>
+    <string name="pref_hold_speed_adjust">2×, drag to change</string>
+    <string name="pref_hold_speed_fixed">Always 2×</string>
+    <string name="pref_hold_speed_none">Off</string>
     <string name="pref_skip_header">Skip segments</string>
     <string name="pref_skip_enabled">Enabled</string>
     <string name="pref_skip_enabled_on">Skip intros and ad segments provided by the launching app</string>

--- a/app/src/main/res/xml/root_preferences.xml
+++ b/app/src/main/res/xml/root_preferences.xml
@@ -267,12 +267,13 @@
             app:summaryOff="@string/pref_disable_volume_brightness_gestures_off"
             app:title="@string/pref_disable_volume_brightness_gestures" />
 
-        <SwitchPreferenceCompat
-            app:key="holdSpeed"
-            app:defaultValue="true"
-            app:summaryOn="@string/pref_hold_speed_on"
-            app:summaryOff="@string/pref_hold_speed_off"
-            app:title="@string/pref_hold_speed" />
+        <ListPreference
+            app:key="holdSpeedMode"
+            app:defaultValue="adjust"
+            app:entries="@array/hold_speed_entries"
+            app:entryValues="@array/hold_speed_values"
+            app:title="@string/pref_hold_speed"
+            app:useSimpleSummaryProvider="true" />
 
         <SwitchPreferenceCompat
             app:key="repeatToggle"


### PR DESCRIPTION
Holding a finger on the video jumps to 2x, and the same finger dragging sideways changes the speed or rewinds. The gesture used to be a fixed 2x, and a thumb that shifts while resting on the picture now takes the speed with it — so the on/off switch becomes a three-way list: the adjustable hold (default), a fixed 2x, or off.

In the fixed mode the drag simply does not update the speed; the press, the pill and the restore on release are unchanged, and rewind never starts.

The stored `holdSpeed` switch migrates once into `holdSpeedMode`, the same way `subtitleSearchMode` does and read before the settings screen inflates, so a viewer who had the gesture off is not shown it back on.