### PR TITLE
Group the settings list into cards, and give it a Material toolbar

### DIFF
--- a/app/src/main/java/com/brouken/player/SettingsActivity.java
+++ b/app/src/main/java/com/brouken/player/SettingsActivity.java
@@ -4,21 +4,28 @@ import android.content.Context;
 import android.content.res.Configuration;
 import android.graphics.Canvas;
 import android.graphics.Color;
+import android.graphics.Outline;
 import android.graphics.Paint;
+import android.graphics.Rect;
+import android.graphics.RectF;
 import android.graphics.drawable.Drawable;
 import android.graphics.drawable.GradientDrawable;
+import android.text.Layout;
 import android.text.SpannableStringBuilder;
 import android.text.Spanned;
 import android.text.style.ImageSpan;
 import android.os.Build;
 import android.os.Bundle;
+import android.text.StaticLayout;
 import android.text.TextUtils;
 import android.view.View;
+import android.view.ViewOutlineProvider;
 import android.widget.LinearLayout;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import android.app.Activity;
+import android.widget.TextView;
 import android.widget.Toast;
 
 import androidx.appcompat.app.ActionBar;
@@ -30,10 +37,16 @@ import androidx.preference.Preference;
 import androidx.preference.PreferenceCategory;
 import androidx.preference.PreferenceFragmentCompat;
 import androidx.preference.PreferenceGroup;
+import androidx.preference.PreferenceGroupAdapter;
 import androidx.preference.PreferenceScreen;
+import androidx.preference.PreferenceViewHolder;
 import androidx.preference.SwitchPreferenceCompat;
+import androidx.preference.TwoStatePreference;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
+import androidx.recyclerview.widget.SimpleItemAnimator;
+
+import com.google.android.material.color.MaterialColors;
 
 import com.brouken.player.together.AliasGenerator;
 import com.brouken.player.together.Relay;
@@ -87,6 +100,7 @@ public class SettingsActivity extends AppCompatActivity
                     .replace(R.id.settings, new SettingsFragment())
                     .commit();
         }
+        setSupportActionBar(findViewById(R.id.toolbar));
         ActionBar actionBar = getSupportActionBar();
         if (actionBar != null) {
             actionBar.setDisplayHomeAsUpEnabled(true);
@@ -413,6 +427,83 @@ public class SettingsActivity extends AppCompatActivity
             }
         }
 
