### PR TITLE
Take the empty icon column out of the settings list

### DIFF
--- a/app/src/main/res/values-sw360dp/bools.xml
+++ b/app/src/main/res/values-sw360dp/bools.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- androidx.preference reserves a 56dp icon column on every device this wide, on the assumption
+         that a settings screen has icons. This one has none, so the column is empty and the rows sit
+         72dp from the left against 16dp on the right. Overridden here rather than per row: the value
+         has to carry the sw360dp qualifier to win against the library's own. -->
+    <bool name="config_materialPreferenceIconSpaceReserved">false</bool>
+</resources>


### PR DESCRIPTION
Every row in the settings list started 72dp from the left while the right edge sat at 16dp — a 4.5:1 asymmetry that reads as a huge left margin.

The 72dp is 16dp of list padding plus a 56dp icon column that androidx.preference holds `INVISIBLE` rather than `GONE`: its styles take `iconSpaceReserved` from `@bool/config_materialPreferenceIconSpaceReserved`, which the library sets to `false` in `values/` but `true` in `values-sw360dp-v13/` — so it is on for every device at least 360dp wide. This screen declares no icons at all, so the column was permanently empty.

Overriding the bool is enough; it just has to carry the `sw360dp` qualifier, because an override in plain `values/` loses to the library's qualified copy at runtime.

Measured on a Pixel 6 emulator (API 34, 420dpi) with uiautomator: rows start at 42px = 16dp instead of 189px = 72dp, symmetric with the end margin. Text measure on a switch row goes from 277dp to 333dp, and the longer summaries drop a wrapped line — "Allow system to adjust refresh rate" is two lines instead of three. Also checked on the TV emulator, where the same column was reserved.