### PR TITLE
Let the settings screen be dark, light or whatever the system says

### DIFF
--- a/app/src/main/java/com/brouken/player/EmptyState.java
+++ b/app/src/main/java/com/brouken/player/EmptyState.java
@@ -219,7 +219,8 @@ class EmptyState {
     // usual way one arrives here, and the only bearable one with a TV remote. Also offered by the gear
     // menu, which is why this is not private.
     void askForLink() {
-        final EditText input = new EditText(activity);
+        final Context dialogContext = Utils.dialogContext(activity);
+        final EditText input = new EditText(dialogContext);
         input.setInputType(InputType.TYPE_TEXT_VARIATION_URI);
         input.setSingleLine(true);
         input.setHint("https://");
@@ -228,7 +229,7 @@ class EmptyState {
             input.setText(pasted.toString());
             input.setSelection(input.getText().length());
         }
-        new MaterialAlertDialogBuilder(activity)
+        new MaterialAlertDialogBuilder(dialogContext)
                 .setTitle(R.string.empty_state_link)
                 .setView(input)
                 .setPositiveButton(android.R.string.ok,

--- a/app/src/main/java/com/brouken/player/MediaStoreChooserActivity.java
+++ b/app/src/main/java/com/brouken/player/MediaStoreChooserActivity.java
@@ -151,10 +151,10 @@ public class MediaStoreChooserActivity extends Activity {
         if (buckets.size() == 0) {
             // Same theme as the populated branch: this activity's own theme carries no dialog style,
             // so without it the "no media" message would come out looking like a different app.
-            alertDialogBuilder = new MaterialAlertDialogBuilder(this, R.style.MediaStoreChooserDialog);
+            alertDialogBuilder = new MaterialAlertDialogBuilder(Utils.dialogContext(this), R.style.MediaStoreChooserDialog);
             alertDialogBuilder.setMessage(R.string.mediastore_empty);
         } else {
-            alertDialogBuilder = new MaterialAlertDialogBuilder(this, R.style.MediaStoreChooserDialog);
+            alertDialogBuilder = new MaterialAlertDialogBuilder(Utils.dialogContext(this), R.style.MediaStoreChooserDialog);
             alertDialogBuilder.setTitle(getString(R.string.choose_file));
             alertDialogBuilder.setItems(bucketDisplayNames, (dialogInterface, i) -> {
                 Intent intent = new Intent(MediaStoreChooserActivity.this, MediaStoreChooserActivity.class);
@@ -181,7 +181,7 @@ public class MediaStoreChooserActivity extends Activity {
         Integer[] ids = files.keySet().toArray(new Integer[0]);
         String[] displayNames = files.values().toArray(new String[0]);
 
-        AlertDialog.Builder alertDialogBuilder = new MaterialAlertDialogBuilder(this, R.style.MediaStoreChooserDialog);
+        AlertDialog.Builder alertDialogBuilder = new MaterialAlertDialogBuilder(Utils.dialogContext(this), R.style.MediaStoreChooserDialog);
         if (title != null) {
             alertDialogBuilder.setTitle(title);
         }

--- a/app/src/main/java/com/brouken/player/PlayerActivity.java
+++ b/app/src/main/java/com/brouken/player/PlayerActivity.java
@@ -1387,7 +1387,7 @@ public class PlayerActivity extends Activity {
         buttonUpdate.setOnClickListener(view -> {
             final UpdateInfo info = mPrefs.updatePending;
             if (info != null) {
-                UpdateUi.showAvailableDialog(this, info, skipUpdate(info),
+                UpdateUi.showAvailableDialog(this, Utils.dialogContext(this), info, skipUpdate(info),
                         player != null && player.isPlaying());
             }
         });
@@ -2389,7 +2389,8 @@ public class PlayerActivity extends Activity {
             if (haveMedia && player != null && player.isPlaying()) {
                 return;
             }
-            UpdateUi.showAvailableDialog(PlayerActivity.this, info, skipUpdate(info), false);
+            UpdateUi.showAvailableDialog(PlayerActivity.this,
+                    Utils.dialogContext(PlayerActivity.this), info, skipUpdate(info), false);
         }));
     }
 
@@ -7571,8 +7572,9 @@ public class PlayerActivity extends Activity {
      * finds has to go back where it was asked from.
      */
     private void showSubtitleSearchDialog(final boolean forSecondary) {
+        final Context dialogContext = Utils.dialogContext(this);
         subtitleSearchForSecondary = forSecondary;
-        final EditText query = new EditText(this);
+        final EditText query = new EditText(dialogContext);
         query.setInputType(InputType.TYPE_CLASS_TEXT);
         query.setSingleLine(true);
         query.setHint(R.string.subtitle_search_hint);
@@ -7583,12 +7585,12 @@ public class PlayerActivity extends Activity {
         // Deliberately not prefilled from the file name: reaching this dialog means the name is already
         // what failed, and clearing a line of release noise with a remote costs more than typing.
 
-        final LinearLayout results = new LinearLayout(this);
+        final LinearLayout results = new LinearLayout(dialogContext);
         results.setOrientation(LinearLayout.VERTICAL);
         final android.widget.ScrollView scroll = new android.widget.ScrollView(this);
         scroll.addView(results);
 
-        final LinearLayout fields = new LinearLayout(this);
+        final LinearLayout fields = new LinearLayout(dialogContext);
         fields.setOrientation(LinearLayout.VERTICAL);
         final int pad = Utils.dpToPx(16);
         fields.setPadding(pad, 0, pad, 0);
@@ -7601,7 +7603,7 @@ public class PlayerActivity extends Activity {
         fields.addView(scroll, new LinearLayout.LayoutParams(
                 ViewGroup.LayoutParams.MATCH_PARENT, listHeight));
 
-        final AlertDialog dialog = new MaterialAlertDialogBuilder(this)
+        final AlertDialog dialog = new MaterialAlertDialogBuilder(dialogContext)
                 .setTitle(R.string.subtitle_search_manual)
                 .setView(fields)
                 .setNegativeButton(android.R.string.cancel, null)
@@ -7766,35 +7768,36 @@ public class PlayerActivity extends Activity {
      * reads as an answerable question.
      */
     private void askSeasonEpisode(TitleSearch.Title title, List<TitleSearch.Episode> episodes) {
+        final Context dialogContext = Utils.dialogContext(this);
         final MediaId current = player != null ? mediaIdAt(player.getCurrentMediaItemIndex()) : null;
 
-        final EditText season = new EditText(this);
+        final EditText season = new EditText(dialogContext);
         season.setInputType(InputType.TYPE_CLASS_NUMBER);
         season.setSingleLine(true);
         if (current != null && current.season >= 0) {
             season.setText(String.valueOf(current.season));
         }
 
-        final EditText episode = new EditText(this);
+        final EditText episode = new EditText(dialogContext);
         episode.setInputType(InputType.TYPE_CLASS_NUMBER);
         episode.setSingleLine(true);
         if (current != null && current.episode >= 1) {
             episode.setText(String.valueOf(current.episode));
         }
 
-        final LinearLayout fields = new LinearLayout(this);
+        final LinearLayout fields = new LinearLayout(dialogContext);
         fields.setOrientation(LinearLayout.VERTICAL);
         final int pad = Utils.dpToPx(16);
         fields.setPadding(pad, 0, pad, 0);
         // Labelled above the fields, not only as hints: prefilling is the normal case here — the whole
         // point is to correct one digit of what is already believed — and a filled field shows no hint,
         // so both rows read as a bare "1" and "2" with nothing to say which is which.
-        fields.addView(fieldLabel(R.string.subtitle_search_season_label));
+        fields.addView(fieldLabel(dialogContext, R.string.subtitle_search_season_label));
         fields.addView(season);
-        fields.addView(fieldLabel(R.string.subtitle_search_episode_label));
+        fields.addView(fieldLabel(dialogContext, R.string.subtitle_search_episode_label));
         fields.addView(episode);
 
-        new MaterialAlertDialogBuilder(this)
+        new MaterialAlertDialogBuilder(dialogContext)
                 .setTitle(R.string.subtitle_search_type)
                 .setView(fields)
                 .setPositiveButton(android.R.string.ok, (dialog, which) -> applyManualTitle(title,
@@ -7805,8 +7808,8 @@ public class PlayerActivity extends Activity {
     }
 
     /** A caption over a text field, in the register the dialog's own hints use. */
-    private TextView fieldLabel(final int textRes) {
-        final TextView label = new TextView(this);
+    private TextView fieldLabel(final Context context, final int textRes) {
+        final TextView label = new TextView(context);
         label.setText(textRes);
         label.setTextSize(TypedValue.COMPLEX_UNIT_SP, ui.textCaption());
         label.setPadding(0, Utils.dpToPx(8), 0, 0);
@@ -7866,7 +7869,8 @@ public class PlayerActivity extends Activity {
         // Seeded from the priority list every time and never written back: the list is the standing
         // answer, and this is one search that wants a different one. Confirming it costs a press. Which
         // list it is seeded from follows the line the search was opened for.
-        LanguagePriorityDialog.show(this, getString(R.string.subtitle_search_language_title),
+        LanguagePriorityDialog.show(Utils.dialogContext(this),
+                getString(R.string.subtitle_search_language_title),
                 R.string.pref_language_subtitle_none, R.string.pref_language_audio_add,
                 Utils.splitLanguages(forSecondary
                         ? mPrefs.languageSubtitleSecondary : mPrefs.languageSubtitle),
@@ -9079,7 +9083,8 @@ public class PlayerActivity extends Activity {
 
     /** A room from the list said it has a password; the code we already know. */
     private void askRoomPassword(final String code) {
-        final EditText input = new EditText(this);
+        final Context dialogContext = Utils.dialogContext(this);
+        final EditText input = new EditText(dialogContext);
         input.setInputType(InputType.TYPE_CLASS_TEXT);
         input.setSingleLine(true);
         input.setHint(getString(R.string.together_password_hint));
@@ -9091,7 +9096,7 @@ public class PlayerActivity extends Activity {
         // not exist.
         input.setText(mPrefs.togetherPassword);
         input.setSelection(input.getText().length());
-        new MaterialAlertDialogBuilder(this)
+        new MaterialAlertDialogBuilder(dialogContext)
                 .setTitle(code)
                 .setView(input)
                 .setPositiveButton(android.R.string.ok,
@@ -9108,6 +9113,7 @@ public class PlayerActivity extends Activity {
      * room being made, not a standing preference worth hunting for in settings.
      */
     private void createRoom() {
+        final Context dialogContext = Utils.dialogContext(this);
         final JSONObject session = sessionDescription();
         if (session == null) {
             return;
@@ -9118,33 +9124,33 @@ public class PlayerActivity extends Activity {
                 ? getString(R.string.together_room_default_name, code)
                 : card.optString("title");
 
-        final EditText name = new EditText(this);
+        final EditText name = new EditText(dialogContext);
         name.setInputType(InputType.TYPE_CLASS_TEXT);
         name.setSingleLine(true);
         name.setText(suggested);
         name.setSelection(name.getText().length());
 
-        final EditText password = new EditText(this);
+        final EditText password = new EditText(dialogContext);
         password.setInputType(InputType.TYPE_CLASS_TEXT);
         password.setSingleLine(true);
         password.setHint(getString(R.string.together_password_hint));
         password.setText(mPrefs.togetherPassword);
 
-        final CheckBox listed = new CheckBox(this);
+        final CheckBox listed = new CheckBox(dialogContext);
         listed.setText(R.string.together_public);
         listed.setChecked(mPrefs.togetherPublic);
 
         // A listed room without a password is open to whoever reads the list. Said as a quiet line under
         // the tick that put it there, not as an error after the fact: the accent here is already the brand
         // coral, and a red field on top of it reads as alarm rather than as the one thing left to fill in.
-        final TextView note = new TextView(this);
+        final TextView note = new TextView(dialogContext);
         note.setText(R.string.together_public_needs_password);
         note.setTextSize(TypedValue.COMPLEX_UNIT_SP, 13);
         note.setTextColor(ContextCompat.getColor(this, R.color.error_ink_muted));
         note.setPadding(0, 0, 0, Utils.dpToPx(4));
         note.setVisibility(View.GONE);
 
-        final LinearLayout fields = new LinearLayout(this);
+        final LinearLayout fields = new LinearLayout(dialogContext);
         fields.setOrientation(LinearLayout.VERTICAL);
         final int pad = Utils.dpToPx(16);
         fields.setPadding(pad, 0, pad, 0);
@@ -9153,7 +9159,7 @@ public class PlayerActivity extends Activity {
         fields.addView(listed);
         fields.addView(note);
 
-        final AlertDialog dialog = new MaterialAlertDialogBuilder(this)
+        final AlertDialog dialog = new MaterialAlertDialogBuilder(dialogContext)
                 .setTitle(getString(R.string.together_create_title, code))
                 .setView(fields)
                 .setPositiveButton(android.R.string.ok, (d, which) -> {
@@ -9206,7 +9212,8 @@ public class PlayerActivity extends Activity {
     /** Ask for the six digits. Also the empty state's way in, which is the only one a TV has when
      *  nothing is playing yet — the gear menu lives in the player's controls. */
     void askRoomCode() {
-        final EditText code = new EditText(this);
+        final Context dialogContext = Utils.dialogContext(this);
+        final EditText code = new EditText(dialogContext);
         // Text, not digits: a room made in Lampa has a letter code, and the same six characters
         // have to be typeable here.
         code.setInputType(InputType.TYPE_CLASS_TEXT | InputType.TYPE_TEXT_FLAG_CAP_CHARACTERS);
@@ -9216,19 +9223,19 @@ public class PlayerActivity extends Activity {
         // Rooms made in Lampa carry a password whenever that setting is on there, and it goes into
         // the room's address — so without it we would land somewhere else entirely and report, quite
         // truthfully and quite uselessly, that no such room exists.
-        final EditText password = new EditText(this);
+        final EditText password = new EditText(dialogContext);
         password.setInputType(InputType.TYPE_CLASS_TEXT);
         password.setSingleLine(true);
         password.setHint(getString(R.string.together_password_hint));
 
-        final LinearLayout fields = new LinearLayout(this);
+        final LinearLayout fields = new LinearLayout(dialogContext);
         fields.setOrientation(LinearLayout.VERTICAL);
         final int pad = Utils.dpToPx(16);
         fields.setPadding(pad, 0, pad, 0);
         fields.addView(code);
         fields.addView(password);
 
-        new MaterialAlertDialogBuilder(this)
+        new MaterialAlertDialogBuilder(dialogContext)
                 .setTitle(R.string.together_join)
                 .setView(fields)
                 .setPositiveButton(android.R.string.ok, (dialog, which) -> {
@@ -9468,6 +9475,7 @@ public class PlayerActivity extends Activity {
     /** The invite as something to point a camera at, for a screen that cannot pass it on itself. The
      *  clipboard gets it too — a box with a keyboard, or a remote-control browser, can still use it. */
     private void showInviteQr(final String invite) {
+        final Context dialogContext = Utils.dialogContext(this);
         copyToClipboard(invite);
         final DisplayMetrics metrics = getResources().getDisplayMetrics();
         final Bitmap qr = Utils.qrBitmap(invite,
@@ -9476,12 +9484,12 @@ public class PlayerActivity extends Activity {
             showSnack(getString(R.string.together_created, together.code()), null);
             return;
         }
-        final ImageView image = new ImageView(this);
+        final ImageView image = new ImageView(dialogContext);
         image.setImageBitmap(qr);
         image.setAdjustViewBounds(true);
         final int padding = Math.round(16 * metrics.density);
         image.setPadding(padding, padding, padding, padding);
-        new MaterialAlertDialogBuilder(this)
+        new MaterialAlertDialogBuilder(dialogContext)
                 .setTitle(getString(R.string.together_qr_title, together.code()))
                 .setMessage(getString(R.string.together_qr_hint))
                 .setView(image)
@@ -13291,10 +13299,11 @@ public class PlayerActivity extends Activity {
     }
 
     void showSnack(final String textPrimary, final String textSecondary) {
+        final Context dialogContext = Utils.dialogContext(this);
         // On TV the Snackbar action button is not reachable with the D-pad, so the "Details" affordance
         // would be lost. Present the error as an AlertDialog instead — its buttons are D-pad focusable.
         if (isTvBox) {
-            final AlertDialog.Builder builder = new MaterialAlertDialogBuilder(this);
+            final AlertDialog.Builder builder = new MaterialAlertDialogBuilder(dialogContext);
             builder.setMessage(textPrimary);
             builder.setPositiveButton(android.R.string.ok, (dialogInterface, i) -> dialogInterface.dismiss());
             if (textSecondary != null) {
@@ -13497,7 +13506,8 @@ public class PlayerActivity extends Activity {
     }
 
     void askForScope(boolean loadSubtitlesOnCancel, boolean skipToNextOnCancel) {
-        final AlertDialog.Builder builder = new MaterialAlertDialogBuilder(PlayerActivity.this);
+        final Context dialogContext = Utils.dialogContext(this);
+        final AlertDialog.Builder builder = new MaterialAlertDialogBuilder(dialogContext);
         builder.setMessage(String.format(getString(R.string.request_scope), getString(R.string.app_name)));
         builder.setPositiveButton(android.R.string.ok, (dialogInterface, i) -> requestDirectoryAccess()
         );
@@ -13818,7 +13828,8 @@ public class PlayerActivity extends Activity {
     }
 
     void askDeleteMedia() {
-        final AlertDialog.Builder builder = new MaterialAlertDialogBuilder(PlayerActivity.this);
+        final Context dialogContext = Utils.dialogContext(this);
+        final AlertDialog.Builder builder = new MaterialAlertDialogBuilder(dialogContext);
         builder.setMessage(getString(R.string.delete_query));
         builder.setPositiveButton(R.string.delete_confirmation, (dialogInterface, i) -> {
             releasePlayer();
@@ -14013,6 +14024,7 @@ public class PlayerActivity extends Activity {
     }
 
     private void showAspectModePicker() {
+        final Context dialogContext = Utils.dialogContext(this);
         final List<AspectMode> modes = getAspectModes();
         final String[] labels = new String[modes.size()];
         int checked = -1;
@@ -14021,7 +14033,7 @@ public class PlayerActivity extends Activity {
             if (isCurrentAspectMode(modes.get(i)))
                 checked = i;
         }
-        final AlertDialog dialog = new MaterialAlertDialogBuilder(this)
+        final AlertDialog dialog = new MaterialAlertDialogBuilder(dialogContext)
                 .setTitle(R.string.button_crop)
                 .setSingleChoiceItems(labels, checked, (d, which) -> {
                     applyAspectMode(which);

--- a/app/src/main/java/com/brouken/player/Prefs.java
+++ b/app/src/main/java/com/brouken/player/Prefs.java
@@ -12,6 +12,7 @@ import android.preference.PreferenceManager;
 import android.provider.DocumentsContract;
 import android.text.TextUtils;
 
+import androidx.appcompat.app.AppCompatDelegate;
 import androidx.media3.exoplayer.DefaultRenderersFactory;
 import androidx.media3.ui.AspectRatioFrameLayout;
 import androidx.media3.ui.CaptionStyleCompat;
@@ -57,6 +58,13 @@ class Prefs {
     private static final String PREF_KEY_AUTO_PIP = "autoPiP";
     private static final String PREF_KEY_DISABLE_VOLUME_BRIGHTNESS_GESTURES = "disableVolumeBrightnessGestures";
     private static final String PREF_KEY_HOLD_SPEED = "holdSpeed";
+    /** Settings-screen appearance. The player and the error screen are dark by design, so these two
+     *  reach only the settings window. */
+    public static final String THEME_MODE_KEY = "themeMode";
+    private static final String PREF_KEY_AMOLED = "amoledBlack";
+    public static final String THEME_DARK = "dark";
+    public static final String THEME_LIGHT = "light";
+    public static final String THEME_SYSTEM = "system";
     private static final String PREF_KEY_HOLD_SPEED_MODE = "holdSpeedMode";
     private static final String PREF_KEY_TUNNELING = "tunneling";
     private static final String PREF_KEY_FRAMERATE_MATCHING = "frameRateMatching";
@@ -549,6 +557,39 @@ class Prefs {
                 .remove(PREF_KEY_SUBTITLE_SEARCH_STRICT)
                 .apply();
         return migrated;
+    }
+
+    public static String getThemeMode(final Context context) {
+        return PreferenceManager.getDefaultSharedPreferences(context)
+                .getString(THEME_MODE_KEY, THEME_SYSTEM);
+    }
+
+    public static void setThemeMode(final Context context, final String mode) {
+        PreferenceManager.getDefaultSharedPreferences(context).edit()
+                .putString(THEME_MODE_KEY, mode).apply();
+    }
+
+    /**
+     * The stored choice as the night mode AppCompat wants. "System" is UNSPECIFIED rather than
+     * FOLLOW_SYSTEM: a local mode outranks the default one, and on a TV box PlayerActivity sets that
+     * default to dark on purpose. Asking to follow the system there would quietly hand a TV whose
+     * system is light a light settings screen, which is not what "System" is being offered for.
+     * UNSPECIFIED defers to whatever default is in force — the TV's dark, the phone's system.
+     */
+    public static int getNightMode(final Context context) {
+        switch (getThemeMode(context)) {
+            case THEME_DARK:
+                return AppCompatDelegate.MODE_NIGHT_YES;
+            case THEME_LIGHT:
+                return AppCompatDelegate.MODE_NIGHT_NO;
+            default:
+                return AppCompatDelegate.MODE_NIGHT_UNSPECIFIED;
+        }
+    }
+
+    public static boolean isAmoledBlack(final Context context) {
+        return PreferenceManager.getDefaultSharedPreferences(context)
+                .getBoolean(PREF_KEY_AMOLED, false);
     }
 
     /**

--- a/app/src/main/java/com/brouken/player/SettingsActivity.java
+++ b/app/src/main/java/com/brouken/player/SettingsActivity.java
@@ -49,6 +49,7 @@ import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 import androidx.recyclerview.widget.SimpleItemAnimator;
 
+import com.google.android.material.appbar.MaterialToolbar;
 import com.google.android.material.button.MaterialButtonToggleGroup;
 import com.google.android.material.color.MaterialColors;
 
@@ -140,6 +141,20 @@ public class SettingsActivity extends AppCompatActivity
             }
         });
 
+        // The title belongs over the column, not at the far edge of a 4K window.
+        final MaterialToolbar bar = findViewById(R.id.toolbar);
+        final View settingsRoot = findViewById(R.id.settings_layout);
+        settingsRoot.addOnLayoutChangeListener((v, l, t, r, b, ol, ot, or2, ob) -> {
+            // Padding rather than content insets: those move the title and leave the up arrow at the
+            // window edge, which reads as two different left margins. On a TV it also brings the arrow
+            // inside the overscan-safe strip, where a remote can be sure of finding it.
+            // Only the part the toolbar does not already inset by itself, or a phone — where the two
+            // are the same 16dp — would indent the title twice.
+            final int extra = Math.max(0,
+                    contentSideInset(this, r - l) - bar.getContentInsetStart());
+            bar.setPadding(extra, bar.getPaddingTop(), extra, bar.getPaddingBottom());
+        });
+
         if (Build.VERSION.SDK_INT >= 29) {
             LinearLayout layout = findViewById(R.id.settings_layout);
             layout.setOnApplyWindowInsetsListener((view, windowInsets) -> {
@@ -154,6 +169,27 @@ public class SettingsActivity extends AppCompatActivity
                 return windowInsets;
             });
         }
+    }
+
+    /**
+     * Side inset that holds the content to one readable column, given the room there is.
+     *
+     * Material asks for a maximum width rather than letting content stretch, and hands widths past
+     * 840dp to layouts with more than one pane. This screen is deliberately one pane — the switches
+     * are meant to be read, not hidden behind rows — so the honest single-pane answer is to stop the
+     * column at the width a label-and-control row still reads as one thing and centre it. 720dp sits
+     * inside Material's medium window, which is the widest a single pane is meant to get.
+     *
+     * A 4K monitor therefore gets the same column with a lot of space around it. Filling that space
+     * properly needs a second pane, which is a different screen, not a wider inset.
+     *
+     * On a TV the floor is the overscan margin the TV guidance asks for (48dp horizontally, 5% of
+     * 960dp) rather than the phone's 16dp: a set narrow enough to miss the cap — 1280x720 at 320 dpi
+     * is exactly 640dp across — would otherwise put rows in the strip a TV may not show.
+     */
+    static int contentSideInset(final Context context, final int availableWidth) {
+        final int base = Utils.isTvBox(context) ? Utils.dpToPx(48) : Utils.dpToPx(16);
+        return Math.max(base, (availableWidth - Utils.dpToPx(720)) / 2);
     }
 
     /**
@@ -1000,12 +1036,7 @@ public class SettingsActivity extends AppCompatActivity
 
         private static final int RADIUS = Utils.dpToPx(20);
         private final int inset = Utils.dpToPx(16);
-        /**
-         * How wide the cards are allowed to get. A settings row is a label on the left and a control
-         * on the right; let the row have a whole television and the two end up a screen apart with
-         * nothing in between, which is why a wide layout reads as broken rather than roomy.
-         */
-        private final int maxContentWidth = Utils.dpToPx(640);
+
         private final int headerGap = Utils.dpToPx(8);
         private final int hairlineInset = Utils.dpToPx(16);
         private final Paint card = new Paint(Paint.ANTI_ALIAS_FLAG);
@@ -1038,9 +1069,9 @@ public class SettingsActivity extends AppCompatActivity
         @Override
         public void getItemOffsets(@NonNull Rect outRect, @NonNull View view,
                                    @NonNull RecyclerView parent, @NonNull RecyclerView.State state) {
-            // Centred once the list is wider than a card is allowed to be. The cards are drawn from
-            // the rows' own bounds, so they follow this without knowing about it.
-            final int side = Math.max(inset, (parent.getWidth() - maxContentWidth) / 2);
+            // Centred once the list is wider than the column is allowed to be. The cards are drawn
+            // from the rows' own bounds, so they follow this without knowing about it.
+            final int side = contentSideInset(parent.getContext(), parent.getWidth());
             outRect.left = side;
             outRect.right = side;
             // The header sits above its card, not against the one before it.

--- a/app/src/main/java/com/brouken/player/SettingsActivity.java
+++ b/app/src/main/java/com/brouken/player/SettingsActivity.java
@@ -174,6 +174,10 @@ public class SettingsActivity extends AppCompatActivity
     }
 
     public static class SettingsFragment extends PreferenceFragmentCompat {
+
+        /** SwitchCompat's own thumb animation, which it keeps to itself as a private constant. */
+        private static final long SWITCH_ANIMATION_MS = 250;
+
         @Override
         public void onCreatePreferences(Bundle savedInstanceState, String rootKey) {
             // Inflation materializes switch defaults, so record whether the key was already
@@ -193,9 +197,20 @@ public class SettingsActivity extends AppCompatActivity
             final Preference preferenceAmoled = findPreference("amoledBlack");
             if (preferenceAmoled != null) {
                 preferenceAmoled.setOnPreferenceChangeListener((preference, value) -> {
-                    // Posted, so the new value is persisted — returning true is what does that —
-                    // before the window that reads it is built again.
-                    new Handler(Looper.getMainLooper()).post(() -> requireActivity().recreate());
+                    // Held past the switch's own animation, so the thumb finishes travelling before the
+                    // window is rebuilt. Rebuilding it straight away cut that animation off mid-way and
+                    // the toggle read as a jerk, which no other switch on this screen does. SwitchCompat
+                    // animates the thumb for 250 ms and keeps the figure to itself.
+                    // The host is taken now rather than looked up later: by the time this runs the
+                    // fragment may have been detached, and asking it for its activity then would either
+                    // throw or, guarded, silently skip the rebuild.
+                    // Returning true is what persists the new value; the rebuilt window reads it.
+                    final Activity host = requireActivity();
+                    new Handler(Looper.getMainLooper()).postDelayed(() -> {
+                        if (!host.isFinishing() && !host.isDestroyed()) {
+                            host.recreate();
+                        }
+                    }, SWITCH_ANIMATION_MS);
                     return true;
                 });
             }

--- a/app/src/main/java/com/brouken/player/SettingsActivity.java
+++ b/app/src/main/java/com/brouken/player/SettingsActivity.java
@@ -16,6 +16,8 @@ import android.text.Spanned;
 import android.text.style.ImageSpan;
 import android.os.Build;
 import android.os.Bundle;
+import android.os.Handler;
+import android.os.Looper;
 import android.text.StaticLayout;
 import android.text.TextUtils;
 import android.view.View;
@@ -46,6 +48,7 @@ import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 import androidx.recyclerview.widget.SimpleItemAnimator;
 
+import com.google.android.material.button.MaterialButtonToggleGroup;
 import com.google.android.material.color.MaterialColors;
 
 import com.brouken.player.together.AliasGenerator;
@@ -77,6 +80,23 @@ public class SettingsActivity extends AppCompatActivity
     @Override
     protected void onCreate(Bundle savedInstanceState) {
 
+        // Before super.onCreate, or AppCompat applies the old mode first and then recreates.
+        getDelegate().setLocalNightMode(Prefs.getNightMode(this));
+
+        super.onCreate(savedInstanceState);
+
+        // After super, so the configuration already carries the night mode set above, and before
+        // anything asks the window for its decor view: reading getDecorView() builds it, and the decor
+        // takes its background out of the theme exactly as it stands at that moment. Pure black is a
+        // dark-theme idea only.
+        final int night = getResources().getConfiguration().uiMode & Configuration.UI_MODE_NIGHT_MASK;
+        if (night == Configuration.UI_MODE_NIGHT_YES && Prefs.isAmoledBlack(this)) {
+            getTheme().applyStyle(R.style.ThemeOverlay_JustPlus_Amoled, true);
+        }
+
+        // Hence below the overlay and not above it, where this block used to sit: its getDecorView()
+        // call was building the decor against the un-overlaid theme, which left the window grey while
+        // the cards drawn later came out black.
         if (Build.VERSION.SDK_INT >= 29) {
             getWindow().getDecorView().setSystemUiVisibility(
                     View.SYSTEM_UI_FLAG_LAYOUT_STABLE | View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION
@@ -84,12 +104,9 @@ public class SettingsActivity extends AppCompatActivity
             getWindow().setNavigationBarColor(Color.TRANSPARENT);
         }
 
-        super.onCreate(savedInstanceState);
-
-        // The status bar takes the window's own surface colour (see Theme.Settings), so its icons have to
-        // follow the theme in force instead of staying light. This sets only the light-icon bit, and on
-        // every SDK — the block above replaces the whole flag set, which is why it cannot do this too.
-        final int night = getResources().getConfiguration().uiMode & Configuration.UI_MODE_NIGHT_MASK;
+        // The bar takes the window's own colour (see Theme.Settings), so its icons have to follow the
+        // theme actually in force — which is the one chosen above, not the system's. Only the light-icon
+        // bit, and on every SDK: the block above replaces the whole flag set.
         WindowCompat.getInsetsController(getWindow(), getWindow().getDecorView())
                 .setAppearanceLightStatusBars(night != Configuration.UI_MODE_NIGHT_YES);
 
@@ -172,6 +189,17 @@ public class SettingsActivity extends AppCompatActivity
             Prefs.getSubtitleTranslate(requireContext());
 
             setPreferencesFromResource(R.xml.root_preferences, rootKey);
+
+            final Preference preferenceAmoled = findPreference("amoledBlack");
+            if (preferenceAmoled != null) {
+                preferenceAmoled.setOnPreferenceChangeListener((preference, value) -> {
+                    // Posted, so the new value is persisted — returning true is what does that —
+                    // before the window that reads it is built again.
+                    new Handler(Looper.getMainLooper()).post(() -> requireActivity().recreate());
+                    return true;
+                });
+            }
+            syncAmoledEnabled();
 
             Preference preferenceAutoPiP = findPreference("autoPiP");
             if (preferenceAutoPiP != null) {
@@ -447,6 +475,7 @@ public class SettingsActivity extends AppCompatActivity
                         title.setEllipsize(null);
                     }
                     reserveTallerSummary(holder, getItem(position));
+                    bindThemeMode(holder, getItem(position));
                 }
             };
         }
@@ -502,6 +531,71 @@ public class SettingsActivity extends AppCompatActivity
         private static int lineCount(final TextView view, final CharSequence text, final int width) {
             return new StaticLayout(text, view.getPaint(), width, Layout.Alignment.ALIGN_NORMAL,
                     view.getLineSpacingMultiplier(), view.getLineSpacingExtra(), false).getLineCount();
+        }
+
+        /**
+         * The theme row is a segmented control rather than a dialog behind a row: three choices, all
+         * worth seeing without opening anything. Bound here because the row is a plain Preference
+         * carrying a custom layout, which is one class fewer than a Preference subclass would be.
+         */
+        private void bindThemeMode(final PreferenceViewHolder holder, final Preference preference) {
+            if (preference == null || !Prefs.THEME_MODE_KEY.equals(preference.getKey())) {
+                return;
+            }
+            // The row itself, not a child: Preference.onBindViewHolder resets the id of the view it
+            // binds, so an id on the layout root would not survive to be looked up here.
+            if (!(holder.itemView instanceof MaterialButtonToggleGroup)) {
+                return;
+            }
+            final MaterialButtonToggleGroup group = (MaterialButtonToggleGroup) holder.itemView;
+            final Context context = group.getContext();
+            // The holder is recycled, so the listener from its last binding has to go first.
+            group.clearOnButtonCheckedListeners();
+            group.check(buttonFor(Prefs.getThemeMode(context)));
+            group.addOnButtonCheckedListener((checkedGroup, checkedId, isChecked) -> {
+                if (!isChecked) {
+                    return;
+                }
+                Prefs.setThemeMode(context, modeFor(checkedId));
+                // Light and dark can share a configuration, in which case the delegate below has
+                // nothing to recreate and this row has to be brought up to date here.
+                syncAmoledEnabled();
+                // Recreates the activity by itself, and only when the mode actually differs.
+                ((SettingsActivity) requireActivity()).getDelegate()
+                        .setLocalNightMode(Prefs.getNightMode(context));
+            });
+        }
+
+        /**
+         * Pure black is something only a dark theme can be, so with Light chosen the row is greyed
+         * rather than hidden: it says the option exists and what it waits for. Under System it stays
+         * live — it takes effect whenever the system turns dark.
+         */
+        private void syncAmoledEnabled() {
+            final Preference amoled = findPreference("amoledBlack");
+            if (amoled != null) {
+                amoled.setEnabled(!Prefs.THEME_LIGHT.equals(Prefs.getThemeMode(requireContext())));
+            }
+        }
+
+        private static int buttonFor(final String mode) {
+            if (Prefs.THEME_DARK.equals(mode)) {
+                return R.id.theme_mode_dark;
+            }
+            if (Prefs.THEME_LIGHT.equals(mode)) {
+                return R.id.theme_mode_light;
+            }
+            return R.id.theme_mode_system;
+        }
+
+        private static String modeFor(final int buttonId) {
+            if (buttonId == R.id.theme_mode_dark) {
+                return Prefs.THEME_DARK;
+            }
+            if (buttonId == R.id.theme_mode_light) {
+                return Prefs.THEME_LIGHT;
+            }
+            return Prefs.THEME_SYSTEM;
         }
 
         // A D-pad can only reach a row that is laid out, and when focus search fails

--- a/app/src/main/java/com/brouken/player/SettingsActivity.java
+++ b/app/src/main/java/com/brouken/player/SettingsActivity.java
@@ -1000,6 +1000,12 @@ public class SettingsActivity extends AppCompatActivity
 
         private static final int RADIUS = Utils.dpToPx(20);
         private final int inset = Utils.dpToPx(16);
+        /**
+         * How wide the cards are allowed to get. A settings row is a label on the left and a control
+         * on the right; let the row have a whole television and the two end up a screen apart with
+         * nothing in between, which is why a wide layout reads as broken rather than roomy.
+         */
+        private final int maxContentWidth = Utils.dpToPx(640);
         private final int headerGap = Utils.dpToPx(8);
         private final int hairlineInset = Utils.dpToPx(16);
         private final Paint card = new Paint(Paint.ANTI_ALIAS_FLAG);
@@ -1032,8 +1038,11 @@ public class SettingsActivity extends AppCompatActivity
         @Override
         public void getItemOffsets(@NonNull Rect outRect, @NonNull View view,
                                    @NonNull RecyclerView parent, @NonNull RecyclerView.State state) {
-            outRect.left = inset;
-            outRect.right = inset;
+            // Centred once the list is wider than a card is allowed to be. The cards are drawn from
+            // the rows' own bounds, so they follow this without knowing about it.
+            final int side = Math.max(inset, (parent.getWidth() - maxContentWidth) / 2);
+            outRect.left = side;
+            outRect.right = side;
             // The header sits above its card, not against the one before it.
             if (isCategory(parent, parent.getChildAdapterPosition(view))) {
                 outRect.top = headerGap;

--- a/app/src/main/java/com/brouken/player/SettingsActivity.java
+++ b/app/src/main/java/com/brouken/player/SettingsActivity.java
@@ -31,6 +31,7 @@ import android.widget.TextView;
 import android.widget.Toast;
 
 import androidx.appcompat.app.ActionBar;
+import androidx.core.content.ContextCompat;
 import androidx.core.view.OneShotPreDrawListener;
 import androidx.core.view.WindowCompat;
 import androidx.appcompat.app.AppCompatActivity;
@@ -77,6 +78,10 @@ public class SettingsActivity extends AppCompatActivity
     /** Key of the sub-screen row last opened, so Back can put the list back on it. */
     private String openedScreenKey;
 
+    /** The surface tones without the AMOLED overlay, resolved in onCreate before it is applied. */
+    private int plainSurface;
+    private int plainCard;
+
     @Override
     protected void onCreate(Bundle savedInstanceState) {
 
@@ -90,6 +95,11 @@ public class SettingsActivity extends AppCompatActivity
         // takes its background out of the theme exactly as it stands at that moment. Pure black is a
         // dark-theme idea only.
         final int night = getResources().getConfiguration().uiMode & Configuration.UI_MODE_NIGHT_MASK;
+        // Read before the overlay goes on, because applyStyle cannot be undone and these are the
+        // values AMOLED has to be able to go back to. Taken from this theme in this configuration —
+        // a ContextThemeWrapper built here does not carry the local night mode and answers light.
+        plainSurface = MaterialColors.getColor(this, R.attr.colorSurface, Color.BLACK);
+        plainCard = MaterialColors.getColor(this, R.attr.colorSurfaceContainer, Color.DKGRAY);
         if (night == Configuration.UI_MODE_NIGHT_YES && Prefs.isAmoledBlack(this)) {
             getTheme().applyStyle(R.style.ThemeOverlay_JustPlus_Amoled, true);
         }
@@ -146,6 +156,33 @@ public class SettingsActivity extends AppCompatActivity
         }
     }
 
+    /**
+     * Repaints the surfaces the AMOLED option owns, so toggling it does not need the window rebuilt.
+     * Rebuilding was visible: the pressed row lit, the switch travelled, and only then did the whole
+     * screen cut over in one frame — two beats where the eye expects none.
+     *
+     * ponytail: the theme object itself is left alone, so a dialog opened between a toggle and the
+     * next launch still carries the previous surface tone (a 20/255 difference on its background).
+     * Give the overlay an inverse and apply that here if it ever shows.
+     */
+    void repaintAmoledSurfaces() {
+        final boolean amoled = isNight() && Prefs.isAmoledBlack(this);
+        final int surface = amoled ? ContextCompat.getColor(this, R.color.black) : plainSurface;
+        getWindow().setBackgroundDrawable(new android.graphics.drawable.ColorDrawable(surface));
+        getWindow().setStatusBarColor(surface);
+        final View toolbar = findViewById(R.id.toolbar);
+        if (toolbar != null) {
+            toolbar.setBackgroundColor(surface);
+        }
+        final int card = amoled ? ContextCompat.getColor(this, R.color.amoled_card) : plainCard;
+        GroupCards.repaint(recyclerView, card);
+    }
+
+    private boolean isNight() {
+        return (getResources().getConfiguration().uiMode & Configuration.UI_MODE_NIGHT_MASK)
+                == Configuration.UI_MODE_NIGHT_YES;
+    }
+
     /** Up from a sub-screen goes back one level, not out of the settings altogether. */
     @Override
     public boolean onSupportNavigateUp() {
@@ -175,9 +212,6 @@ public class SettingsActivity extends AppCompatActivity
 
     public static class SettingsFragment extends PreferenceFragmentCompat {
 
-        /** SwitchCompat's own thumb animation, which it keeps to itself as a private constant. */
-        private static final long SWITCH_ANIMATION_MS = 250;
-
         @Override
         public void onCreatePreferences(Bundle savedInstanceState, String rootKey) {
             // Inflation materializes switch defaults, so record whether the key was already
@@ -197,20 +231,16 @@ public class SettingsActivity extends AppCompatActivity
             final Preference preferenceAmoled = findPreference("amoledBlack");
             if (preferenceAmoled != null) {
                 preferenceAmoled.setOnPreferenceChangeListener((preference, value) -> {
-                    // Held past the switch's own animation, so the thumb finishes travelling before the
-                    // window is rebuilt. Rebuilding it straight away cut that animation off mid-way and
-                    // the toggle read as a jerk, which no other switch on this screen does. SwitchCompat
-                    // animates the thumb for 250 ms and keeps the figure to itself.
-                    // The host is taken now rather than looked up later: by the time this runs the
-                    // fragment may have been detached, and asking it for its activity then would either
-                    // throw or, guarded, silently skip the rebuild.
-                    // Returning true is what persists the new value; the rebuilt window reads it.
-                    final Activity host = requireActivity();
-                    new Handler(Looper.getMainLooper()).postDelayed(() -> {
-                        if (!host.isFinishing() && !host.isDestroyed()) {
-                            host.recreate();
-                        }
-                    }, SWITCH_ANIMATION_MS);
+                    // Posted, because returning true is what persists the value and repaintAmoledSurfaces
+                    // reads it back. Repainting rather than recreating: the window is the same one, so the
+                    // switch keeps animating over surfaces that have already changed under it.
+                    // getActivity, not requireActivity: a row can be bound on a fragment that is on its
+                    // way out, and throwing there would take the app down over a colour.
+                    final Activity host = getActivity();
+                    if (host instanceof SettingsActivity) {
+                        new Handler(Looper.getMainLooper())
+                                .post(((SettingsActivity) host)::repaintAmoledSurfaces);
+                    }
                     return true;
                 });
             }
@@ -645,9 +675,9 @@ public class SettingsActivity extends AppCompatActivity
                             .setSupportsChangeAnimations(false);
                 }
             }
-            if (Build.VERSION.SDK_INT >= 29) {
-                recyclerView = getListView();
-            }
+            // Unconditionally: the inset padding below wants it only on 29+, but repaintAmoledSurfaces
+            // needs the list on every SDK, or the cards keep the old tone on 23-28 until the next launch.
+            recyclerView = getListView();
             if (getArguments() != null) {
                 // A sub-screen is a replaced fragment, and a replaced fragment starts with nothing
                 // focused: the first D-pad press then goes wherever the view root guesses instead
@@ -970,6 +1000,23 @@ public class SettingsActivity extends AppCompatActivity
             card.setColor(MaterialColors.getColor(context, R.attr.colorSurfaceContainer, Color.DKGRAY));
             hairline.setColor(MaterialColors.getColor(context, R.attr.colorOutlineVariant, Color.GRAY));
             hairline.setStrokeWidth(Utils.dpToPx(1));
+        }
+
+        /**
+         * Recolours the cards of a list already on screen. The hairlines are left alone — outlineVariant
+         * does not move with the AMOLED option, and they read the same over either card tone.
+         */
+        static void repaint(final RecyclerView list, final int cardColor) {
+            if (list == null) {
+                return;
+            }
+            for (int i = 0; i < list.getItemDecorationCount(); i++) {
+                final RecyclerView.ItemDecoration decoration = list.getItemDecorationAt(i);
+                if (decoration instanceof GroupCards) {
+                    ((GroupCards) decoration).card.setColor(cardColor);
+                }
+            }
+            list.invalidate();
         }
 
         @Override

--- a/app/src/main/java/com/brouken/player/SettingsActivity.java
+++ b/app/src/main/java/com/brouken/player/SettingsActivity.java
@@ -489,7 +489,7 @@ public class SettingsActivity extends AppCompatActivity
                                 return;
                             }
                             if (info != null) {
-                                UpdateUi.showAvailableDialog(activity, info, null, false);
+                                UpdateUi.showAvailableDialog(activity, activity, info, null, false);
                             } else {
                                 Toast.makeText(activity, R.string.update_none, Toast.LENGTH_SHORT).show();
                             }
@@ -594,6 +594,16 @@ public class SettingsActivity extends AppCompatActivity
             }
             final MaterialButtonToggleGroup group = (MaterialButtonToggleGroup) holder.itemView;
             final Context context = group.getContext();
+            // A TV box has no system theme of its own to follow — PlayerActivity makes dark the default
+            // there, so "System" resolves to dark and does exactly what the button next to it does. An
+            // option that duplicates its neighbour is worse than one fewer option, so it goes; a choice
+            // stored from a phone becomes the Dark it already behaves as.
+            if (Utils.isTvBox(context)) {
+                group.findViewById(R.id.theme_mode_system).setVisibility(View.GONE);
+                if (Prefs.THEME_SYSTEM.equals(Prefs.getThemeMode(context))) {
+                    Prefs.setThemeMode(context, Prefs.THEME_DARK);
+                }
+            }
             // The holder is recycled, so the listener from its last binding has to go first.
             group.clearOnButtonCheckedListeners();
             group.check(buttonFor(Prefs.getThemeMode(context)));

--- a/app/src/main/java/com/brouken/player/SettingsActivity.java
+++ b/app/src/main/java/com/brouken/player/SettingsActivity.java
@@ -20,7 +20,9 @@ import android.os.Handler;
 import android.os.Looper;
 import android.text.StaticLayout;
 import android.text.TextUtils;
+import android.view.KeyEvent;
 import android.view.View;
+import android.view.ViewGroup;
 import android.view.ViewOutlineProvider;
 import android.widget.LinearLayout;
 
@@ -52,6 +54,7 @@ import androidx.recyclerview.widget.SimpleItemAnimator;
 import com.google.android.material.appbar.MaterialToolbar;
 import com.google.android.material.button.MaterialButtonToggleGroup;
 import com.google.android.material.color.MaterialColors;
+import com.google.android.material.snackbar.Snackbar;
 
 import com.brouken.player.together.AliasGenerator;
 import com.brouken.player.together.Relay;
@@ -150,8 +153,12 @@ public class SettingsActivity extends AppCompatActivity
             // inside the overscan-safe strip, where a remote can be sure of finding it.
             // Only the part the toolbar does not already inset by itself, or a phone — where the two
             // are the same 16dp — would indent the title twice.
+            // The width the list will get, not the root's: the window insets are applied to this
+            // root as padding, and the list sits inside them. Measuring the outer width put the
+            // title off the column by half the inset wherever a system bar takes a side.
+            final int usable = r - l - v.getPaddingLeft() - v.getPaddingRight();
             final int extra = Math.max(0,
-                    contentSideInset(this, r - l) - bar.getContentInsetStart());
+                    contentSideInset(this, usable) - bar.getContentInsetStart());
             bar.setPadding(extra, bar.getPaddingTop(), extra, bar.getPaddingBottom());
         });
 
@@ -172,6 +179,33 @@ public class SettingsActivity extends AppCompatActivity
     }
 
     /**
+     * Says something back, inside the content column.
+     *
+     * A Toast lands at the bottom of the window, which on a television is the overscan strip this
+     * screen spends 48dp staying out of — so the one row whose only feedback is a message ("Reset
+     * learned audio workarounds") looked inert and invited a second press. A Snackbar over the list
+     * is inset to the same column as the cards and clears the strip.
+     */
+    static void say(final Activity activity, final int textRes) {
+        final View host = activity.findViewById(R.id.settings);
+        if (host == null) {
+            Toast.makeText(activity, textRes, Toast.LENGTH_SHORT).show();
+            return;
+        }
+        final Snackbar bar = Snackbar.make(host, textRes, Snackbar.LENGTH_SHORT);
+        final int side = contentSideInset(activity, host.getWidth());
+        final View view = bar.getView();
+        final ViewGroup.MarginLayoutParams lp = (ViewGroup.MarginLayoutParams) view.getLayoutParams();
+        lp.leftMargin += side;
+        lp.rightMargin += side;
+        if (Utils.isTvBox(activity)) {
+            lp.bottomMargin += Utils.dpToPx(27);
+        }
+        view.setLayoutParams(lp);
+        bar.show();
+    }
+
+    /**
      * Side inset that holds the content to one readable column, given the room there is.
      *
      * Material asks for a maximum width rather than letting content stretch, and hands widths past
@@ -180,8 +214,11 @@ public class SettingsActivity extends AppCompatActivity
      * column at the width a label-and-control row still reads as one thing and centre it. 720dp sits
      * inside Material's medium window, which is the widest a single pane is meant to get.
      *
-     * A 4K monitor therefore gets the same column with a lot of space around it. Filling that space
-     * properly needs a second pane, which is a different screen, not a wider inset.
+     * Past twice that the column is allowed to grow to 960dp, because a 720dp strip in the middle of
+     * a 1932dp television — what a set rendering its interface at 4K gives you — leaves 63% of the
+     * panel empty and reads as a mistake rather than a margin. 960dp is the ceiling: wider rows put
+     * the switch too far from its label again, and filling more than that properly needs a second
+     * pane, which is a different screen, not a wider inset.
      *
      * On a TV the floor is the overscan margin the TV guidance asks for (48dp horizontally, 5% of
      * 960dp) rather than the phone's 16dp: a set narrow enough to miss the cap — 1280x720 at 320 dpi
@@ -189,7 +226,9 @@ public class SettingsActivity extends AppCompatActivity
      */
     static int contentSideInset(final Context context, final int availableWidth) {
         final int base = Utils.isTvBox(context) ? Utils.dpToPx(48) : Utils.dpToPx(16);
-        return Math.max(base, (availableWidth - Utils.dpToPx(720)) / 2);
+        final int column = Math.max(Utils.dpToPx(720),
+                Math.min(Utils.dpToPx(960), availableWidth / 2));
+        return Math.max(base, (availableWidth - column) / 2);
     }
 
     /**
@@ -263,6 +302,14 @@ public class SettingsActivity extends AppCompatActivity
             Prefs.getSubtitleTranslate(requireContext());
 
             setPreferencesFromResource(R.xml.root_preferences, rootKey);
+
+            final Preference dangerousWarning = findPreference("dangerousWarning");
+            if (dangerousWarning != null && Utils.isTvBox(requireContext())) {
+                // A remote cannot land on an unselectable row, so it stepped over the one piece of
+                // safety text in front of the two settings that can stop video from playing. It does
+                // nothing when pressed, which is the correct amount for a warning.
+                dangerousWarning.setSelectable(true);
+            }
 
             final Preference preferenceAmoled = findPreference("amoledBlack");
             if (preferenceAmoled != null) {
@@ -492,7 +539,7 @@ public class SettingsActivity extends AppCompatActivity
             if (resetAudioWorkarounds != null) {
                 resetAudioWorkarounds.setOnPreferenceClickListener(preference -> {
                     Prefs.resetRevokedAudioMimes(requireContext());
-                    Toast.makeText(getContext(), R.string.pref_reset_audio_workarounds_done, Toast.LENGTH_SHORT).show();
+                    say(requireActivity(), R.string.pref_reset_audio_workarounds_done);
                     return true;
                 });
             }
@@ -519,7 +566,7 @@ public class SettingsActivity extends AppCompatActivity
                         if (activity == null) {
                             return true;
                         }
-                        Toast.makeText(activity, R.string.update_checking, Toast.LENGTH_SHORT).show();
+                        say(activity, R.string.update_checking);
                         Updater.find(info -> activity.runOnUiThread(() -> {
                             if (activity.isFinishing()) {
                                 return;
@@ -527,7 +574,7 @@ public class SettingsActivity extends AppCompatActivity
                             if (info != null) {
                                 UpdateUi.showAvailableDialog(activity, activity, info, null, false);
                             } else {
-                                Toast.makeText(activity, R.string.update_none, Toast.LENGTH_SHORT).show();
+                                say(activity, R.string.update_none);
                             }
                         }));
                         return true;
@@ -714,6 +761,7 @@ public class SettingsActivity extends AppCompatActivity
                 setDivider(null);
                 setDividerHeight(0);
                 cardList.addItemDecoration(new GroupCards(cardList.getContext()));
+                bindCategoryJump(cardList);
                 // Toggling a switch re-binds its row, and cross-fading the old text over the new one
                 // reads as a flicker in a list that is otherwise still.
                 if (cardList.getItemAnimator() instanceof SimpleItemAnimator) {
@@ -746,8 +794,78 @@ public class SettingsActivity extends AppCompatActivity
                 final String key = activity.getIntent().getStringExtra(EXTRA_SCROLL_TO);
                 if (key != null) {
                     openAtPreference(key, 3);
+                } else if (Utils.isTvBox(activity)) {
+                    // Opened from the player menu with no section to land on. A remote needs
+                    // something focused or the first press goes wherever the view root guesses;
+                    // the sub-screen path above has said so for a while, and the root path never
+                    // did the same.
+                    openAtPosition(0, 3);
                 }
             }
+        }
+
+        /**
+         * Left and Right do nothing in a one-column list, and this one is 26 stops deep on a
+         * television with no fast scroll and no search. Give them the jump a category rail would
+         * have given them: to the first row of the previous or next section, nine stops instead of
+         * twenty-six, without a second pane and without undoing the rule that keeps short groups
+         * visible.
+         *
+         * Only on a remote, and never on the theme row, whose segmented control needs Left and
+         * Right for itself.
+         */
+        private void bindCategoryJump(final RecyclerView list) {
+            if (!Utils.isTvBox(list.getContext())) {
+                return;
+            }
+            list.setOnKeyListener((view, keyCode, event) -> {
+                if (event.getAction() != KeyEvent.ACTION_DOWN
+                        || (keyCode != KeyEvent.KEYCODE_DPAD_LEFT
+                        && keyCode != KeyEvent.KEYCODE_DPAD_RIGHT)) {
+                    return false;
+                }
+                final View focused = list.findFocus();
+                if (focused == null || focused instanceof MaterialButtonToggleGroup) {
+                    return false;
+                }
+                final int from = list.getChildAdapterPosition(list.findContainingItemView(focused));
+                if (from == RecyclerView.NO_POSITION) {
+                    return false;
+                }
+                final int target = categoryNeighbour(list, from,
+                        keyCode == KeyEvent.KEYCODE_DPAD_RIGHT);
+                if (target == RecyclerView.NO_POSITION) {
+                    return false;
+                }
+                openAtPosition(target, 3);
+                return true;
+            });
+        }
+
+        /** First row under the section before or after the one holding {@code from}. */
+        private static int categoryNeighbour(final RecyclerView list, final int from,
+                                             final boolean forward) {
+            final RecyclerView.Adapter<?> adapter = list.getAdapter();
+            if (!(adapter instanceof PreferenceGroupAdapter)) {
+                return RecyclerView.NO_POSITION;
+            }
+            final PreferenceGroupAdapter rows = (PreferenceGroupAdapter) adapter;
+            final int step = forward ? 1 : -1;
+            // Walk off the current section first, or Left from its first row would find its own
+            // header and go nowhere.
+            int i = from;
+            if (!forward) {
+                while (i > 0 && !(rows.getItem(i - 1) instanceof PreferenceCategory)) {
+                    i--;
+                }
+                i--;
+            }
+            for (i += step; i >= 0 && i < rows.getItemCount(); i += step) {
+                if (rows.getItem(i) instanceof PreferenceCategory && i + 1 < rows.getItemCount()) {
+                    return i + 1;
+                }
+            }
+            return RecyclerView.NO_POSITION;
         }
 
         /**
@@ -916,7 +1034,7 @@ public class SettingsActivity extends AppCompatActivity
                     || Color.parseColor(textColor) != Color.parseColor(backgroundColor)) {
                 return true;
             }
-            Toast.makeText(getContext(), R.string.pref_subtitle_color_clash, Toast.LENGTH_SHORT).show();
+            say(requireActivity(), R.string.pref_subtitle_color_clash);
             return false;
         }
 
@@ -1035,7 +1153,6 @@ public class SettingsActivity extends AppCompatActivity
     private static final class GroupCards extends RecyclerView.ItemDecoration {
 
         private static final int RADIUS = Utils.dpToPx(20);
-        private final int inset = Utils.dpToPx(16);
 
         private final int headerGap = Utils.dpToPx(8);
         private final int hairlineInset = Utils.dpToPx(16);

--- a/app/src/main/java/com/brouken/player/Utils.java
+++ b/app/src/main/java/com/brouken/player/Utils.java
@@ -723,6 +723,35 @@ class Utils {
         return sb.toString();
     }
 
+    /**
+     * A context for dialogs raised from the player, themed by the appearance choice instead of by the
+     * window that raises them. The player's own theme is dark by design, so a dialog built against it
+     * cannot follow that choice at all: this wraps the chosen night mode around the configuration and
+     * hands back a DayNight theme carrying the app's colour roles.
+     *
+     * Every view a dialog builds for itself has to come from this context too, or dark text lands on a
+     * light panel.
+     */
+    public static Context dialogContext(final Context base) {
+        String mode = Prefs.getThemeMode(base);
+        if (Prefs.THEME_SYSTEM.equals(mode) && isTvBox(base)) {
+            // A TV box has no system theme worth following, and PlayerActivity makes dark the default
+            // there — so on TV a dialog follows the app rather than the box.
+            mode = Prefs.THEME_DARK;
+        }
+        Context configured = base;
+        if (!Prefs.THEME_SYSTEM.equals(mode)) {
+            final Configuration override = new Configuration(base.getResources().getConfiguration());
+            override.uiMode = (override.uiMode & ~Configuration.UI_MODE_NIGHT_MASK)
+                    | (Prefs.THEME_LIGHT.equals(mode) ? Configuration.UI_MODE_NIGHT_NO
+                    : Configuration.UI_MODE_NIGHT_YES);
+            configured = base.createConfigurationContext(override);
+        }
+        // Theme.Settings is where the DayNight parent and the brand roles already live. It is used here
+        // for what it resolves, not as a window theme, so it is not worth a second name.
+        return new android.view.ContextThemeWrapper(configured, R.style.Theme_Settings);
+    }
+
     public static boolean isTvBox(Context context) {
         final PackageManager pm = context.getPackageManager();
 

--- a/app/src/main/java/com/brouken/player/Utils.java
+++ b/app/src/main/java/com/brouken/player/Utils.java
@@ -734,22 +734,22 @@ class Utils {
      */
     public static Context dialogContext(final Context base) {
         String mode = Prefs.getThemeMode(base);
-        if (Prefs.THEME_SYSTEM.equals(mode) && isTvBox(base)) {
-            // A TV box has no system theme worth following, and PlayerActivity makes dark the default
-            // there — so on TV a dialog follows the app rather than the box.
-            mode = Prefs.THEME_DARK;
+        if (Prefs.THEME_SYSTEM.equals(mode)) {
+            if (isTvBox(base)) {
+                // A TV box has no system theme worth following, and PlayerActivity makes dark the
+                // default there — so on TV a dialog follows the app rather than the box.
+                mode = Prefs.THEME_DARK;
+            } else {
+                final int night = base.getResources().getConfiguration().uiMode
+                        & Configuration.UI_MODE_NIGHT_MASK;
+                mode = night == Configuration.UI_MODE_NIGHT_YES ? Prefs.THEME_DARK : Prefs.THEME_LIGHT;
+            }
         }
-        Context configured = base;
-        if (!Prefs.THEME_SYSTEM.equals(mode)) {
-            final Configuration override = new Configuration(base.getResources().getConfiguration());
-            override.uiMode = (override.uiMode & ~Configuration.UI_MODE_NIGHT_MASK)
-                    | (Prefs.THEME_LIGHT.equals(mode) ? Configuration.UI_MODE_NIGHT_NO
-                    : Configuration.UI_MODE_NIGHT_YES);
-            configured = base.createConfigurationContext(override);
-        }
-        // Theme.Settings is where the DayNight parent and the brand roles already live. It is used here
-        // for what it resolves, not as a window theme, so it is not worth a second name.
-        return new android.view.ContextThemeWrapper(configured, R.style.Theme_Settings);
+        // Wrapped straight around whatever it was handed — an Activity, in every real call — because a
+        // ContextThemeWrapper keeps its base's window token and a dialog needs one to exist at all.
+        return new android.view.ContextThemeWrapper(base,
+                Prefs.THEME_LIGHT.equals(mode) ? R.style.Theme_Dialogs_Light
+                        : R.style.Theme_Dialogs_Dark);
     }
 
     public static boolean isTvBox(Context context) {

--- a/app/src/main/java/com/brouken/player/update/UpdateUi.java
+++ b/app/src/main/java/com/brouken/player/update/UpdateUi.java
@@ -1,6 +1,7 @@
 package com.brouken.player.update;
 
 import android.app.Activity;
+import android.content.Context;
 import android.graphics.Typeface;
 import android.text.SpannableStringBuilder;
 import android.text.Spanned;
@@ -33,13 +34,14 @@ public final class UpdateUi {
      * {@code warnPlaybackStops} spells out that installing ends the film: the dialog is reachable
      * mid-playback from the button beside the gear, and the installer takes the process with it.
      */
-    public static void showAvailableDialog(final Activity activity, final UpdateInfo info,
+    public static void showAvailableDialog(final Activity activity, final Context dialogContext,
+                                           final UpdateInfo info,
                                            final Runnable onSkip, final boolean warnPlaybackStops) {
         if (activity.isFinishing()) {
             return;
         }
-        final int padH = dp(activity, 20);
-        final TextView message = new TextView(activity);
+        final int padH = dp(dialogContext, 20);
+        final TextView message = new TextView(dialogContext);
         final String header = activity.getString(R.string.update_available, BuildConfig.VERSION_NAME, info.versionName);
         final String changelog = info.changelog != null ? info.changelog.trim() : "";
 
@@ -54,14 +56,14 @@ public final class UpdateUi {
         message.setText(text);
         message.setMovementMethod(LinkMovementMethod.getInstance());
 
-        final ScrollView scroll = new ScrollView(activity);
-        scroll.setPadding(padH, dp(activity, 8), padH, 0);
+        final ScrollView scroll = new ScrollView(dialogContext);
+        scroll.setPadding(padH, dp(dialogContext, 8), padH, 0);
         scroll.addView(message);
 
-        final AlertDialog.Builder builder = new MaterialAlertDialogBuilder(activity)
+        final AlertDialog.Builder builder = new MaterialAlertDialogBuilder(dialogContext)
                 .setTitle(R.string.pref_update_header)
                 .setView(scroll)
-                .setPositiveButton(R.string.update_now, (dialog, which) -> startDownload(activity, info))
+                .setPositiveButton(R.string.update_now, (dialog, which) -> startDownload(activity, dialogContext, info))
                 .setNegativeButton(R.string.update_later, null);
         if (onSkip != null) {
             builder.setNeutralButton(R.string.update_skip, (dialog, which) -> onSkip.run());
@@ -70,16 +72,17 @@ public final class UpdateUi {
     }
 
     /** Downloads the APK with a progress dialog, then launches the system installer. */
-    public static void startDownload(final Activity activity, final UpdateInfo info) {
+    public static void startDownload(final Activity activity, final Context dialogContext,
+                                     final UpdateInfo info) {
         if (activity.isFinishing()) {
             return;
         }
-        final ProgressBar bar = new ProgressBar(activity, null, android.R.attr.progressBarStyleHorizontal);
+        final ProgressBar bar = new ProgressBar(dialogContext, null, android.R.attr.progressBarStyleHorizontal);
         bar.setMax(100);
         bar.setIndeterminate(info.size <= 0);
 
-        final int pad = dp(activity, 20);
-        final LinearLayout layout = new LinearLayout(activity);
+        final int pad = dp(dialogContext, 20);
+        final LinearLayout layout = new LinearLayout(dialogContext);
         layout.setOrientation(LinearLayout.VERTICAL);
         layout.setPadding(pad, pad, pad, pad);
         layout.addView(bar);
@@ -88,7 +91,7 @@ public final class UpdateUi {
         // dismiss it — so the cancel action reaches it through this holder. Nothing can read it before it
         // is assigned: show() only posts, and the assignment happens before this returns to the looper.
         final Thread[] download = new Thread[1];
-        final AlertDialog dialog = new MaterialAlertDialogBuilder(activity)
+        final AlertDialog dialog = new MaterialAlertDialogBuilder(dialogContext)
                 .setTitle(R.string.update_downloading)
                 .setView(layout)
                 // Without this the dialog had no way out at all: a download that stalls without failing
@@ -136,7 +139,7 @@ public final class UpdateUi {
         }
     }
 
-    private static int dp(final Activity activity, final int value) {
-        return Math.round(value * activity.getResources().getDisplayMetrics().density);
+    private static int dp(final Context context, final int value) {
+        return Math.round(value * context.getResources().getDisplayMetrics().density);
     }
 }

--- a/app/src/main/res/layout-w600dp/preference_theme_mode.xml
+++ b/app/src/main/res/layout-w600dp/preference_theme_mode.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Wide screens (w600dp — the available width, which is what "wide" means here; a 1280x720 TV at
+     213 dpi is 962dp across but only 541dp on its smallest side, so sw600dp misses it): the control is
+     sized to its content instead of being stretched across the row. Two
+     choices spread over a 1280dp TV read as a mistake, and Material sizes a segmented button to its
+     content once there is room for it. The segments stay equal without weights pulling them apart,
+     because every label fits inside the minimum width. Narrow screens keep layout/.
+
+     The row itself stays match_parent: GroupCards draws each card to the width of its first row, so a
+     row that wraps its content pulls the card in with it and leaves the switch below stranded outside
+     it. Only the buttons are sized to content. -->
+<com.google.android.material.button.MaterialButtonToggleGroup
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:paddingStart="16dp"
+    android:paddingEnd="16dp"
+    android:paddingTop="12dp"
+    android:paddingBottom="12dp"
+    app:selectionRequired="true"
+    app:singleSelection="true">
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/theme_mode_dark"
+        style="?attr/materialButtonOutlinedStyle"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:minWidth="132dp"
+        android:paddingStart="4dp"
+        android:paddingEnd="4dp"
+        android:text="@string/pref_theme_dark" />
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/theme_mode_light"
+        style="?attr/materialButtonOutlinedStyle"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:minWidth="132dp"
+        android:paddingStart="4dp"
+        android:paddingEnd="4dp"
+        android:text="@string/pref_theme_light" />
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/theme_mode_system"
+        style="?attr/materialButtonOutlinedStyle"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:minWidth="132dp"
+        android:paddingStart="4dp"
+        android:paddingEnd="4dp"
+        android:text="@string/pref_theme_system" />
+
+</com.google.android.material.button.MaterialButtonToggleGroup>

--- a/app/src/main/res/layout/preference_theme_mode.xml
+++ b/app/src/main/res/layout/preference_theme_mode.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Row layout for the theme preference: the three choices as one segmented control, which is
+     cheaper to read and to hit than a dialog with three radio rows. Wired in SettingsActivity. -->
+<com.google.android.material.button.MaterialButtonToggleGroup
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:paddingStart="16dp"
+    android:paddingEnd="16dp"
+    android:paddingTop="12dp"
+    android:paddingBottom="12dp"
+    app:selectionRequired="true"
+    app:singleSelection="true">
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/theme_mode_dark"
+        style="?attr/materialButtonOutlinedStyle"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_weight="1"
+        android:paddingStart="4dp"
+        android:paddingEnd="4dp"
+        android:text="@string/pref_theme_dark" />
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/theme_mode_light"
+        style="?attr/materialButtonOutlinedStyle"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_weight="1"
+        android:paddingStart="4dp"
+        android:paddingEnd="4dp"
+        android:text="@string/pref_theme_light" />
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/theme_mode_system"
+        style="?attr/materialButtonOutlinedStyle"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_weight="1"
+        android:paddingStart="4dp"
+        android:paddingEnd="4dp"
+        android:text="@string/pref_theme_system" />
+
+</com.google.android.material.button.MaterialButtonToggleGroup>

--- a/app/src/main/res/values-notouch/themes.xml
+++ b/app/src/main/res/values-notouch/themes.xml
@@ -9,4 +9,9 @@
     <style name="Theme.Error" parent="BaseTheme.Error">
         <item name="colorControlHighlight">@color/white</item>
     </style>
+    <!-- The settings list is where a remote spends most of its presses, and the default M3
+         highlight is barely a shade over the card it sits on. Same white as the other two. -->
+    <style name="Theme.Settings" parent="BaseTheme.Settings">
+        <item name="colorControlHighlight">@color/white</item>
+    </style>
 </resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -53,6 +53,12 @@
     <string name="pref_allow_system_framerate_on">Плеер может менять частоту обновления экрана под видео (на некоторых телевизорах возможно мигание)</string>
     <string name="pref_allow_system_framerate_off">Не менять частоту обновления экрана во время воспроизведения</string>
     <string name="pref_general_header">Общие</string>
+    <string name="pref_appearance_header">Внешний вид</string>
+    <string name="pref_theme_dark">Тёмная</string>
+    <string name="pref_theme_light">Светлая</string>
+    <string name="pref_theme_system">Системная</string>
+    <string name="pref_amoled">AMOLED-чёрный</string>
+    <string name="pref_amoled_summary">Чисто чёрный фон в тёмной теме</string>
     <string name="pref_title">Настройки</string>
     <string name="pref_repeat_toggle">Переключение повтора</string>
     <string name="pref_repeat_toggle_summary">Дополнительное управление, позволяющее бесконечно зацикливать видео (требуется перезапуск приложения)</string>

--- a/app/src/main/res/values-television/themes.xml
+++ b/app/src/main/res/values-television/themes.xml
@@ -9,4 +9,9 @@
     <style name="Theme.Error" parent="BaseTheme.Error">
         <item name="colorControlHighlight">@color/white</item>
     </style>
+    <!-- The settings list is where a remote spends most of its presses, and the default M3
+         highlight is barely a shade over the card it sits on. Same white as the other two. -->
+    <style name="Theme.Settings" parent="BaseTheme.Settings">
+        <item name="colorControlHighlight">@color/white</item>
+    </style>
 </resources>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -42,6 +42,12 @@
     <string name="delete_confirmation">Видалити</string>
     <string name="pref_title">Налаштування</string>
     <string name="pref_general_header">Загальні</string>
+    <string name="pref_appearance_header">Вигляд</string>
+    <string name="pref_theme_dark">Темна</string>
+    <string name="pref_theme_light">Світла</string>
+    <string name="pref_theme_system">Системна</string>
+    <string name="pref_amoled">AMOLED-чорний</string>
+    <string name="pref_amoled_summary">Чисто чорне тло в темній темі</string>
     <string name="pref_framerate_matching">Автоматичне узгодження частоти кадрів</string>
     <string name="pref_framerate_matching_on">Переключати частоту оновлення екрану відповідно до частоти кадрів відеосигналу</string>
     <string name="pref_framerate_matching_off">Не змінювати частоту оновлення екрану</string>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -11,6 +11,9 @@
     <color name="brand_container">#FF7A2019</color>
     <!-- M3 on-primary: the ink that sits on the brand, e.g. the switch handle when it is on. -->
     <color name="brand_on">#FF5F1411</color>
+    <!-- AMOLED: the card tone over a pure black window, still a shade above it so cards read as cards. -->
+    <color name="amoled_card">#FF141416</color>
+
     <color name="shortcut_background">#F5F5F5</color>
 
     <!-- Error screen (ErrorActivity): a calm dark surface, not an alarming full-red state. -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -43,6 +43,12 @@
     <string name="delete_confirmation">Delete</string>
     <string name="pref_title">Settings</string>
     <string name="pref_general_header">General</string>
+    <string name="pref_appearance_header">Appearance</string>
+    <string name="pref_theme_dark">Dark</string>
+    <string name="pref_theme_light">Light</string>
+    <string name="pref_theme_system">System</string>
+    <string name="pref_amoled">AMOLED black</string>
+    <string name="pref_amoled_summary">Use a pure black background in the dark theme</string>
     <string name="pref_framerate_matching">Auto frame rate matching</string>
     <string name="pref_framerate_matching_on">Switch display refresh rate to match video frame rate</string>
     <string name="pref_framerate_matching_off">Do not change display refresh rate</string>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -49,7 +49,7 @@
     <style name="Theme.Error" parent="BaseTheme.Error">
     </style>
 
-    <style name="Theme.Settings" parent="Theme.Material3.DayNight.NoActionBar">
+    <style name="BaseTheme.Settings" parent="Theme.Material3.DayNight.NoActionBar">
         <item name="alertDialogTheme">@style/ThemeOverlay.JustPlus.AlertDialog</item>
         <!-- One field with the list below it. Left unset, a Material theme paints the bar from the
              primary colour, which with a coral primary is a red band across the top of the screen.
@@ -61,6 +61,12 @@
         <item name="colorAccent">@color/brand</item>
         <item name="colorControlActivated">@color/brand</item>
         <item name="android:colorControlActivated">@color/brand</item>
+    </style>
+
+    <!-- Split like Theme.Player and Theme.Error, so values-television and values-notouch can give the
+         settings list the white focus highlight a remote needs. This is the screen a remote spends
+         the most presses in, and it was the one theme that never got the override. -->
+    <style name="Theme.Settings" parent="BaseTheme.Settings">
     </style>
 
     <!-- androidx.preference builds its list and text dialogs with a plain AlertDialog.Builder, so they

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -73,6 +73,15 @@
         <item name="android:windowBackground">@drawable/bg_dialog_material3</item>
     </style>
 
+    <!-- AMOLED: the M3 dark scheme with its greys taken out, for a panel that costs nothing to leave
+         black. Applied to the settings window at runtime, and only when the theme is actually dark. -->
+    <style name="ThemeOverlay.JustPlus.Amoled" parent="">
+        <item name="android:windowBackground">@color/black</item>
+        <item name="colorSurface">@color/black</item>
+        <item name="colorSurfaceContainer">@color/amoled_card</item>
+        <item name="colorSurfaceContainerHigh">@color/amoled_card</item>
+    </style>
+
     <style name="ExoStyledControls.Button.Center.Secondary" parent="ExoStyledControls.Button.Center">
         <item name="android:layout_width">60dp</item>
         <item name="android:layout_height">60dp</item>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -88,6 +88,24 @@
         <item name="colorSurfaceContainerHigh">@color/amoled_card</item>
     </style>
 
+    <!-- Themes for dialogs raised from the player, which is dark by design and so cannot follow the
+         appearance choice on its own. Two explicit themes rather than one DayNight theme over an
+         overridden configuration: createConfigurationContext returns a context with no activity
+         token, and a dialog built against one cannot add its window at all. -->
+    <style name="Theme.Dialogs.Light" parent="Theme.Material3.Light.NoActionBar">
+        <item name="alertDialogTheme">@style/ThemeOverlay.JustPlus.AlertDialog</item>
+        <item name="colorPrimary">@color/brand</item>
+        <item name="colorPrimaryContainer">@color/brand_container</item>
+        <item name="colorOnPrimary">@color/brand_on</item>
+    </style>
+
+    <style name="Theme.Dialogs.Dark" parent="Theme.Material3.Dark.NoActionBar">
+        <item name="alertDialogTheme">@style/ThemeOverlay.JustPlus.AlertDialog</item>
+        <item name="colorPrimary">@color/brand</item>
+        <item name="colorPrimaryContainer">@color/brand_container</item>
+        <item name="colorOnPrimary">@color/brand_on</item>
+    </style>
+
     <style name="ExoStyledControls.Button.Center.Secondary" parent="ExoStyledControls.Button.Center">
         <item name="android:layout_width">60dp</item>
         <item name="android:layout_height">60dp</item>
@@ -106,8 +124,9 @@
         <item name="android:backgroundDimEnabled">false</item>
     </style>
 
-    <!-- DayNight, because the dialog context this is applied over carries the appearance choice. -->
-    <style name="MediaStoreChooserDialog" parent="Theme.Material3.DayNight.Dialog.Alert">
+    <!-- Parentless on purpose: applied as an overlay over the dialog context, which already carries
+         the appearance choice. A parent here would replace that choice with its own. -->
+    <style name="MediaStoreChooserDialog" parent="">
         <item name="android:maxLines">1</item>
         <item name="android:ellipsize">end</item>
         <item name="android:singleLine">true</item> <!-- When focused, line scrolls -->

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -100,7 +100,8 @@
         <item name="android:backgroundDimEnabled">false</item>
     </style>
 
-    <style name="MediaStoreChooserDialog" parent="Theme.Material3.Dark.Dialog.Alert">
+    <!-- DayNight, because the dialog context this is applied over carries the appearance choice. -->
+    <style name="MediaStoreChooserDialog" parent="Theme.Material3.DayNight.Dialog.Alert">
         <item name="android:maxLines">1</item>
         <item name="android:ellipsize">end</item>
         <item name="android:singleLine">true</item> <!-- When focused, line scrolls -->

--- a/app/src/main/res/xml/root_preferences.xml
+++ b/app/src/main/res/xml/root_preferences.xml
@@ -438,7 +438,10 @@
 
     <PreferenceCategory app:title="@string/pref_dangerous_header">
 
+        <!-- Keyed so SettingsActivity can make it focusable on a remote: unselectable, a D-pad steps
+             from the header straight to the decoder rows and never lands on the warning about them. -->
         <Preference
+            app:key="dangerousWarning"
             app:selectable="false"
             app:summary="@string/pref_dangerous_warning" />
 

--- a/app/src/main/res/xml/root_preferences.xml
+++ b/app/src/main/res/xml/root_preferences.xml
@@ -5,6 +5,23 @@
          behind a row of its own (Skip segments, Watch together, subtitle Appearance). Paying a tap to
          reveal three switches is worse than reading them. -->
 
+    <PreferenceCategory app:title="@string/pref_appearance_header">
+
+        <!-- Written by SettingsActivity, which also binds the segmented control this row is. -->
+        <Preference
+            app:key="themeMode"
+            app:layout="@layout/preference_theme_mode"
+            app:persistent="false"
+            app:selectable="false" />
+
+        <SwitchPreferenceCompat
+            app:defaultValue="false"
+            app:key="amoledBlack"
+            app:summary="@string/pref_amoled_summary"
+            app:title="@string/pref_amoled" />
+
+    </PreferenceCategory>
+
     <PreferenceCategory app:title="@string/pref_general_header">
 
         <ListPreference


### PR DESCRIPTION
Part of the Material UI series, into `feature/material-ui`. Last of the settings work.

An Appearance section at the top of the list: Dark / Light / System as one segmented control, and AMOLED black for the dark theme. The player and the error screen are dark by design, so the choice reaches only the settings window.

The theme row is a plain `Preference` carrying a custom layout — one class fewer than a `Preference` subclass — bound through `holder.itemView`, because `Preference.onBindViewHolder` resets the id of the view it binds and an id on the layout root would not survive to be looked up.

### Two things this needed that were not obvious

**"System" stores `MODE_NIGHT_UNSPECIFIED`, not `MODE_NIGHT_FOLLOW_SYSTEM`.** A local night mode outranks the default one, and on a TV box `PlayerActivity` sets that default to dark deliberately — asking to follow the system there would hand a TV whose system is light a light settings screen, which is not what "System" is being offered for. `UNSPECIFIED` defers to whichever default is in force: the TV's dark, the phone's system. Checked on the TV emulator with its system switched to light — the screen stays dark.

**The window background has to be decided before anything reads `getDecorView()`.** Reading it builds the decor, and the decor takes its background from the theme exactly as it stands at that moment. The system-UI block that used to sit at the top of `onCreate` was therefore building the decor against the un-overlaid theme, and AMOLED came out as a grey window with black cards drawn on it. Measured rather than eyeballed: the window was `#141218` where the cards were `#141416`. With that block moved below the overlay, the window and the status bar read `#000000` and the cards `#141416`, which is the whole point of the option.

### Checked

All four stored states, set with `run-as sed` on the preferences file and a relaunch — no taps needed:

| Stored | Result |
|---|---|
| System (system light) | light screen, System checked |
| Dark (system light) | dark screen, Dark checked — the local mode wins |
| Dark + AMOLED | `#000000` window and status bar, `#141416` cards, no seam at the toolbar |
| Light + AMOLED on | light screen, AMOLED row greyed with its value kept |

On the TV emulator: the section renders at 1280 wide, the segmented control fits, and System resolves to dark even with the TV's own system set to light.

AMOLED is greyed under Light rather than hidden — it says the option exists and what it waits for. Under System it stays live, since the system can turn dark at any time.