+        /**
+         * Rows are corner-clipped to the card they sit in, so a ripple — and the focus highlight a
+         * D-pad leaves on TV — stops at the rounded corner instead of squaring it off.
+         */
+        @Override
+        protected RecyclerView.Adapter onCreateAdapter(@NonNull PreferenceScreen preferenceScreen) {
+            return new PreferenceGroupAdapter(preferenceScreen) {
+                @Override
+                public void onBindViewHolder(@NonNull PreferenceViewHolder holder, int position) {
+                    super.onBindViewHolder(holder, position);
+                    GroupCards.clip(this, holder.itemView, position);
+                    final TextView title = (TextView) holder.findViewById(android.R.id.title);
+                    if (title != null) {
+                        // The library's row keeps the title on one line and marquees the overflow,
+                        // which on a phone just clips it ("Allow system to adjust refres.."), and the
+                        // card's side insets make the line shorter still. Let it wrap instead.
+                        title.setSingleLine(false);
+                        title.setEllipsize(null);
+                    }
+                    reserveTallerSummary(holder, getItem(position));
+                }
+            };
+        }
+
+        /**
+         * A switch whose summaryOn and summaryOff wrap to a different number of lines makes its row —
+         * and everything below it — jump the moment it is toggled. Reserve the taller of the two up
+         * front, so flipping the switch only changes the words.
+         */
+        private static void reserveTallerSummary(final PreferenceViewHolder holder,
+                                                 final Preference preference) {
+            final View view = holder.findViewById(android.R.id.summary);
+            if (!(view instanceof TextView)) {
+                return;
+            }
+            final TextView summary = (TextView) view;
+            final CharSequence on = preference instanceof TwoStatePreference
+                    ? ((TwoStatePreference) preference).getSummaryOn() : null;
+            final CharSequence off = preference instanceof TwoStatePreference
+                    ? ((TwoStatePreference) preference).getSummaryOff() : null;
+            if (on == null || off == null || on.toString().equals(off.toString())) {
+                summary.setMinLines(0);
+                return;
+            }
+            // Straight away where the row already has a width — a re-bind after the switch was flipped
+            // does — because clearing the reservation and restoring it before the draw is itself the
+            // jump this is here to prevent.
+            applyTallerSummary(summary, on, off);
+            // A holder bound for the first time has no width yet, but it has one before the draw.
+            OneShotPreDrawListener.add(summary, () -> applyTallerSummary(summary, on, off));
+        }
+
+        private static void applyTallerSummary(final TextView summary, final CharSequence on,
+                                               final CharSequence off) {
+            // The summary is laid out wrap_content, so its own width is the width of whichever text it
+            // happens to hold — measuring the other one against that is what reserved a line for rows
+            // where both fit on one. The room either text may wrap into is the column it sits in.
+            if (!(summary.getParent() instanceof View)) {
+                return;
+            }
+            final View column = (View) summary.getParent();
+            final int width = column.getWidth() - column.getPaddingLeft() - column.getPaddingRight()
+                    - summary.getPaddingLeft() - summary.getPaddingRight();
+            if (width <= 0) {
+                return;
+            }
+            final int lines = Math.max(lineCount(summary, on, width), lineCount(summary, off, width));
+            if (summary.getMinLines() != lines) {
+                summary.setMinLines(lines);
+            }
+        }
+
+        private static int lineCount(final TextView view, final CharSequence text, final int width) {
+            return new StaticLayout(text, view.getPaint(), width, Layout.Alignment.ALIGN_NORMAL,
+                    view.getLineSpacingMultiplier(), view.getLineSpacingExtra(), false).getLineCount();
+        }
+
         // A D-pad can only reach a row that is laid out, and when focus search fails
         // LinearLayoutManager extends the layout by a third of a screen and looks again — which is
         // not past a run of unfocusable rows: the group a switched-off "dependency" disables, or the
@@ -431,6 +522,20 @@ public class SettingsActivity extends AppCompatActivity
         @Override
         public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
             super.onViewCreated(view, savedInstanceState);
+            final RecyclerView cardList = getListView();
+            if (cardList != null) {
+                // The card's own hairlines replace the list's full-width dividers, which would cut
+                // across the card edges.
+                setDivider(null);
+                setDividerHeight(0);
+                cardList.addItemDecoration(new GroupCards(cardList.getContext()));
+                // Toggling a switch re-binds its row, and cross-fading the old text over the new one
+                // reads as a flicker in a list that is otherwise still.
+                if (cardList.getItemAnimator() instanceof SimpleItemAnimator) {
+                    ((SimpleItemAnimator) cardList.getItemAnimator())
+                            .setSupportsChangeAnimations(false);
+                }
+            }
             if (Build.VERSION.SDK_INT >= 29) {
                 recyclerView = getListView();
             }
@@ -733,4 +838,140 @@ public class SettingsActivity extends AppCompatActivity
         }
 
         }
