### PR TITLE
Give the preference icon-space bool a base declaration

### DIFF
--- a/app/src/main/res/values/bools.xml
+++ b/app/src/main/res/values/bools.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- The default the qualified copy in values-sw360dp overrides, and the one lintVital wants to
+         exist: androidx.preference declares this same false in its own base values, so a device
+         narrower than 360dp keeps exactly the behaviour it already had. -->
+    <bool name="config_materialPreferenceIconSpaceReserved">false</bool>
+</resources>


### PR DESCRIPTION
The release build broke on the previous change: `lintVital` raises `MissingDefaultResource` for `config_materialPreferenceIconSpaceReserved`, which existed only in `values-sw360dp/`, and it is an error rather than a warning in a release build.

Declaring the same `false` in the base `values/` folder is what androidx.preference itself does, so anything narrower than 360dp keeps the behaviour it already had, and the qualified copy still wins where it needs to.

`./gradlew lintVitalLatestUniversalRelease` passes locally — that is the exact task that failed on the v1.4.2 tag.