### PR TITLE
Never revoke audio/raw from passthrough

### DIFF
--- a/app/src/main/java/com/brouken/player/PlayerActivity.java
+++ b/app/src/main/java/com/brouken/player/PlayerActivity.java
@@ -12242,7 +12242,14 @@ public class PlayerActivity extends Activity {
     // guarded by mPrefs.revokedAudioMimes itself, so a repeat failure on the same mime after the
     // switch falls through to the normal error screen instead of looping.
     private boolean recoverByRevokingAudioMime(String mime, boolean persist) {
-        if (mime == null || player == null || audioSink == null
+        // audio/raw is never a passthrough mime: it is what a decoder feeds the sink, and it is also the
+        // format both audio renderers probe the sink with before they will decode anything at all. Denying
+        // it therefore denies decoding itself — every audio track becomes FORMAT_UNSUPPORTED_SUBTYPE, no
+        // audio track is selected, and the device plays every file in silence with no decoder in the
+        // report (JPP-C: a Realtek TV box, persisted, so no codec and no decoder priority brought sound
+        // back). An AudioTrack that failed while carrying decoded PCM reaches here with exactly that mime,
+        // via AudioSink.InitializationException.format, and there is nothing to revoke for it.
+        if (mime == null || MimeTypes.AUDIO_RAW.equals(mime) || player == null || audioSink == null
                 || mPrefs.revokedAudioMimes.contains(mime) || sessionRevokedAudioMimes.contains(mime)) {
             return false;
         }

--- a/app/src/main/java/com/brouken/player/Prefs.java
+++ b/app/src/main/java/com/brouken/player/Prefs.java
@@ -12,6 +12,7 @@ import android.preference.PreferenceManager;
 import android.provider.DocumentsContract;
 import android.text.TextUtils;
 
+import androidx.media3.common.MimeTypes;
 import androidx.media3.exoplayer.DefaultRenderersFactory;
 import androidx.media3.ui.AspectRatioFrameLayout;
 import androidx.media3.ui.CaptionStyleCompat;
@@ -452,6 +453,20 @@ class Prefs {
         // process restarted — including for the player rebuild that follows leaving the settings screen.
         revokedAudioMimes = mSharedPreferences.getStringSet(
                 PREF_KEY_REVOKED_AUDIO_MIMES, Collections.emptySet());
+        // A build up to 1.4.2 could write audio/raw here, when an AudioTrack carrying decoded PCM failed
+        // to open. That mime is what both audio renderers probe the sink with before they decode, so the
+        // entry left the device with no selectable audio track at all — silence for every file, every
+        // codec and every decoder priority, remembered for good. Dropped on read (rather than by another
+        // one-shot reset, which would throw away verdicts that are real) and rewritten, so the error
+        // report and the ffmpeg fallback see the same set as the sink.
+        if (revokedAudioMimes.contains(MimeTypes.AUDIO_RAW)) {
+            final Set<String> cleaned = new HashSet<>(revokedAudioMimes);
+            cleaned.remove(MimeTypes.AUDIO_RAW);
+            revokedAudioMimes = cleaned;
+            mSharedPreferences.edit()
+                    .putStringSet(PREF_KEY_REVOKED_AUDIO_MIMES, cleaned)
+                    .apply();
+        }
     }
 
     public void setLanguageAudio(final String languages) {


### PR DESCRIPTION
## Symptom

A Realtek TV box (Android 7.1.1, API 25) played every file in complete silence, with both hardware and software decoders, and it survived restarts. Its error report:

```
Video: id=1, mimeType=video/avc, ...
Audio: null
Decoders: OMX.realtek.video.decoder / none
Tracks: 1 video, 2 audio, 0 subtitle
Audio passthrough revoked: [audio/raw]
```

Two audio tracks in the file, none selected, no audio decoder at all.

## Cause

`audio/raw` had been remembered in the learned passthrough denylist, and `AudioPassthroughDenylistSink` answers `SINK_FORMAT_UNSUPPORTED` for it. But `audio/raw` is not a passthrough mime — it is what a decoder feeds the sink, and it is also the format both audio renderers probe the sink with before they will decode anything:

- `MediaCodecAudioRenderer.supportsFormat` → `audioSink.supportsFormat(getPcmFormat(...))`
- `FfmpegAudioRenderer.supportsFormatInternal` → the same, for PCM 16-bit and float

So denying that one mime denies decoding itself: every audio format becomes `FORMAT_UNSUPPORTED_SUBTYPE`, the selector picks no audio track, and no decoder priority or codec choice can bring the sound back.

It got written because an AudioTrack that fails to open while carrying decoded PCM raises `AudioSink.InitializationException` whose `format` is the sink's *input* format — `audio/raw`. The stall branch checks `audioSink.isPassthrough()` before blaming a mime; the `ERROR_CODE_AUDIO_TRACK_INIT_FAILED` branch never did, and that branch is the one that persists its verdict. One AudioTrack failure on an old box therefore cost the device its sound permanently.

## Fix

- Reject `audio/raw` in `recoverByRevokingAudioMime()` — the single point both callers route through, so neither the stall nor the AudioTrack path can write it.
- Drop an already-persisted `audio/raw` when preferences are read, so affected devices recover on the next launch instead of needing "Reset learned audio workarounds" or an app data reset. Only that entry is dropped; genuine verdicts for real bitstream mimes are kept.

## Testing

`./gradlew assembleLatestUniversalDebug` and a signed `assembleLatestUniversalRelease` both build. There are no tests in this project; the affected device is a user's box, so the fix is verified against the report above and the Media3 renderer capability paths it names.