+
+    /**
+     * Groups the list the way a Material settings screen is grouped: every run of rows under one
+     * category is one rounded card, inset from the edges, with a hairline between its rows.
+     *
+     * Drawn behind the rows instead of being set as their background, so each row keeps the ripple
+     * and the D-pad focus highlight that androidx.preference gives it — replacing the background is
+     * what costs a TV remote its focus indicator.
+     */
+    private static final class GroupCards extends RecyclerView.ItemDecoration {
+
+        private static final int RADIUS = Utils.dpToPx(20);
+        private final int inset = Utils.dpToPx(16);
+        private final int headerGap = Utils.dpToPx(8);
+        private final int hairlineInset = Utils.dpToPx(16);
+        private final Paint card = new Paint(Paint.ANTI_ALIAS_FLAG);
+        private final Paint hairline = new Paint(Paint.ANTI_ALIAS_FLAG);
+        private final RectF bounds = new RectF();
+
+        GroupCards(final Context context) {
+            card.setColor(MaterialColors.getColor(context, R.attr.colorSurfaceContainer, Color.DKGRAY));
+            hairline.setColor(MaterialColors.getColor(context, R.attr.colorOutlineVariant, Color.GRAY));
+            hairline.setStrokeWidth(Utils.dpToPx(1));
+        }
+
+        @Override
+        public void getItemOffsets(@NonNull Rect outRect, @NonNull View view,
+                                   @NonNull RecyclerView parent, @NonNull RecyclerView.State state) {
+            outRect.left = inset;
+            outRect.right = inset;
+            // The header sits above its card, not against the one before it.
+            if (isCategory(parent, parent.getChildAdapterPosition(view))) {
+                outRect.top = headerGap;
+            }
+        }
+
+        @Override
+        public void onDraw(@NonNull Canvas canvas, @NonNull RecyclerView parent,
+                           @NonNull RecyclerView.State state) {
+            final int count = parent.getChildCount();
+            int i = 0;
+            while (i < count) {
+                final View first = parent.getChildAt(i);
+                final int firstPosition = parent.getChildAdapterPosition(first);
+                if (firstPosition == RecyclerView.NO_POSITION || isCategory(parent, firstPosition)) {
+                    i++;
+                    continue;
+                }
+                // Collect the rest of this card: everything up to the next header or the last row on screen.
+                int last = i;
+                while (last + 1 < count) {
+                    final int next = parent.getChildAdapterPosition(parent.getChildAt(last + 1));
+                    if (next == RecyclerView.NO_POSITION || isCategory(parent, next)) {
+                        break;
+                    }
+                    last++;
+                }
+                final View lastView = parent.getChildAt(last);
+                float top = first.getTop();
+                float bottom = lastView.getBottom();
+                // A card scrolled off either edge keeps its corners out of sight, so it does not read
+                // as a card that ends where the viewport does.
+                if (!isCardTop(parent, firstPosition)) {
+                    top -= RADIUS * 2f;
+                }
+                if (!isCardBottom(parent, parent.getChildAdapterPosition(lastView))) {
+                    bottom += RADIUS * 2f;
+                }
+                bounds.set(first.getLeft(), top, first.getRight(), bottom);
+                canvas.drawRoundRect(bounds, RADIUS, RADIUS, card);
+                i = last + 1;
+            }
+        }
+
+        /**
+         * The hairlines go on top of the rows, not under them: a pressed or focused row paints a state
+         * layer over its whole height, and a divider drawn beneath it would vanish for as long as the
+         * touch lasts.
+         */
+        @Override
+        public void onDrawOver(@NonNull Canvas canvas, @NonNull RecyclerView parent,
+                               @NonNull RecyclerView.State state) {
+            for (int i = 0; i < parent.getChildCount(); i++) {
+                final View row = parent.getChildAt(i);
+                final int position = parent.getChildAdapterPosition(row);
+                if (position == RecyclerView.NO_POSITION || isCategory(parent, position)
+                        || isCardBottom(parent, position)) {
+                    continue;
+                }
+                final float y = row.getBottom();
+                canvas.drawLine(row.getLeft() + hairlineInset, y,
+                        row.getRight() - hairlineInset, y, hairline);
+            }
+        }
+
+        /** Corner-clips one row to its card: rounded at the card's ends, square inside it. */
+        static void clip(final PreferenceGroupAdapter adapter, final View row, final int position) {
+            if (adapter.getItem(position) instanceof PreferenceCategory) {
+                row.setClipToOutline(false);
+                row.setOutlineProvider(ViewOutlineProvider.BACKGROUND);
+                return;
+            }
+            final boolean top = position == 0
+                    || adapter.getItem(position - 1) instanceof PreferenceCategory;
+            final boolean bottom = position == adapter.getItemCount() - 1
+                    || adapter.getItem(position + 1) instanceof PreferenceCategory;
+            row.setOutlineProvider(new ViewOutlineProvider() {
+                @Override
+                public void getOutline(final View view, final Outline outline) {
+                    // An outline carries one radius for all four corners, so the end that has to stay
+                    // square is pushed a radius beyond the row rather than rounded.
+                    outline.setRoundRect(0, top ? 0 : -RADIUS, view.getWidth(),
+                            view.getHeight() + (bottom ? 0 : RADIUS), RADIUS);
+                }
+            });
+            row.setClipToOutline(true);
+        }
+
+        private static boolean isCardTop(final RecyclerView parent, final int position) {
+            return position == 0 || isCategory(parent, position - 1);
+        }
+
+        private static boolean isCardBottom(final RecyclerView parent, final int position) {
+            final RecyclerView.Adapter<?> adapter = parent.getAdapter();
+            return adapter == null || position == adapter.getItemCount() - 1
+                    || isCategory(parent, position + 1);
+        }
+
+        private static boolean isCategory(final RecyclerView parent, final int position) {
+            final RecyclerView.Adapter<?> adapter = parent.getAdapter();
+            if (position == RecyclerView.NO_POSITION || !(adapter instanceof PreferenceGroupAdapter)) {
+                return false;
+            }
+            return ((PreferenceGroupAdapter) adapter).getItem(position) instanceof PreferenceCategory;
+        }
+    }
 }

