### PR TITLE
Give the player chrome's colours one home

### DIFF
--- a/app/src/main/java/com/brouken/player/DurationPanel.java
+++ b/app/src/main/java/com/brouken/player/DurationPanel.java
@@ -23,6 +23,8 @@ import android.widget.LinearLayout;
 import android.widget.ScrollView;
 import android.widget.TextView;
 
+import androidx.core.content.ContextCompat;
+
 import java.util.Date;
 import java.util.Locale;
 
@@ -142,7 +144,7 @@ final class DurationPanel {
         // Where the duration lands in wall-clock terms — the same phrasing the header uses for the end of
         // the video, since it answers the same question.
         final TextView endsAt = new TextView(activity);
-        endsAt.setTextColor(0xB3FFFFFF);
+        endsAt.setTextColor(ContextCompat.getColor(activity, R.color.ink_medium));
         endsAt.setTextSize(TypedValue.COMPLEX_UNIT_SP, ui.textEndsAt());
         endsAt.setPadding(0, 0, 0, Utils.dpToPx(6));
         readoutColumn.addView(endsAt);
@@ -151,7 +153,7 @@ final class DurationPanel {
         final View divider = new View(activity);
         divider.setLayoutParams(new LinearLayout.LayoutParams(
                 ViewGroup.LayoutParams.MATCH_PARENT, Utils.dpToPx(1)));
-        divider.setBackgroundColor(0x1AFFFFFF);
+        divider.setBackgroundColor(ContextCompat.getColor(activity, R.color.divider));
         readoutColumn.addView(divider);
 
         final Runnable render = () -> {
@@ -279,7 +281,8 @@ final class DurationPanel {
             // OxygenOS treat the panel as immersive and demand two back swipes.
             window.setLayout(ui.pickerWidthPx(cfg), ViewGroup.LayoutParams.MATCH_PARENT);
             window.setGravity(Gravity.END);
-            window.setBackgroundDrawable(new ColorDrawable(0xF0141414));
+            window.setBackgroundDrawable(
+                    new ColorDrawable(ContextCompat.getColor(activity, R.color.panel_surface)));
         }
         // Only where there is a D-pad. In touch mode this scrolls the title out of sight for nothing, since
         // a focus ring is not drawn there anyway.
@@ -344,7 +347,9 @@ final class DurationPanel {
         // them in pixels instead is what once squeezed this keypad down to its middle column.
         key.setLayoutParams(new LinearLayout.LayoutParams(
                 0, ViewGroup.LayoutParams.MATCH_PARENT, 1f));
-        key.setBackground(new RippleDrawable(ColorStateList.valueOf(0x40FFFFFF), null, null));
+        key.setBackground(new RippleDrawable(
+                ColorStateList.valueOf(ContextCompat.getColor(activity, R.color.ripple_strong)),
+                null, null));
         key.setOnClickListener(v -> onTap.run());
         return key;
     }
@@ -367,7 +372,9 @@ final class DurationPanel {
         final GradientDrawable mask = new GradientDrawable();
         mask.setCornerRadius(Utils.dpToPx(8));
         mask.setColor(Color.WHITE);
-        action.setBackground(new RippleDrawable(ColorStateList.valueOf(0x40FFFFFF), null, mask));
+        action.setBackground(new RippleDrawable(
+                ColorStateList.valueOf(ContextCompat.getColor(activity, R.color.ripple_strong)),
+                null, mask));
         return action;
     }
 }

--- a/app/src/main/java/com/brouken/player/OffsetPanel.java
+++ b/app/src/main/java/com/brouken/player/OffsetPanel.java
@@ -23,6 +23,7 @@ import android.widget.ScrollView;
 import android.widget.SeekBar;
 import android.widget.TextView;
 
+import androidx.core.content.ContextCompat;
 import androidx.core.view.ViewCompat;
 import androidx.core.widget.TextViewCompat;
 
@@ -184,8 +185,9 @@ final class OffsetPanel {
         // The same focus edge the pills take: a ripple is touch feedback, not something a remote across
         // a room can find, and this pill is the last stop of the D-pad path through here.
         final int resetCorner = Utils.dpToPx(22);
-        reset.setBackground(new RippleDrawable(ColorStateList.valueOf(0x20FFFFFF),
-                pillFill(accent, false, resetCorner), roundMask(resetCorner)));
+        reset.setBackground(new RippleDrawable(
+                ColorStateList.valueOf(ContextCompat.getColor(activity, R.color.ripple_soft)),
+                pillFill(activity, accent, false, resetCorner), roundMask(resetCorner)));
         final LinearLayout.LayoutParams resetLp = new LinearLayout.LayoutParams(
                 ViewGroup.LayoutParams.WRAP_CONTENT, ViewGroup.LayoutParams.WRAP_CONTENT);
         resetLp.gravity = Gravity.CENTER_HORIZONTAL;
@@ -221,7 +223,8 @@ final class OffsetPanel {
             window.setLayout(ui.pickerWidthPx(activity.getResources().getConfiguration()),
                     ViewGroup.LayoutParams.MATCH_PARENT);
             window.setGravity(Gravity.END);
-            window.setBackgroundDrawable(new ColorDrawable(0xF0141414));
+            window.setBackgroundDrawable(
+                    new ColorDrawable(ContextCompat.getColor(activity, R.color.panel_surface)));
         }
         // The choice, not the slider: it is the panel's first decision and it is at the top, so a
         // remote lands on it and the scroller stays where the title is. Focusing the slider scrolled
@@ -257,9 +260,11 @@ final class OffsetPanel {
         final Runnable render = () -> {
             for (int i = 0; i < pills.length; i++) {
                 final boolean on = i == picked[0];
-                pills[i].setBackground(new RippleDrawable(ColorStateList.valueOf(0x20FFFFFF),
-                        pillFill(accent, on, corner), roundMask(corner)));
-                pills[i].setTextColor(on ? 0xFF141414 : 0xB3FFFFFF);
+                pills[i].setBackground(new RippleDrawable(
+                        ColorStateList.valueOf(ContextCompat.getColor(activity, R.color.ripple_soft)),
+                        pillFill(activity, accent, on, corner), roundMask(corner)));
+                pills[i].setTextColor(ContextCompat.getColor(activity,
+                        on ? R.color.ink_on_accent : R.color.ink_medium));
                 pills[i].setTypeface(on ? Typeface.DEFAULT_BOLD : Typeface.DEFAULT);
                 // Said again without colour, for a screen reader and for anyone who cannot tell these
                 // two shades apart.
@@ -324,18 +329,20 @@ final class OffsetPanel {
     }
 
     /** Pill background: filled with the accent while in force, and edged in white while focused. */
-    private static Drawable pillFill(final int accent, final boolean on, final int corner) {
+    private static Drawable pillFill(final Context context, final int accent, final boolean on,
+                                     final int corner) {
         final StateListDrawable states = new StateListDrawable();
-        states.addState(new int[]{android.R.attr.state_focused}, pillShape(accent, on, corner, true));
-        states.addState(StateSet.WILD_CARD, pillShape(accent, on, corner, false));
+        states.addState(new int[]{android.R.attr.state_focused},
+                pillShape(context, accent, on, corner, true));
+        states.addState(StateSet.WILD_CARD, pillShape(context, accent, on, corner, false));
         return states;
     }
 
-    private static Drawable pillShape(final int accent, final boolean on, final int corner,
-                                      final boolean focused) {
+    private static Drawable pillShape(final Context context, final int accent, final boolean on,
+                                      final int corner, final boolean focused) {
         final GradientDrawable shape = new GradientDrawable();
         shape.setCornerRadius(corner);
-        shape.setColor(on ? accent : 0x14FFFFFF);
+        shape.setColor(on ? accent : ContextCompat.getColor(context, R.color.pill_off_fill));
         if (focused) {
             // The accent, like the Skip pill's own focus ring — and white only on the pill that is
             // already the accent, where a coral edge would not show. One signal and one language: an
@@ -357,7 +364,7 @@ final class OffsetPanel {
                                    final int accent, final Line line, final double maxSec,
                                    final double stepSec, final float valueSp,
                                    final List<Runnable> resets) {
-        final int trackBg = 0x33FFFFFF;
+        final int trackBg = ContextCompat.getColor(activity, R.color.track_white);
         final int progressMax = (int) Math.round(2 * maxSec / stepSec);
         final int mid = progressMax / 2;
         final int dragSnap = Math.max(1, (int) Math.round(1 / stepSec)); // drag resolution: 1 s
@@ -366,7 +373,7 @@ final class OffsetPanel {
         if (line.caption != null) {
             final TextView caption = new TextView(activity);
             caption.setText(line.caption);
-            caption.setTextColor(0xB3FFFFFF);
+            caption.setTextColor(ContextCompat.getColor(activity, R.color.ink_medium));
             caption.setTextSize(TypedValue.COMPLEX_UNIT_SP, ui.textAction());
             caption.setGravity(Gravity.CENTER);
             // Asymmetric on purpose, and fixed rather than left to the weighted spacers: a caption

--- a/app/src/main/java/com/brouken/player/PlayerActivity.java
+++ b/app/src/main/java/com/brouken/player/PlayerActivity.java
@@ -582,10 +582,6 @@ public class PlayerActivity extends Activity {
     private TextView endsAtView;
     // Longest window still read as a live broadcast rather than a recording — see isLiveStream().
     private static final long LIVE_WINDOW_MAX_MS = 10 * 60_000L;
-    // The end time is a qualifier beside the clock, so it is written a step down from white. The live
-    // label takes the brand colour instead: it is a state, not a reading, and the only one this row ever
-    // reports — see updateEndsAt.
-    private static final int ENDS_AT_COLOR = 0xB3FFFFFF;
     private TextView roomPill;
     private TextView statsView;
     private OutlineTextClock overlayClock;
@@ -1010,17 +1006,7 @@ public class PlayerActivity extends Activity {
     // pref_skip_mode_brief option names these seconds out loud ("Skip button for 3 seconds"), so changing
     // this means changing that string in every locale too.
     static final long SKIP_NOTICE_MS = 5000;
-    // Faint groove the pill's countdown underline drains along; transparent when there is no underline.
-    static final int SKIP_PILL_GROOVE_COLOR = 0x33FFFFFF;
-    // Segment highlights (see CustomDefaultTimeBar): a *_FILL band across the segment plus a crisp boundary
-    // hairline in the lighter *_HIGHLIGHT colour. Three-colour timeline system — coral = playback (hue 354,
-    // @color/timebar_played), blue = skip, amber = ad (hue 38). The blue (hue 192) sits opposite the warm
-    // coral, so it never merges over the played track and stays legible over the dark unplayed track. The
-    // skip band is opaque, so it reads as the same blue over both.
-    static final int SKIP_HIGHLIGHT_COLOR = 0xFFEAF6FF;
-    static final int SKIP_FILL_COLOR = 0xFF0696BB;
-    static final int AD_HIGHLIGHT_COLOR = 0xFFFFD27A;
-    static final int AD_FILL_COLOR = 0xC7FFA000;
+    // Segment highlights live in colors.xml as @color/skip_* and @color/ad_*; see the note there.
     // Watch together: one room per screen, alive across the player rebuilds a session accumulates.
     TogetherManager together;
     /** True only while the room's own media change is being applied — see checkRoomMedia. */
@@ -1480,7 +1466,7 @@ public class PlayerActivity extends Activity {
         slotParams.setMarginEnd(ui.dpS(16));
         slotParams.gravity = Gravity.TOP;
         posterSlot.setLayoutParams(slotParams);
-        posterSlot.setBackgroundColor(0xFF333333); // bg_placeholder_card
+        posterSlot.setBackgroundColor(ContextCompat.getColor(this, R.color.placeholder_card));
         final int posterCornerRadius = Utils.dpToPx(4);
         posterSlot.setClipToOutline(true);
         posterSlot.setOutlineProvider(new ViewOutlineProvider() {
@@ -1503,7 +1489,7 @@ public class PlayerActivity extends Activity {
                 FrameLayout.LayoutParams.MATCH_PARENT, FrameLayout.LayoutParams.MATCH_PARENT));
         posterPlaceholderView.setMinWidth(Utils.dpToPx(54));
         posterPlaceholderView.setGravity(Gravity.CENTER);
-        posterPlaceholderView.setTextColor(0x80FFFFFF); // text_tertiary
+        posterPlaceholderView.setTextColor(ContextCompat.getColor(this, R.color.ink_tertiary));
         posterPlaceholderView.setTextSize(TypedValue.COMPLEX_UNIT_SP, ui.textPlaceholder());
         posterPlaceholderView.setTypeface(Typeface.DEFAULT_BOLD);
         posterPlaceholderView.setVisibility(View.GONE);
@@ -1569,7 +1555,7 @@ public class PlayerActivity extends Activity {
         timeRow.setLayoutParams(timeRowLp);
 
         endsAtView = new TextView(this);
-        endsAtView.setTextColor(ENDS_AT_COLOR);
+        endsAtView.setTextColor(ContextCompat.getColor(this, R.color.ink_medium));
         // A step below the clock: the clock is the anchor, the end time is the qualifier next to it.
         endsAtView.setTextSize(TypedValue.COMPLEX_UNIT_SP, ui.textEndsAt());
         endsAtView.setVisibility(View.GONE);
@@ -1580,7 +1566,7 @@ public class PlayerActivity extends Activity {
         headerClock.setFormat24Hour("HH:mm");
         // A step above the "until …" text but short of pure white, which read as too harsh; the black outline
         // and bold weight carry the rest of the legibility. The overlay clock must use the same value.
-        headerClock.setTextColor(0xC2FFFFFF);
+        headerClock.setTextColor(ContextCompat.getColor(this, R.color.ink_clock));
         headerClock.setTypeface(Typeface.DEFAULT_BOLD);
         headerClock.setTextSize(TypedValue.COMPLEX_UNIT_SP, ui.textClock());
         final LinearLayout.LayoutParams headerClockLp = new LinearLayout.LayoutParams(
@@ -1684,10 +1670,11 @@ public class PlayerActivity extends Activity {
         final int skipBarHeight = Utils.dpToPx(3);
         final int skipBarCorner = Utils.dpToPx(2);
         final GradientDrawable skipPillFill = new GradientDrawable();
-        skipPillFill.setColor(Color.argb(0xF0, 0x16, 0x16, 0x16));
+        skipPillFill.setColor(ContextCompat.getColor(this, R.color.pill_surface));
         skipPillFill.setCornerRadius(skipCornerRadius);
         skipPillGroove = new GradientDrawable();
-        skipPillGroove.setColor(SKIP_PILL_GROOVE_COLOR);
+        // Faint groove the pill's countdown underline drains along; transparent when there is no underline.
+        skipPillGroove.setColor(ContextCompat.getColor(this, R.color.track_white));
         skipPillGroove.setCornerRadius(skipBarCorner);
         final GradientDrawable skipBarFill = new GradientDrawable();
         skipBarFill.setColor(brandColor()); // accent: this is a countdown, not decoration
@@ -1781,7 +1768,7 @@ public class PlayerActivity extends Activity {
         speedBoostIndicator.setCompoundDrawableTintList(ColorStateList.valueOf(brandColor()));
 
         final GradientDrawable speedBoostBackground = new GradientDrawable();
-        speedBoostBackground.setColor(Color.argb(0xF0, 0x16, 0x16, 0x16));
+        speedBoostBackground.setColor(ContextCompat.getColor(this, R.color.pill_surface));
         speedBoostBackground.setCornerRadius(skipCornerRadius);
         speedBoostIndicator.setBackground(speedBoostBackground);
 
@@ -1801,7 +1788,7 @@ public class PlayerActivity extends Activity {
         overlayClock.setFormat12Hour("h:mm a");
         overlayClock.setFormat24Hour("HH:mm");
         // Same white as the header clock — the black outline keeps it readable over bright frames.
-        overlayClock.setTextColor(0xC2FFFFFF);
+        overlayClock.setTextColor(ContextCompat.getColor(this, R.color.ink_clock));
         overlayClock.setTypeface(Typeface.DEFAULT_BOLD);
         // Must match the header clock size (see below) so the two line up exactly when controls toggle.
         overlayClock.setTextSize(TypedValue.COMPLEX_UNIT_SP, ui.textClock());
@@ -1816,12 +1803,12 @@ public class PlayerActivity extends Activity {
         // endsAtRunnable, hidden by stopEndsAtUpdates), so it is never left sitting over the video, and it
         // carries no touch handling of its own — the left half of the screen is the brightness swipe zone.
         statsView = new TextView(this);
-        statsView.setTextColor(0xB3FFFFFF);
+        statsView.setTextColor(ContextCompat.getColor(this, R.color.ink_medium));
         statsView.setTypeface(Typeface.MONOSPACE);
         statsView.setTextSize(TypedValue.COMPLEX_UNIT_SP, ui.textInfo());
         // Same corner as the lock button, the time pill and the poster — a floating box in this UI is rounded.
         final GradientDrawable statsBackground = new GradientDrawable();
-        statsBackground.setColor(0x99000000);
+        statsBackground.setColor(ContextCompat.getColor(this, R.color.pill_scrim));
         statsBackground.setCornerRadius(ui.pillCorner());
         statsView.setBackground(statsBackground);
         final int statsPadding = Utils.dpToPx(8);
@@ -1841,10 +1828,10 @@ public class PlayerActivity extends Activity {
         // the Skip pill's corner and the only band that stays free while the controls are up: the header is
         // above, the transport below, the stats panel is centred on the left edge.
         roomPill = new TextView(this);
-        roomPill.setTextColor(0xE6FFFFFF);
+        roomPill.setTextColor(ContextCompat.getColor(this, R.color.ink_high));
         roomPill.setTextSize(TypedValue.COMPLEX_UNIT_SP, ui.textInfo());
         final GradientDrawable roomPillBackground = new GradientDrawable();
-        roomPillBackground.setColor(0x99000000);
+        roomPillBackground.setColor(ContextCompat.getColor(this, R.color.pill_scrim));
         roomPillBackground.setCornerRadius(ui.pillCorner());
         roomPill.setBackground(roomPillBackground);
         roomPill.setPadding(Utils.dpToPx(10), Utils.dpToPx(5), Utils.dpToPx(10), Utils.dpToPx(5));
@@ -1869,10 +1856,10 @@ public class PlayerActivity extends Activity {
         // controls are down. It goes under the centre disc, on the loading rate's geometry, because that is
         // where the eye already is when the picture stops.
         roomBadge = new TextView(this);
-        roomBadge.setTextColor(0xE6FFFFFF);
+        roomBadge.setTextColor(ContextCompat.getColor(this, R.color.ink_high));
         roomBadge.setTextSize(TypedValue.COMPLEX_UNIT_SP, ui.textInfo());
         final GradientDrawable roomBackground = new GradientDrawable();
-        roomBackground.setColor(0x99000000);
+        roomBackground.setColor(ContextCompat.getColor(this, R.color.pill_scrim));
         roomBackground.setCornerRadius(ui.pillCorner());
         roomBadge.setBackground(roomBackground);
         roomBadge.setPadding(Utils.dpToPx(10), Utils.dpToPx(5), Utils.dpToPx(10), Utils.dpToPx(5));
@@ -3960,13 +3947,17 @@ public class PlayerActivity extends Activity {
         final long[] ends = new long[count];
         final int[] colors = new int[count];
         final int[] fillColors = new int[count];
+        final int skipEdge = ContextCompat.getColor(this, R.color.skip_edge);
+        final int skipFill = ContextCompat.getColor(this, R.color.skip_fill);
+        final int adEdge = ContextCompat.getColor(this, R.color.ad_edge);
+        final int adFill = ContextCompat.getColor(this, R.color.ad_fill);
         for (int i = 0; i < count; i++) {
             final SkipSegment segment = segments.get(i);
             final boolean ad = segment.type == SkipSegment.Type.AD;
             starts[i] = segment.startMs();
             ends[i] = segment.endMs();
-            colors[i] = ad ? AD_HIGHLIGHT_COLOR : SKIP_HIGHLIGHT_COLOR;
-            fillColors[i] = ad ? AD_FILL_COLOR : SKIP_FILL_COLOR;
+            colors[i] = ad ? adEdge : skipEdge;
+            fillColors[i] = ad ? adFill : skipFill;
         }
         timeBar.setSkipHighlights(starts, ends, colors, fillColors, durationMs);
     }
@@ -4241,7 +4232,7 @@ public class PlayerActivity extends Activity {
      */
     private void setSkipPillUnderline(double fraction) {
         if (skipPillGroove != null) {
-            skipPillGroove.setColor(SKIP_PILL_GROOVE_COLOR);
+            skipPillGroove.setColor(ContextCompat.getColor(this, R.color.track_white));
         }
         if (skipButtonProgress != null) {
             skipButtonProgress.setLevel((int) Math.round(Math.max(0, Math.min(1, fraction)) * 10000));
@@ -4808,7 +4799,7 @@ public class PlayerActivity extends Activity {
 
     private TextView createInfoLine(int topMargin) {
         final TextView view = new TextView(this);
-        view.setTextColor(0x99FFFFFF); // text_secondary
+        view.setTextColor(ContextCompat.getColor(this, R.color.ink_secondary));
         view.setTextSize(TypedValue.COMPLEX_UNIT_SP, ui.textInfo());
         view.setMaxLines(1);
         view.setEllipsize(TextUtils.TruncateAt.END);
@@ -5076,11 +5067,13 @@ public class PlayerActivity extends Activity {
         // window the stream is offering right now — a minute from now, and about nothing.
         if (isLiveStream()) {
             endsAtView.setText(R.string.time_live);
+            // The live label takes the brand colour: it is a state, not a reading, and the only one
+            // this row ever reports. Every other time the row is a qualifier beside the clock.
             endsAtView.setTextColor(brandColor());
             endsAtView.setVisibility(View.VISIBLE);
             return;
         }
-        endsAtView.setTextColor(ENDS_AT_COLOR);
+        endsAtView.setTextColor(ContextCompat.getColor(this, R.color.ink_medium));
         final long duration = player.getDuration();
         if (duration == C.TIME_UNSET || duration <= 0) {
             endsAtView.setVisibility(View.GONE);
@@ -5391,7 +5384,7 @@ public class PlayerActivity extends Activity {
         lp.setMargins(Utils.dpToPx(3), Utils.dpToPx(3), 0, 0);
         badge.setLayoutParams(lp);
         final GradientDrawable bg = new GradientDrawable();
-        bg.setColor(0xCC000000);
+        bg.setColor(ContextCompat.getColor(this, R.color.badge_scrim));
         bg.setCornerRadius(Utils.dpToPx(3));
         badge.setBackground(bg);
         badge.setGravity(Gravity.CENTER);
@@ -5484,7 +5477,7 @@ public class PlayerActivity extends Activity {
                 ViewGroup.LayoutParams.MATCH_PARENT, Utils.dpToPx(1));
         dividerLp.bottomMargin = Utils.dpToPx(4);
         divider.setLayoutParams(dividerLp);
-        divider.setBackgroundColor(0x1AFFFFFF);
+        divider.setBackgroundColor(ContextCompat.getColor(this, R.color.divider));
         listLayout.addView(divider);
 
         for (int i = 0; i < count; i++) {
@@ -5512,7 +5505,9 @@ public class PlayerActivity extends Activity {
             final GradientDrawable rowMask = new GradientDrawable();
             rowMask.setCornerRadius(Utils.dpToPx(8));
             rowMask.setColor(Color.WHITE);
-            row.setBackground(new RippleDrawable(ColorStateList.valueOf(0x40FFFFFF), rowContent, rowMask));
+            row.setBackground(new RippleDrawable(
+                    ColorStateList.valueOf(ContextCompat.getColor(this, R.color.ripple_strong)),
+                    rowContent, rowMask));
             if (isCurrent) {
                 currentRow[0] = row;
             }
@@ -5524,7 +5519,7 @@ public class PlayerActivity extends Activity {
             boxLp.gravity = Gravity.CENTER_VERTICAL;
             box.setLayoutParams(boxLp);
             box.setMinimumWidth(Utils.dpToPx(40));
-            box.setBackgroundColor(0xFF2A2A2A);
+            box.setBackgroundColor(ContextCompat.getColor(this, R.color.thumb_box));
             box.setClipToOutline(true);
             box.setOutlineProvider(new ViewOutlineProvider() {
                 @Override
@@ -5555,7 +5550,7 @@ public class PlayerActivity extends Activity {
                         FrameLayout.LayoutParams.MATCH_PARENT, FrameLayout.LayoutParams.MATCH_PARENT));
                 number.setGravity(Gravity.CENTER);
                 number.setMinWidth(Utils.dpToPx(40));
-                number.setTextColor(0x99FFFFFF);
+                number.setTextColor(ContextCompat.getColor(this, R.color.ink_secondary));
                 number.setTextSize(TypedValue.COMPLEX_UNIT_SP, ui.textListNumber());
                 box.addView(number);
             }
@@ -5563,7 +5558,7 @@ public class PlayerActivity extends Activity {
 
             final TextView titleText = new TextView(this);
             titleText.setText(title);
-            titleText.setTextColor(isCurrent ? 0xFFFFFFFF : 0xFFDDDDDD);
+            titleText.setTextColor(isCurrent ? Color.WHITE : ContextCompat.getColor(this, R.color.ink_row_inactive));
             titleText.setTextSize(TypedValue.COMPLEX_UNIT_SP, ui.textList());
             if (isCurrent) {
                 titleText.setTypeface(Typeface.DEFAULT_BOLD);
@@ -5619,7 +5614,8 @@ public class PlayerActivity extends Activity {
             // panel as immersive and apply its two-swipe back-gesture guard. A plain window closes on one back.
             window.setLayout(ui.pickerWidthPx(getResources().getConfiguration()), ViewGroup.LayoutParams.MATCH_PARENT);
             window.setGravity(Gravity.END);
-            window.setBackgroundDrawable(new android.graphics.drawable.ColorDrawable(0xF0141414));
+            window.setBackgroundDrawable(new android.graphics.drawable.ColorDrawable(
+                    ContextCompat.getColor(this, R.color.panel_surface)));
         }
         // Hide the player's overlay (header + bottom controls) so only the playlist panel is shown.
         showPickerDialog(playlistDialog);
@@ -5771,7 +5767,7 @@ public class PlayerActivity extends Activity {
                 ViewGroup.LayoutParams.MATCH_PARENT, Utils.dpToPx(1));
         dividerLp.bottomMargin = Utils.dpToPx(4);
         divider.setLayoutParams(dividerLp);
-        divider.setBackgroundColor(0x1AFFFFFF);
+        divider.setBackgroundColor(ContextCompat.getColor(this, R.color.divider));
         listLayout.addView(divider);
 
         for (int i = 0; i < choices.size(); i++) {
@@ -5791,7 +5787,9 @@ public class PlayerActivity extends Activity {
             final GradientDrawable rowMask = new GradientDrawable();
             rowMask.setCornerRadius(Utils.dpToPx(8));
             rowMask.setColor(Color.WHITE);
-            row.setBackground(new RippleDrawable(ColorStateList.valueOf(0x40FFFFFF), rowContent, rowMask));
+            row.setBackground(new RippleDrawable(
+                    ColorStateList.valueOf(ContextCompat.getColor(this, R.color.ripple_strong)),
+                    rowContent, rowMask));
             if (isCurrent) {
                 currentRow[0] = row;
             }
@@ -5805,7 +5803,7 @@ public class PlayerActivity extends Activity {
 
             final TextView title = new TextView(this);
             title.setText(qualityChoiceTitle(choice));
-            title.setTextColor(isCurrent ? 0xFFFFFFFF : 0xFFDDDDDD);
+            title.setTextColor(isCurrent ? Color.WHITE : ContextCompat.getColor(this, R.color.ink_row_inactive));
             title.setTextSize(TypedValue.COMPLEX_UNIT_SP, ui.textBody());
             if (isCurrent) {
                 title.setTypeface(Typeface.DEFAULT_BOLD);
@@ -5817,7 +5815,7 @@ public class PlayerActivity extends Activity {
             if (subtitle != null && !subtitle.isEmpty()) {
                 details = new TextView(this);
                 details.setText(subtitle);
-                details.setTextColor(0x99FFFFFF);
+                details.setTextColor(ContextCompat.getColor(this, R.color.ink_secondary));
                 details.setTextSize(TypedValue.COMPLEX_UNIT_SP, ui.textCaption());
                 textBlock.addView(details);
             }
@@ -5827,7 +5825,7 @@ public class PlayerActivity extends Activity {
             if (choice.bitrateText != null && !choice.bitrateText.isEmpty()) {
                 final TextView bitrate = new TextView(this);
                 bitrate.setText(choice.bitrateText);
-                bitrate.setTextColor(0x99FFFFFF);
+                bitrate.setTextColor(ContextCompat.getColor(this, R.color.ink_secondary));
                 bitrate.setTextSize(TypedValue.COMPLEX_UNIT_SP, ui.textCaption());
                 bitrate.setGravity(Gravity.END | Gravity.CENTER_VERTICAL);
                 bitrate.setSingleLine(true);
@@ -5864,7 +5862,8 @@ public class PlayerActivity extends Activity {
             // panel as immersive and apply its two-swipe back-gesture guard. A plain window closes on one back.
             window.setLayout(ui.pickerWidthPx(getResources().getConfiguration()), ViewGroup.LayoutParams.MATCH_PARENT);
             window.setGravity(Gravity.END);
-            window.setBackgroundDrawable(new android.graphics.drawable.ColorDrawable(0xF0141414));
+            window.setBackgroundDrawable(new android.graphics.drawable.ColorDrawable(
+                    ContextCompat.getColor(this, R.color.panel_surface)));
         }
         showPickerDialog(qualityDialog);
         if (currentRow[0] != null) {
@@ -5970,7 +5969,7 @@ public class PlayerActivity extends Activity {
         lp.topMargin = topPx;
         lp.bottomMargin = bottomPx;
         rule.setLayoutParams(lp);
-        rule.setBackgroundColor(0x1AFFFFFF);
+        rule.setBackgroundColor(ContextCompat.getColor(this, R.color.divider));
         return rule;
     }
 
@@ -5982,7 +5981,7 @@ public class PlayerActivity extends Activity {
     private View menuCaption(CharSequence text) {
         final TextView caption = new TextView(this);
         caption.setText(text);
-        caption.setTextColor(0x99FFFFFF);
+        caption.setTextColor(ContextCompat.getColor(this, R.color.ink_secondary));
         caption.setTextSize(TypedValue.COMPLEX_UNIT_SP, ui.textCaption());
         caption.setPadding(Utils.dpToPx(12), Utils.dpToPx(8), Utils.dpToPx(12), Utils.dpToPx(2));
         return caption;
@@ -6045,7 +6044,9 @@ public class PlayerActivity extends Activity {
             final GradientDrawable rowMask = new GradientDrawable();
             rowMask.setCornerRadius(Utils.dpToPx(8));
             rowMask.setColor(Color.WHITE);
-            row.setBackground(new RippleDrawable(ColorStateList.valueOf(0x40FFFFFF), rowContent, rowMask));
+            row.setBackground(new RippleDrawable(
+                    ColorStateList.valueOf(ContextCompat.getColor(this, R.color.ripple_strong)),
+                    rowContent, rowMask));
             if (isCurrent) {
                 currentRow[0] = row;
             }
@@ -6062,7 +6063,7 @@ public class PlayerActivity extends Activity {
                 art.setScaleType(ImageView.ScaleType.CENTER_CROP);
                 // Same placeholder as the header's poster slot, so a slow load is a quiet grey card
                 // rather than a hole that shifts the text when it fills.
-                art.setBackgroundColor(0xFF333333);
+                art.setBackgroundColor(ContextCompat.getColor(this, R.color.placeholder_card));
                 final int artCorner = Utils.dpToPx(4);
                 art.setClipToOutline(true);
                 art.setOutlineProvider(new ViewOutlineProvider() {
@@ -6080,7 +6081,8 @@ public class PlayerActivity extends Activity {
             } else if (item.iconRes != 0) {
                 final ImageView icon = new ImageView(this);
                 icon.setImageResource(item.iconRes);
-                icon.setImageTintList(ColorStateList.valueOf(isCurrent ? 0xFFFFFFFF : 0xFFDDDDDD));
+                icon.setImageTintList(ColorStateList.valueOf(
+                        isCurrent ? Color.WHITE : ContextCompat.getColor(this, R.color.ink_row_inactive)));
                 final int iconSize = Utils.dpToPx(22);
                 final LinearLayout.LayoutParams iconLp = new LinearLayout.LayoutParams(iconSize, iconSize);
                 iconLp.setMarginEnd(Utils.dpToPx(16));
@@ -6097,7 +6099,7 @@ public class PlayerActivity extends Activity {
 
             final TextView title = new TextView(this);
             title.setText(item.title);
-            title.setTextColor(isCurrent ? 0xFFFFFFFF : 0xFFDDDDDD);
+            title.setTextColor(isCurrent ? Color.WHITE : ContextCompat.getColor(this, R.color.ink_row_inactive));
             title.setTextSize(TypedValue.COMPLEX_UNIT_SP, ui.textBody());
             if (isCurrent) {
                 title.setTypeface(Typeface.DEFAULT_BOLD);
@@ -6110,7 +6112,8 @@ public class PlayerActivity extends Activity {
                 if (mark != null) {
                     final int markBox = Math.round(title.getTextSize());
                     mark.setBounds(0, 0, markBox, markBox);
-                    mark.setTintList(ColorStateList.valueOf(isCurrent ? 0xFFFFFFFF : 0xFFDDDDDD));
+                    mark.setTintList(ColorStateList.valueOf(
+                            isCurrent ? Color.WHITE : ContextCompat.getColor(this, R.color.ink_row_inactive)));
                     title.setCompoundDrawablesRelative(mark, null, null, null);
                     title.setCompoundDrawablePadding(Utils.dpToPx(6));
                 }
@@ -6121,7 +6124,7 @@ public class PlayerActivity extends Activity {
             if (item.subtitle != null && item.subtitle.length() > 0) {
                 details = new TextView(this);
                 details.setText(item.subtitle);
-                details.setTextColor(0x99FFFFFF);
+                details.setTextColor(ContextCompat.getColor(this, R.color.ink_secondary));
                 details.setTextSize(TypedValue.COMPLEX_UNIT_SP, ui.textCaption());
                 textBlock.addView(details);
             }
@@ -6155,7 +6158,8 @@ public class PlayerActivity extends Activity {
             // panel as immersive and apply its two-swipe back-gesture guard. A plain window closes on one back.
             window.setLayout(ui.pickerWidthPx(getResources().getConfiguration()), ViewGroup.LayoutParams.MATCH_PARENT);
             window.setGravity(Gravity.END);
-            window.setBackgroundDrawable(new android.graphics.drawable.ColorDrawable(0xF0141414));
+            window.setBackgroundDrawable(new android.graphics.drawable.ColorDrawable(
+                    ContextCompat.getColor(this, R.color.panel_surface)));
         }
         showPickerDialog(menuDialog);
         final View focus = currentRow[0] != null ? currentRow[0] : firstRow[0];
@@ -7891,7 +7895,7 @@ public class PlayerActivity extends Activity {
     private TextView searchNote(CharSequence text) {
         final TextView note = new TextView(this);
         note.setText(text);
-        note.setTextColor(0x99FFFFFF);
+        note.setTextColor(ContextCompat.getColor(this, R.color.ink_secondary));
         note.setTextSize(TypedValue.COMPLEX_UNIT_SP, ui.textBody());
         note.setPadding(Utils.dpToPx(12), Utils.dpToPx(10), Utils.dpToPx(12), Utils.dpToPx(10));
         return note;
@@ -7917,13 +7921,15 @@ public class PlayerActivity extends Activity {
         final GradientDrawable mask = new GradientDrawable();
         mask.setCornerRadius(Utils.dpToPx(8));
         mask.setColor(Color.WHITE);
-        row.setBackground(new RippleDrawable(ColorStateList.valueOf(0x40FFFFFF), content, mask));
+        row.setBackground(new RippleDrawable(
+                ColorStateList.valueOf(ContextCompat.getColor(this, R.color.ripple_strong)), content, mask));
 
         final ImageView art = new ImageView(this);
         art.setScaleType(ImageView.ScaleType.CENTER_CROP);
         // Grey only while something is on its way. A title the catalogue has no poster for led with a
         // grey card standing in for an image that was never coming — the row should lead with nothing.
-        art.setBackgroundColor(imageUrl != null ? 0xFF333333 : Color.TRANSPARENT);
+        art.setBackgroundColor(
+                imageUrl != null ? ContextCompat.getColor(this, R.color.placeholder_card) : Color.TRANSPARENT);
         final int corner = Utils.dpToPx(4);
         art.setClipToOutline(true);
         art.setOutlineProvider(new ViewOutlineProvider() {
@@ -7946,14 +7952,14 @@ public class PlayerActivity extends Activity {
                 0, ViewGroup.LayoutParams.WRAP_CONTENT, 1f));
         final TextView titleView = new TextView(this);
         titleView.setText(name);
-        titleView.setTextColor(0xFFDDDDDD);
+        titleView.setTextColor(ContextCompat.getColor(this, R.color.ink_row_inactive));
         titleView.setTextSize(TypedValue.COMPLEX_UNIT_SP, ui.textBody());
         textBlock.addView(titleView);
         TextView detailView = null;
         if (detail != null && detail.length() > 0) {
             detailView = new TextView(this);
             detailView.setText(detail);
-            detailView.setTextColor(0x99FFFFFF);
+            detailView.setTextColor(ContextCompat.getColor(this, R.color.ink_secondary));
             detailView.setTextSize(TypedValue.COMPLEX_UNIT_SP, ui.textCaption());
             textBlock.addView(detailView);
         }
@@ -9522,7 +9528,7 @@ public class PlayerActivity extends Activity {
                 // Losing the relay does not stop the picture, so it is stated rather than alarmed about —
                 // but on the brand colour, because the room has stopped being in step and nothing else says so.
                 final int tint = together.connected()
-                        ? 0xE6FFFFFF
+                        ? ContextCompat.getColor(this, R.color.ink_high)
                         : ContextCompat.getColor(this, R.color.brand);
                 roomPill.setTextColor(tint);
                 roomPill.setCompoundDrawableTintList(ColorStateList.valueOf(tint));
@@ -10522,11 +10528,11 @@ public class PlayerActivity extends Activity {
             emptyState.hide();
             if (isNetworkUri) {
                 // Reads as a light rail ahead of the playhead, the way the design shows a buffering stream.
-                timeBar.setBufferedColor(0xC0FFFFFF);
+                timeBar.setBufferedColor(ContextCompat.getColor(this, R.color.buffered_white));
             } else {
                 // Local files report the whole file as buffered, so anything brighter floods the bar:
                 // https://github.com/google/ExoPlayer/issues/5765
-                timeBar.setBufferedColor(0x33FFFFFF);
+                timeBar.setBufferedColor(ContextCompat.getColor(this, R.color.track_white));
             }
 
             playerView.setResizeMode(mPrefs.resizeMode);
@@ -13677,7 +13683,7 @@ public class PlayerActivity extends Activity {
         final GradientDrawable mask = new GradientDrawable();
         mask.setShape(GradientDrawable.OVAL);
         mask.setColor(Color.WHITE);
-        return new RippleDrawable(ColorStateList.valueOf(0x33FFFFFF),
+        return new RippleDrawable(ColorStateList.valueOf(ContextCompat.getColor(this, R.color.ripple_medium)),
                 new InsetDrawable((Drawable) ring, discInset / 2),
                 new InsetDrawable((Drawable) mask, discInset));
     }

--- a/app/src/main/java/com/brouken/player/SwipeToUnlockView.java
+++ b/app/src/main/java/com/brouken/player/SwipeToUnlockView.java
@@ -45,7 +45,7 @@ public class SwipeToUnlockView extends FrameLayout {
 
         // Single line, centered, and inset on both sides so it clears the resting icon and never wraps.
         swipeText = new TextView(context);
-        swipeText.setTextColor(0xFFFFFFFF);
+        swipeText.setTextColor(ContextCompat.getColor(context, R.color.white));
         swipeText.setTextSize(13);
         swipeText.setSingleLine(true);
         swipeText.setMaxLines(1);

--- a/app/src/main/res/layout/exo_player_control_view.xml
+++ b/app/src/main/res/layout/exo_player_control_view.xml
@@ -168,7 +168,7 @@
       android:layout_width="wrap_content"
       android:layout_height="wrap_content"
       android:layout_gravity="center"
-      android:textColor="#B3FFFFFF"
+      android:textColor="@color/ink_medium"
       android:visibility="gone"/>
 
   <View android:id="@+id/exo_top"

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -53,8 +53,7 @@
     <color name="divider">#1AFFFFFF</color>
     <color name="track_white">#33FFFFFF</color>
     <color name="pill_off_fill">#14FFFFFF</color>
-    <!-- Buffered lead, brightened on network sources only: a local file reports the whole file as
-         buffered (ExoPlayer #5765), where a bright lead would flood the bar. -->
+    <!-- Buffered lead ahead of the playhead; used on network sources only, see the call site. -->
     <color name="buffered_white">#C0FFFFFF</color>
 
     <!-- Press feedback. Three tones today, one per surface family; they are independent knobs
@@ -63,9 +62,12 @@
     <color name="ripple_medium">#33FFFFFF</color>
     <color name="ripple_soft">#20FFFFFF</color>
 
-    <!-- Timeline segments. These carry meaning — skipped run vs advertisement — so they stay off the
-         brand accent, which on the same bar means "played". Opaque: the old translucent band picked
-         up whatever was under it and read as two colours along one segment. -->
+    <!-- Segment highlights (see CustomDefaultTimeBar): a *_fill band across the segment plus a crisp
+         boundary hairline in the lighter *_edge colour. Three-colour timeline system — coral =
+         playback (hue 354, @color/timebar_played), blue = skip, amber = ad (hue 38). The blue
+         (hue 192) sits opposite the warm coral, so it never merges over the played track and stays
+         legible over the dark unplayed track. The skip band is opaque, so it reads as the same blue
+         over both. -->
     <color name="skip_edge">#FFEAF6FF</color>
     <color name="skip_fill">#FF0696BB</color>
     <color name="ad_edge">#FFFFD27A</color>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -2,7 +2,7 @@
 <resources xmlns:tools="http://schemas.android.com/tools">
     <color name="black">#FF000000</color>
     <color name="white">#FFFFFFFF</color>
-    <color name="brand">#fe6f61</color>
+    <color name="brand">#FFFE6F61</color>
     <!-- The mark's ramp (see design/just+.svg); the vector drawables carry these same two stops. -->
     <color name="brand_ramp_start">#FFFF6E3C</color>
     <color name="brand_ramp_end">#FFFF0D63</color>
@@ -26,6 +26,50 @@
     <!-- Volume/brightness OSD bar (LevelBar); the boost segment is everything above 100%. -->
     <color name="level_bar_track">#4DFFFFFF</color>
     <color name="volume_boost">#FFF57C00</color>
+
+    <!-- Player chrome ink. The player UI is built in code over video, so its text is white at an
+         emphasis rather than a theme colour: the frame behind is unknown, and a theme's onSurface
+         would be picked for a surface that isn't there. Named by the role, not by the alpha. -->
+    <color name="ink_high">#E6FFFFFF</color>
+    <color name="ink_clock">#C2FFFFFF</color>
+    <color name="ink_medium">#B3FFFFFF</color>
+    <color name="ink_secondary">#99FFFFFF</color>
+    <color name="ink_tertiary">#80FFFFFF</color>
+    <!-- A row that is not the current one: opaque grey, not white at an alpha, so it stays a step
+         below the current row even where the fill behind them differs. -->
+    <color name="ink_row_inactive">#FFDDDDDD</color>
+    <!-- Ink on a brand-filled control, e.g. a selected offset pill. -->
+    <color name="ink_on_accent">#FF141414</color>
+
+    <!-- Player chrome surfaces, all translucent so the picture keeps showing through. -->
+    <color name="panel_surface">#F0141414</color>
+    <color name="pill_surface">#F0161616</color>
+    <color name="pill_scrim">#99000000</color>
+    <color name="badge_scrim">#CC000000</color>
+    <color name="placeholder_card">#FF333333</color>
+    <color name="thumb_box">#FF2A2A2A</color>
+
+    <!-- Hairlines, grooves and the unfilled part of a track. -->
+    <color name="divider">#1AFFFFFF</color>
+    <color name="track_white">#33FFFFFF</color>
+    <color name="pill_off_fill">#14FFFFFF</color>
+    <!-- Buffered lead, brightened on network sources only: a local file reports the whole file as
+         buffered (ExoPlayer #5765), where a bright lead would flood the bar. -->
+    <color name="buffered_white">#C0FFFFFF</color>
+
+    <!-- Press feedback. Three tones today, one per surface family; they are independent knobs
+         rather than a deliberate scale. -->
+    <color name="ripple_strong">#40FFFFFF</color>
+    <color name="ripple_medium">#33FFFFFF</color>
+    <color name="ripple_soft">#20FFFFFF</color>
+
+    <!-- Timeline segments. These carry meaning — skipped run vs advertisement — so they stay off the
+         brand accent, which on the same bar means "played". Opaque: the old translucent band picked
+         up whatever was under it and read as two colours along one segment. -->
+    <color name="skip_edge">#FFEAF6FF</color>
+    <color name="skip_fill">#FF0696BB</color>
+    <color name="ad_edge">#FFFFD27A</color>
+    <color name="ad_fill">#C7FFA000</color>
 
     <color name="ui_controls_background">#98000000</color>
     <color name="exo_bottom_bar_background" tools:keep="@color/exo_bottom_bar_background">@color/ui_controls_background</color>


### PR DESCRIPTION
Part of the Material UI series. This targets the integration branch `feature/material-ui`, not `master` — the whole series lands on `master` as one merge at the end.

First step of the Material 3 / one-palette work: the colour values the player draws with get names, and the code reads them from `colors.xml` instead of spelling them out at the point of use.

Nothing moves on screen. Every replaced value is identical to the one it replaces, checked mechanically — each literal removed was counted against the resource value put in its place, so the paths behind a tap are covered too, not just the ones a screenshot can reach.

### Why

The player UI is built in code, so its colours were written as `0xAARRGGBB` at the call site: 69 of them across four files, 24 distinct values. The panel surface alone had six copies, one of them spelled `Color.argb(0xF0, 0x16, 0x16, 0x16)` instead. Three literals already carried a comment naming the token they wanted — `// text_secondary`, `// text_tertiary`, `// bg_placeholder_card` — so the palette existed; it just had nowhere to live, and no theme could reach it.

### What is in here

- `colors.xml` gains the names, grouped by role: ink at an emphasis, translucent chrome surfaces, hairlines and tracks, press feedback, and the timeline's skip/ad segments.
- `PlayerActivity`, `OffsetPanel`, `DurationPanel` and `SwipeToUnlockView` read those names.
- `ENDS_AT_COLOR`, `SKIP_PILL_GROOVE_COLOR` and the four segment constants are gone — a `static final int` cannot read a resource. The comments that explained them move with the values: the timeline's three-colour rationale now sits above the segment colours in `colors.xml`, where the next person to change them will be looking.
- `brand` loses its odd six-digit lowercase spelling, the only one in the file.

Three press-feedback tones (`ripple_strong` / `ripple_medium` / `ripple_soft`) get three names rather than one. They are almost certainly drift rather than design, but collapsing them moves pixels, so that is left for the pass that changes the player's look on purpose.

### Checked

`./gradlew assembleLatestUniversalDebug`, then installed on a phone emulator: the app opens, plays a clip, and draws its chrome with a clean log. The panels are behind a tap and were covered by the value check instead.
