### PR TITLE
Make a single remote click worth 3 seconds

### DIFF
--- a/app/src/main/java/com/brouken/player/PlayerActivity.java
+++ b/app/src/main/java/com/brouken/player/PlayerActivity.java
@@ -3073,8 +3073,8 @@ public class PlayerActivity extends Activity {
         if (duration <= 0) {
             // Live, unseekable, or a duration not known yet (C.TIME_UNSET): nothing to clamp the target
             // against — clamping to a zero duration would throw every press to the start of the file, so
-            // keep the plain 10s step per press.
-            final long seekTo = Math.max(0, pos + (forward ? 10_000 : -10_000));
+            // keep the plain single-press step, without the ladder.
+            final long seekTo = Math.max(0, pos + (forward ? 3_000 : -3_000));
             player.setSeekParameters(forward ? SeekParameters.NEXT_SYNC : SeekParameters.PREVIOUS_SYNC);
             player.seekTo(seekTo);
             showKeySeekMessage(seekTo);
@@ -3093,13 +3093,20 @@ public class PlayerActivity extends Activity {
         return true;
     }
 
-    /** 10s → 30s → 1m → 2% of the duration (≈2.5 min per press in a 2-hour film). */
+    /**
+     * 3s → 10s → 30s → 1m → 2% of the duration (≈2.5 min per press in a 2-hour film). The first rung is
+     * what a single click is worth: small enough to land back on the line of dialogue that was missed,
+     * which is most of what a click is for. The rungs above it are reached two presses later than they
+     * used to be, and a held key still climbs the whole ladder in well under a second.
+     */
     private long keyScrubStep(long duration) {
-        if (keyScrubSteps < 1)
+        if (keyScrubSteps < 2)
+            return 3_000;
+        if (keyScrubSteps < 4)
             return 10_000;
-        if (keyScrubSteps < 5)
+        if (keyScrubSteps < 8)
             return 30_000;
-        if (keyScrubSteps < 12)
+        if (keyScrubSteps < 15)
             return 60_000;
         return Math.max(120_000, duration / 50);
     }


### PR DESCRIPTION
The D-pad seek ladder started at 10s. That is a lot for what a click is usually for — landing back on the line of dialogue that was missed — so 3s becomes the first rung:

| press | step |
|---|---|
| 1-2 | 3s |
| 3-4 | 10s |
| 5-8 | 30s |
| 9-15 | 1 min |
| 16+ | 2% of the duration |

The rungs above the first are reached two presses later than they used to be (the top was 13 presses, now 16). A held key auto-repeats about twenty times a second, so it still climbs the whole ladder in well under a second and the fast end feels the same.

The live / unknown-duration branch has no ladder at all and takes the same 3s per press.

Verified on the TV emulator against a 48-minute file: one click `+00:03`, eight clicks `+02:26` (146s), eighteen clicks `+15:26` (926s), and one click after a pause `-00:03` — the ladder, the reset and both directions land exactly on the arithmetic.