### PR TITLE
Put the themes and every dialog on Material 3

### DIFF
--- a/app/src/main/java/com/brouken/player/EmptyState.java
+++ b/app/src/main/java/com/brouken/player/EmptyState.java
@@ -5,7 +5,6 @@ import android.animation.AnimatorListenerAdapter;
 import android.animation.ObjectAnimator;
 import android.animation.PropertyValuesHolder;
 import android.animation.ValueAnimator;
-import android.app.AlertDialog;
 import android.content.ClipData;
 import android.content.ClipboardManager;
 import android.content.Context;
@@ -22,6 +21,8 @@ import android.view.animation.AccelerateDecelerateInterpolator;
 import android.view.animation.PathInterpolator;
 import android.widget.EditText;
 import android.widget.TextView;
+
+import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 
 /**
  * The branded page shown while there is no clip to play: an animated brand-mark reveal, the "Open
@@ -227,7 +228,7 @@ class EmptyState {
             input.setText(pasted.toString());
             input.setSelection(input.getText().length());
         }
-        new AlertDialog.Builder(activity)
+        new MaterialAlertDialogBuilder(activity)
                 .setTitle(R.string.empty_state_link)
                 .setView(input)
                 .setPositiveButton(android.R.string.ok,

--- a/app/src/main/java/com/brouken/player/LanguagePriorityDialog.java
+++ b/app/src/main/java/com/brouken/player/LanguagePriorityDialog.java
@@ -11,8 +11,9 @@ import android.widget.LinearLayout;
 import android.widget.ScrollView;
 import android.widget.TextView;
 
-import androidx.appcompat.app.AlertDialog;
 import androidx.core.content.ContextCompat;
+
+import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -86,7 +87,7 @@ final class LanguagePriorityDialog {
 
         editor.rebuild(-1, 0);
 
-        new AlertDialog.Builder(context)
+        new MaterialAlertDialogBuilder(context)
                 .setTitle(title)
                 .setView(scroll)
                 .setNegativeButton(android.R.string.cancel, null)
@@ -212,7 +213,7 @@ final class LanguagePriorityDialog {
         for (int i = 0; i < codes.size(); i++) {
             labels[i] = label(allLanguages, codes.get(i));
         }
-        new AlertDialog.Builder(context)
+        new MaterialAlertDialogBuilder(context)
                 .setTitle(addRes)
                 .setItems(labels, (dialog, which) -> {
                     languages.add(codes.get(which));

--- a/app/src/main/java/com/brouken/player/MediaStoreChooserActivity.java
+++ b/app/src/main/java/com/brouken/player/MediaStoreChooserActivity.java
@@ -2,7 +2,6 @@ package com.brouken.player;
 
 import android.Manifest;
 import android.app.Activity;
-import android.app.AlertDialog;
 import android.content.ContentUris;
 import android.content.Intent;
 import android.content.pm.PackageManager;
@@ -15,6 +14,9 @@ import android.provider.MediaStore;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.RequiresApi;
+import androidx.appcompat.app.AlertDialog;
+
+import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -147,10 +149,12 @@ public class MediaStoreChooserActivity extends Activity {
 
         AlertDialog.Builder alertDialogBuilder;
         if (buckets.size() == 0) {
-            alertDialogBuilder = new AlertDialog.Builder(this);
+            // Same theme as the populated branch: this activity's own theme carries no dialog style,
+            // so without it the "no media" message would come out looking like a different app.
+            alertDialogBuilder = new MaterialAlertDialogBuilder(this, R.style.MediaStoreChooserDialog);
             alertDialogBuilder.setMessage(R.string.mediastore_empty);
         } else {
-            alertDialogBuilder = new AlertDialog.Builder(this, R.style.MediaStoreChooserDialog);
+            alertDialogBuilder = new MaterialAlertDialogBuilder(this, R.style.MediaStoreChooserDialog);
             alertDialogBuilder.setTitle(getString(R.string.choose_file));
             alertDialogBuilder.setItems(bucketDisplayNames, (dialogInterface, i) -> {
                 Intent intent = new Intent(MediaStoreChooserActivity.this, MediaStoreChooserActivity.class);
@@ -177,7 +181,7 @@ public class MediaStoreChooserActivity extends Activity {
         Integer[] ids = files.keySet().toArray(new Integer[0]);
         String[] displayNames = files.values().toArray(new String[0]);
 
-        AlertDialog.Builder alertDialogBuilder = new AlertDialog.Builder(this, R.style.MediaStoreChooserDialog);
+        AlertDialog.Builder alertDialogBuilder = new MaterialAlertDialogBuilder(this, R.style.MediaStoreChooserDialog);
         if (title != null) {
             alertDialogBuilder.setTitle(title);
         }

--- a/app/src/main/java/com/brouken/player/PlayerActivity.java
+++ b/app/src/main/java/com/brouken/player/PlayerActivity.java
@@ -7,7 +7,6 @@ import android.animation.AnimatorListenerAdapter;
 import android.annotation.SuppressLint;
 import android.annotation.TargetApi;
 import android.app.Activity;
-import android.app.AlertDialog;
 import android.app.AppOpsManager;
 import android.app.PendingIntent;
 import android.app.PictureInPictureParams;
@@ -91,6 +90,7 @@ import android.window.OnBackInvokedDispatcher;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.RequiresApi;
+import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.app.AppCompatDelegate;
 import androidx.coordinatorlayout.widget.CoordinatorLayout;
 import androidx.core.content.ContextCompat;
@@ -174,6 +174,7 @@ import com.bumptech.glide.load.DataSource;
 import com.bumptech.glide.load.engine.GlideException;
 import com.bumptech.glide.request.RequestListener;
 import com.bumptech.glide.request.target.Target;
+import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 import com.google.android.material.snackbar.Snackbar;
 
 import org.json.JSONObject;
@@ -7600,7 +7601,7 @@ public class PlayerActivity extends Activity {
         fields.addView(scroll, new LinearLayout.LayoutParams(
                 ViewGroup.LayoutParams.MATCH_PARENT, listHeight));
 
-        final AlertDialog dialog = new AlertDialog.Builder(this)
+        final AlertDialog dialog = new MaterialAlertDialogBuilder(this)
                 .setTitle(R.string.subtitle_search_manual)
                 .setView(fields)
                 .setNegativeButton(android.R.string.cancel, null)
@@ -7793,7 +7794,7 @@ public class PlayerActivity extends Activity {
         fields.addView(fieldLabel(R.string.subtitle_search_episode_label));
         fields.addView(episode);
 
-        new AlertDialog.Builder(this)
+        new MaterialAlertDialogBuilder(this)
                 .setTitle(R.string.subtitle_search_type)
                 .setView(fields)
                 .setPositiveButton(android.R.string.ok, (dialog, which) -> applyManualTitle(title,
@@ -9090,7 +9091,7 @@ public class PlayerActivity extends Activity {
         // not exist.
         input.setText(mPrefs.togetherPassword);
         input.setSelection(input.getText().length());
-        new AlertDialog.Builder(this)
+        new MaterialAlertDialogBuilder(this)
                 .setTitle(code)
                 .setView(input)
                 .setPositiveButton(android.R.string.ok,
@@ -9152,7 +9153,7 @@ public class PlayerActivity extends Activity {
         fields.addView(listed);
         fields.addView(note);
 
-        final AlertDialog dialog = new AlertDialog.Builder(this)
+        final AlertDialog dialog = new MaterialAlertDialogBuilder(this)
                 .setTitle(getString(R.string.together_create_title, code))
                 .setView(fields)
                 .setPositiveButton(android.R.string.ok, (d, which) -> {
@@ -9227,7 +9228,7 @@ public class PlayerActivity extends Activity {
         fields.addView(code);
         fields.addView(password);
 
-        new AlertDialog.Builder(this)
+        new MaterialAlertDialogBuilder(this)
                 .setTitle(R.string.together_join)
                 .setView(fields)
                 .setPositiveButton(android.R.string.ok, (dialog, which) -> {
@@ -9480,7 +9481,7 @@ public class PlayerActivity extends Activity {
         image.setAdjustViewBounds(true);
         final int padding = Math.round(16 * metrics.density);
         image.setPadding(padding, padding, padding, padding);
-        new AlertDialog.Builder(this)
+        new MaterialAlertDialogBuilder(this)
                 .setTitle(getString(R.string.together_qr_title, together.code()))
                 .setMessage(getString(R.string.together_qr_hint))
                 .setView(image)
@@ -13293,7 +13294,7 @@ public class PlayerActivity extends Activity {
         // On TV the Snackbar action button is not reachable with the D-pad, so the "Details" affordance
         // would be lost. Present the error as an AlertDialog instead — its buttons are D-pad focusable.
         if (isTvBox) {
-            final AlertDialog.Builder builder = new AlertDialog.Builder(this);
+            final AlertDialog.Builder builder = new MaterialAlertDialogBuilder(this);
             builder.setMessage(textPrimary);
             builder.setPositiveButton(android.R.string.ok, (dialogInterface, i) -> dialogInterface.dismiss());
             if (textSecondary != null) {
@@ -13496,7 +13497,7 @@ public class PlayerActivity extends Activity {
     }
 
     void askForScope(boolean loadSubtitlesOnCancel, boolean skipToNextOnCancel) {
-        final AlertDialog.Builder builder = new AlertDialog.Builder(PlayerActivity.this);
+        final AlertDialog.Builder builder = new MaterialAlertDialogBuilder(PlayerActivity.this);
         builder.setMessage(String.format(getString(R.string.request_scope), getString(R.string.app_name)));
         builder.setPositiveButton(android.R.string.ok, (dialogInterface, i) -> requestDirectoryAccess()
         );
@@ -13817,7 +13818,7 @@ public class PlayerActivity extends Activity {
     }
 
     void askDeleteMedia() {
-        final AlertDialog.Builder builder = new AlertDialog.Builder(PlayerActivity.this);
+        final AlertDialog.Builder builder = new MaterialAlertDialogBuilder(PlayerActivity.this);
         builder.setMessage(getString(R.string.delete_query));
         builder.setPositiveButton(R.string.delete_confirmation, (dialogInterface, i) -> {
             releasePlayer();
@@ -14020,7 +14021,7 @@ public class PlayerActivity extends Activity {
             if (isCurrentAspectMode(modes.get(i)))
                 checked = i;
         }
-        final AlertDialog dialog = new AlertDialog.Builder(this)
+        final AlertDialog dialog = new MaterialAlertDialogBuilder(this)
                 .setTitle(R.string.button_crop)
                 .setSingleChoiceItems(labels, checked, (d, which) -> {
                     applyAspectMode(which);

--- a/app/src/main/java/com/brouken/player/SettingsActivity.java
+++ b/app/src/main/java/com/brouken/player/SettingsActivity.java
@@ -23,6 +23,7 @@ import android.widget.Toast;
 
 import androidx.appcompat.app.ActionBar;
 import androidx.core.view.OneShotPreDrawListener;
+import androidx.core.view.WindowCompat;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.preference.ListPreference;
 import androidx.preference.Preference;
@@ -68,19 +69,16 @@ public class SettingsActivity extends AppCompatActivity
                     View.SYSTEM_UI_FLAG_LAYOUT_STABLE | View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION
             );
             getWindow().setNavigationBarColor(Color.TRANSPARENT);
-
-            if (Build.VERSION.SDK_INT >= 35) {
-                int nightModeFlags = getResources().getConfiguration().uiMode & Configuration.UI_MODE_NIGHT_MASK;
-
-                if (nightModeFlags == Configuration.UI_MODE_NIGHT_YES) {
-                    getWindow().getDecorView().setSystemUiVisibility(0);
-                } else if (nightModeFlags == Configuration.UI_MODE_NIGHT_NO) {
-                    getWindow().getDecorView().setSystemUiVisibility(View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR);
-                }
-            }
         }
 
         super.onCreate(savedInstanceState);
+
+        // The status bar takes the window's own surface colour (see Theme.Settings), so its icons have to
+        // follow the theme in force instead of staying light. This sets only the light-icon bit, and on
+        // every SDK — the block above replaces the whole flag set, which is why it cannot do this too.
+        final int night = getResources().getConfiguration().uiMode & Configuration.UI_MODE_NIGHT_MASK;
+        WindowCompat.getInsetsController(getWindow(), getWindow().getDecorView())
+                .setAppearanceLightStatusBars(night != Configuration.UI_MODE_NIGHT_YES);
 
         setContentView(R.layout.settings_activity);
         if (savedInstanceState == null) {

--- a/app/src/main/java/com/brouken/player/update/UpdateUi.java
+++ b/app/src/main/java/com/brouken/player/update/UpdateUi.java
@@ -1,7 +1,6 @@
 package com.brouken.player.update;
 
 import android.app.Activity;
-import android.app.AlertDialog;
 import android.graphics.Typeface;
 import android.text.SpannableStringBuilder;
 import android.text.Spanned;
@@ -13,8 +12,11 @@ import android.widget.ScrollView;
 import android.widget.TextView;
 import android.widget.Toast;
 
+import androidx.appcompat.app.AlertDialog;
+
 import com.brouken.player.BuildConfig;
 import com.brouken.player.R;
+import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 
 /**
  * Shared, Activity-agnostic UI for the self-updater: the "update available" dialog and the
@@ -56,7 +58,7 @@ public final class UpdateUi {
         scroll.setPadding(padH, dp(activity, 8), padH, 0);
         scroll.addView(message);
 
-        final AlertDialog.Builder builder = new AlertDialog.Builder(activity)
+        final AlertDialog.Builder builder = new MaterialAlertDialogBuilder(activity)
                 .setTitle(R.string.pref_update_header)
                 .setView(scroll)
                 .setPositiveButton(R.string.update_now, (dialog, which) -> startDownload(activity, info))
@@ -86,7 +88,7 @@ public final class UpdateUi {
         // dismiss it — so the cancel action reaches it through this holder. Nothing can read it before it
         // is assigned: show() only posts, and the assignment happens before this returns to the looper.
         final Thread[] download = new Thread[1];
-        final AlertDialog dialog = new AlertDialog.Builder(activity)
+        final AlertDialog dialog = new MaterialAlertDialogBuilder(activity)
                 .setTitle(R.string.update_downloading)
                 .setView(layout)
                 // Without this the dialog had no way out at all: a download that stalls without failing

--- a/app/src/main/res/drawable/bg_dialog_material3.xml
+++ b/app/src/main/res/drawable/bg_dialog_material3.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- The container MaterialAlertDialogBuilder builds in code, as a drawable a plain AlertDialog can
+     use: extra-large corners on the M3 dialog surface. The inset is appcompat's own, so the window
+     keeps the margin its layout already assumes. -->
+<inset xmlns:android="http://schemas.android.com/apk/res/android"
+    android:insetLeft="@dimen/appcompat_dialog_background_inset"
+    android:insetTop="@dimen/appcompat_dialog_background_inset"
+    android:insetRight="@dimen/appcompat_dialog_background_inset"
+    android:insetBottom="@dimen/appcompat_dialog_background_inset">
+    <shape android:shape="rectangle">
+        <corners android:radius="28dp" />
+        <solid android:color="?attr/colorSurfaceContainerHigh" />
+    </shape>
+</inset>

--- a/app/src/main/res/values-notouch/themes.xml
+++ b/app/src/main/res/values-notouch/themes.xml
@@ -2,4 +2,11 @@
     <style name="Theme.Player" parent="BaseTheme.Player">
         <item name="colorControlHighlight">@color/white</item>
     </style>
+
+    <!-- The error screen's action buttons ride on selectableItemBackgroundBorderless, so their focus
+         wash is whatever the theme highlight happens to be. On a remote it has to be the same white the
+         player uses. -->
+    <style name="Theme.Error" parent="BaseTheme.Error">
+        <item name="colorControlHighlight">@color/white</item>
+    </style>
 </resources>

--- a/app/src/main/res/values-television/themes.xml
+++ b/app/src/main/res/values-television/themes.xml
@@ -2,4 +2,11 @@
     <style name="Theme.Player" parent="BaseTheme.Player">
         <item name="colorControlHighlight">@color/white</item>
     </style>
+
+    <!-- The error screen's action buttons ride on selectableItemBackgroundBorderless, so their focus
+         wash is whatever the theme highlight happens to be. On a remote it has to be the same white the
+         player uses. -->
+    <style name="Theme.Error" parent="BaseTheme.Error">
+        <item name="colorControlHighlight">@color/white</item>
+    </style>
 </resources>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -6,6 +6,11 @@
     <!-- The mark's ramp (see design/just+.svg); the vector drawables carry these same two stops. -->
     <color name="brand_ramp_start">#FFFF6E3C</color>
     <color name="brand_ramp_end">#FFFF0D63</color>
+    <!-- M3 primary container (switch track when on, tonal surfaces): the brand at container tone.
+         One value for both day and night — a deep coral reads on white and on the dark settings list alike. -->
+    <color name="brand_container">#FF7A2019</color>
+    <!-- M3 on-primary: the ink that sits on the brand, e.g. the switch handle when it is on. -->
+    <color name="brand_on">#FF5F1411</color>
     <color name="shortcut_background">#F5F5F5</color>
 
     <!-- Error screen (ErrorActivity): a calm dark surface, not an alarming full-red state. -->

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -1,6 +1,6 @@
 <resources xmlns:tools="http://schemas.android.com/tools">
 
-    <style name="BaseTheme.Player" parent="Theme.AppCompat.NoActionBar">
+    <style name="BaseTheme.Player" parent="Theme.Material3.Dark.NoActionBar">
         <!-- Transparent so the OS-toggled status bar doesn't paint its own @color/ui_controls_background strip,
              which desyncs from the controller fade. The controller-synced exo_top scrim (given a height on all
              SDKs in PlayerActivity's insets listener) provides the darkening behind the status-bar icons. -->
@@ -9,6 +9,9 @@
         <item name="android:windowBackground">@color/black</item>
         <item name="android:windowLayoutInDisplayCutoutMode" tools:ignore="NewApi">shortEdges</item>
         <item name="android:forceDarkAllowed" tools:targetApi="29">false</item>
+        <item name="colorPrimary">@color/brand</item>
+        <item name="colorPrimaryContainer">@color/brand_container</item>
+        <item name="colorOnPrimary">@color/brand_on</item>
         <item name="colorAccent">@color/brand</item>
         <item name="android:colorControlActivated">@color/brand</item>
     </style>
@@ -27,21 +30,47 @@
         <item name="android:focusable">true</item>
     </style>
 
-    <style name="Theme.Error" parent="Theme.AppCompat.NoActionBar">
+    <style name="BaseTheme.Error" parent="Theme.Material3.Dark.NoActionBar">
         <!-- The wash is the window background, not the layout's, so the one gradient covers the
              system bars too — a bar painted in a flat colour would cut a seam across it. -->
         <item name="android:windowBackground">@drawable/bg_brand_wash</item>
         <item name="android:statusBarColor">@android:color/transparent</item>
         <item name="android:navigationBarColor">@android:color/transparent</item>
         <item name="android:forceDarkAllowed" tools:targetApi="29">false</item>
+        <item name="colorPrimary">@color/brand</item>
+        <item name="colorPrimaryContainer">@color/brand_container</item>
+        <item name="colorOnPrimary">@color/brand_on</item>
         <item name="colorAccent">@color/brand</item>
         <item name="android:colorControlActivated">@color/brand</item>
     </style>
 
-    <style name="Theme.Settings" parent="Theme.AppCompat.DayNight.NoActionBar">
+    <!-- Split like Theme.Player, so values-television and values-notouch can give the error screen the
+         same white focus highlight the player already gets there. -->
+    <style name="Theme.Error" parent="BaseTheme.Error">
+    </style>
+
+    <style name="Theme.Settings" parent="Theme.Material3.DayNight.NoActionBar">
+        <item name="alertDialogTheme">@style/ThemeOverlay.JustPlus.AlertDialog</item>
+        <!-- One field with the list below it. Left unset, a Material theme paints the bar from the
+             primary colour, which with a coral primary is a red band across the top of the screen.
+             SettingsActivity sets the icon appearance to match. -->
+        <item name="android:statusBarColor">?attr/colorSurface</item>
+        <item name="colorPrimary">@color/brand</item>
+        <item name="colorPrimaryContainer">@color/brand_container</item>
+        <item name="colorOnPrimary">@color/brand_on</item>
         <item name="colorAccent">@color/brand</item>
         <item name="colorControlActivated">@color/brand</item>
         <item name="android:colorControlActivated">@color/brand</item>
+    </style>
+
+    <!-- androidx.preference builds its list and text dialogs with a plain AlertDialog.Builder, so they
+         get none of what MaterialAlertDialogBuilder applies in code: an AppCompat row with the radio
+         parked on the right, in a square container. Hand it the Material pieces through the theme.
+         The parent must be ThemeOverlay.Material3.MaterialAlertDialog — ThemeOverlay.Material3.Dialog.Alert
+         sets only the button style, and m3_alert_dialog_title.xml needs materialAlertDialogTitlePanelStyle,
+         without which the first preference dialog to open throws InflateException. -->
+    <style name="ThemeOverlay.JustPlus.AlertDialog" parent="ThemeOverlay.Material3.MaterialAlertDialog">
+        <item name="android:windowBackground">@drawable/bg_dialog_material3</item>
     </style>
 
     <style name="ExoStyledControls.Button.Center.Secondary" parent="ExoStyledControls.Button.Center">
@@ -50,7 +79,10 @@
         <item name="android:visibility">gone</item>
     </style>
 
-    <style name="Transparent" parent="@android:style/Theme.Material.NoActionBar">
+    <!-- MediaStoreChooserActivity has no content view — it only shows dialogs. The parent is a Material
+         one so that the context those dialogs are built against resolves the attributes
+         MaterialAlertDialogBuilder reads from it (materialAlertDialogTheme among them). -->
+    <style name="Transparent" parent="Theme.Material3.Dark.NoActionBar">
         <item name="android:windowIsTranslucent">true</item>
         <item name="android:windowBackground">@android:color/transparent</item>
         <item name="android:windowContentOverlay">@null</item>
@@ -59,7 +91,7 @@
         <item name="android:backgroundDimEnabled">false</item>
     </style>
 
-    <style name="MediaStoreChooserDialog" parent="@android:style/Theme.Material.Dialog.Alert">
+    <style name="MediaStoreChooserDialog" parent="Theme.Material3.Dark.Dialog.Alert">
         <item name="android:maxLines">1</item>
         <item name="android:ellipsize">end</item>
         <item name="android:singleLine">true</item> <!-- When focused, line scrolls -->


### PR DESCRIPTION
Part of the Material UI series, into `feature/material-ui`.

Material 1.12.0 has been a dependency all along and doing nothing — every theme inherited from `Theme.AppCompat`, so no Material component could resolve its attributes. Swapping the four theme parents is the whole unlock.

### What changes

- `BaseTheme.Player` and `BaseTheme.Error` → `Theme.Material3.Dark.NoActionBar`; `Theme.Settings` → `Theme.Material3.DayNight.NoActionBar`; `MediaStoreChooserDialog` → `Theme.Material3.Dark.Dialog.Alert`.
- The coral is `colorPrimary`. Two roles it leaks through get their own values: `colorPrimaryContainer` is the switch track when on, `colorOnPrimary` its handle. `colorSecondaryContainer` and the whole surface ramp stay at the library default on purpose — neutral, and they follow light and dark for free.
- All 18 `AlertDialog.Builder` call sites become `MaterialAlertDialogBuilder`.
- `ThemeOverlay.JustPlus.AlertDialog` + `bg_dialog_material3.xml` — the only way into the dialogs `androidx.preference` builds for itself, since it uses a plain `AlertDialog.Builder` with no hook. Its parent has to be `ThemeOverlay.Material3.MaterialAlertDialog`; the `Dialog.Alert` overlay leaves out the title-panel style the M3 title layout needs and throws `InflateException` the moment a list preference opens.

### Three things this had to fix beyond the swap

1. **The settings status bar.** Left unset, a Material theme paints it from the primary colour, so a coral primary put a red band across the top of the screen. It now takes `colorSurface`, and the icon appearance follows the theme in force — on every SDK, replacing a block that only did it on 35+ and by overwriting the whole system-UI flag set.
2. **`Theme.Error` splits into a base and an override**, the way `Theme.Player` already does, so `values-television` and `values-notouch` can give the error screen the same white focus highlight they give the player. Its action buttons ride on `selectableItemBackgroundBorderless`, so without that the remote's highlight was whatever the theme happened to supply.
3. **`Transparent`**, the chooser activity's theme, was a framework theme that resolves no Material attribute at all — and `MaterialAlertDialogBuilder` reads several from the context it is handed.

Nothing in the player chrome needed a colour added: every text view there already sets one explicitly, which is exactly what the two previous commits guaranteed.

### Checked on a phone emulator

- A real `ListPreference` dialog opened (via a temporary posted `performClick()` probe, removed before committing): no `InflateException`, M3 container with 28dp corners, radio on the left, coral selection and coral text button.
- Settings in light **and** dark: status bar is the surface in both, icons legible in both, coral section headers, switch track `brand_container` with a coral handle when on.
- Player chrome and the error screen render, log clean.

One ANR appeared during testing and was chased down to the test rig — `adb root` restarting adbd while an activity was being stacked on a live `PlayerActivity`. Zero ANRs on a clean run.