--- a/app/src/main/res/layout/preference_widget_switch_compat.xml
+++ b/app/src/main/res/layout/preference_widget_switch_compat.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Overrides androidx.preference's own copy, which inflates a SwitchCompat: that is the pre-M3
+     switch — a narrow track with a small thumb hanging over its edges. MaterialSwitch is the Material 3
+     one, and being a SwitchCompat subclass it keeps the id and the binding the library expects. -->
+<com.google.android.material.materialswitch.MaterialSwitch
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/switchWidget"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:focusable="false"
+    android:clickable="false"
+    android:background="@null" />

--- a/app/src/main/res/layout/settings_activity.xml
+++ b/app/src/main/res/layout/settings_activity.xml
@@ -1,7 +1,14 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:id="@+id/settings_layout"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:orientation="vertical">
+
+    <com.google.android.material.appbar.MaterialToolbar
+        android:id="@+id/toolbar"
+        android:layout_width="match_parent"
+        android:layout_height="?attr/actionBarSize"
+        android:background="?attr/colorSurface" />
 
     <FrameLayout
         android:id="@+id/settings"


### PR DESCRIPTION
Part of the Material UI series, into `feature/material-ui`.

The settings screen was a flat run of rows under text headers — what `androidx.preference` draws by default, and not what a settings screen has looked like for some years. Every run of rows under one category is now one rounded card, inset from the edges, with a hairline between its rows; the switches are the Material 3 ones; the title bar is a `MaterialToolbar` rather than nothing at all; and row titles wrap instead of being clipped mid-word.

### Three decisions that are less obvious than they look

**Cards are drawn behind the rows**, by a `RecyclerView.ItemDecoration` — not set as row backgrounds. Replacing a row's background is what costs a TV remote its focus indicator and a finger its ripple, and both matter more than the shape does. Rows are corner-clipped instead, so a ripple stops at the card's rounded end; since an `Outline` carries one radius for all four corners, the end that must stay square is pushed a radius *outside* the row rather than rounded. Hairlines are drawn **over** the rows, because a pressed row paints a state layer across its whole height and would swallow a divider drawn beneath it. A card running past the top or bottom of the viewport pushes its corners out of sight, so it does not read as ending where the screen does.

**`MaterialSwitch` arrives by resource-name override** — `layout/preference_widget_switch_compat.xml` shadows `androidx.preference`'s own copy. That works only because `MaterialSwitch extends SwitchCompat`, so the id and the binding the library performs on it still resolve. No code changes hands.

**Summary height is reserved up front.** A switch whose `summaryOn` and `summaryOff` wrap to a different number of lines made its row — and everything below it — jump on every toggle. The measurement is against the *parent column*, not the summary's own width: the summary is `wrap_content`, so its width is the width of whatever text it holds right now, and measuring the other string against that reserved a line for rows where both fit on one. Applied synchronously when the row already has a width, because clearing the reservation and restoring it before the draw is itself the jump it is meant to prevent.

### Checked on a phone emulator

Light and dark: cards read as cards in both (`colorSurfaceContainer` against the window, `colorOutlineVariant` hairlines), toolbar with a back arrow, coral section headers, `MaterialSwitch` in its M3 shape with the coral on-state, long titles wrapping to three lines inside the card.

Not in here: the theme choice and AMOLED black — that is a feature rather than a restyle, and it comes next.