### PR TITLE
Put every text field in a Material box

### DIFF
--- a/app/src/main/java/com/brouken/player/EmptyState.java
+++ b/app/src/main/java/com/brouken/player/EmptyState.java
@@ -221,7 +221,8 @@ class EmptyState {
     void askForLink() {
         final Context dialogContext = Utils.dialogContext(activity);
         final ViewGroup fields = Utils.dialogFields(dialogContext);
-        final EditText input = Utils.textField(fields, "https://");
+        final EditText input =
+                Utils.textField(fields, activity.getString(R.string.field_url), "https://");
         input.setInputType(InputType.TYPE_TEXT_VARIATION_URI);
         final Uri pasted = clipboardUri();
         if (pasted != null) {

--- a/app/src/main/java/com/brouken/player/EmptyState.java
+++ b/app/src/main/java/com/brouken/player/EmptyState.java
@@ -220,10 +220,9 @@ class EmptyState {
     // menu, which is why this is not private.
     void askForLink() {
         final Context dialogContext = Utils.dialogContext(activity);
-        final EditText input = new EditText(dialogContext);
+        final ViewGroup fields = Utils.dialogFields(dialogContext);
+        final EditText input = Utils.textField(fields, "https://");
         input.setInputType(InputType.TYPE_TEXT_VARIATION_URI);
-        input.setSingleLine(true);
-        input.setHint("https://");
         final Uri pasted = clipboardUri();
         if (pasted != null) {
             input.setText(pasted.toString());
@@ -231,7 +230,7 @@ class EmptyState {
         }
         new MaterialAlertDialogBuilder(dialogContext)
                 .setTitle(R.string.empty_state_link)
-                .setView(input)
+                .setView(fields)
                 .setPositiveButton(android.R.string.ok,
                         (dialog, which) -> openLink(input.getText().toString()))
                 .setNegativeButton(android.R.string.cancel, null)

--- a/app/src/main/java/com/brouken/player/PlayerActivity.java
+++ b/app/src/main/java/com/brouken/player/PlayerActivity.java
@@ -7575,7 +7575,8 @@ public class PlayerActivity extends Activity {
         final Context dialogContext = Utils.dialogContext(this);
         subtitleSearchForSecondary = forSecondary;
         final LinearLayout fields = Utils.dialogFields(dialogContext);
-        final EditText query = Utils.textField(fields, getString(R.string.subtitle_search_hint));
+        final EditText query = Utils.textField(fields, getString(R.string.subtitle_search_label),
+                getString(R.string.subtitle_search_hint));
         query.setInputType(InputType.TYPE_CLASS_TEXT);
         // Without this the keyboard takes the whole screen in landscape — its extract mode — and covers
         // the dialog it belongs to, list and all. The list is the point of this dialog: it fills in while
@@ -9063,7 +9064,7 @@ public class PlayerActivity extends Activity {
     private void askRoomPassword(final String code) {
         final Context dialogContext = Utils.dialogContext(this);
         final LinearLayout fields = Utils.dialogFields(dialogContext);
-        final EditText input = Utils.textField(fields, getString(R.string.together_password_hint));
+        final EditText input = Utils.textField(fields, getString(R.string.together_password));
         // The room has said it is locked, so the default is worth offering here exactly as it is offered
         // when creating one: people watching together tend to reuse one password, and this is the only
         // dialog that knows for certain a password is wanted. Not offered when joining by code, where
@@ -9106,8 +9107,7 @@ public class PlayerActivity extends Activity {
         name.setText(suggested);
         name.setSelection(name.getText().length());
 
-        final EditText password =
-                Utils.textField(fields, getString(R.string.together_password_hint));
+        final EditText password = Utils.textField(fields, getString(R.string.together_password));
         password.setText(mPrefs.togetherPassword);
 
         final CheckBox listed = new CheckBox(dialogContext);
@@ -9184,14 +9184,13 @@ public class PlayerActivity extends Activity {
         final LinearLayout fields = Utils.dialogFields(dialogContext);
         // Text, not digits: a room made in Lampa has a letter code, and the same six characters
         // have to be typeable here.
-        final EditText code = Utils.textField(fields, "ABC234");
+        final EditText code = Utils.textField(fields, getString(R.string.together_code), "ABC234");
         code.setInputType(InputType.TYPE_CLASS_TEXT | InputType.TYPE_TEXT_FLAG_CAP_CHARACTERS);
 
         // Rooms made in Lampa carry a password whenever that setting is on there, and it goes into
         // the room's address — so without it we would land somewhere else entirely and report, quite
         // truthfully and quite uselessly, that no such room exists.
-        final EditText password =
-                Utils.textField(fields, getString(R.string.together_password_hint));
+        final EditText password = Utils.textField(fields, getString(R.string.together_password));
 
         new MaterialAlertDialogBuilder(dialogContext)
                 .setTitle(R.string.together_join)

--- a/app/src/main/java/com/brouken/player/PlayerActivity.java
+++ b/app/src/main/java/com/brouken/player/PlayerActivity.java
@@ -7574,10 +7574,9 @@ public class PlayerActivity extends Activity {
     private void showSubtitleSearchDialog(final boolean forSecondary) {
         final Context dialogContext = Utils.dialogContext(this);
         subtitleSearchForSecondary = forSecondary;
-        final EditText query = new EditText(dialogContext);
+        final LinearLayout fields = Utils.dialogFields(dialogContext);
+        final EditText query = Utils.textField(fields, getString(R.string.subtitle_search_hint));
         query.setInputType(InputType.TYPE_CLASS_TEXT);
-        query.setSingleLine(true);
-        query.setHint(R.string.subtitle_search_hint);
         // Without this the keyboard takes the whole screen in landscape — its extract mode — and covers
         // the dialog it belongs to, list and all. The list is the point of this dialog: it fills in while
         // the name is still being typed, and a player is always in landscape.
@@ -7590,11 +7589,6 @@ public class PlayerActivity extends Activity {
         final android.widget.ScrollView scroll = new android.widget.ScrollView(this);
         scroll.addView(results);
 
-        final LinearLayout fields = new LinearLayout(dialogContext);
-        fields.setOrientation(LinearLayout.VERTICAL);
-        final int pad = Utils.dpToPx(16);
-        fields.setPadding(pad, 0, pad, 0);
-        fields.addView(query);
         // Capped rather than free: the list has to leave the field and the keyboard on screen, because
         // the next thing typed is what narrows it down. Half the window is the ceiling because the
         // player is landscape — a fixed height that fits a phone upright pushes the field off it.
@@ -7771,31 +7765,24 @@ public class PlayerActivity extends Activity {
         final Context dialogContext = Utils.dialogContext(this);
         final MediaId current = player != null ? mediaIdAt(player.getCurrentMediaItemIndex()) : null;
 
-        final EditText season = new EditText(dialogContext);
+        // Labelled, not hinted: prefilling is the normal case here — the whole point is to correct one
+        // digit of what is already believed — and a hint leaves the moment a field is filled, so both
+        // rows would read as a bare "1" and "2" with nothing to say which is which. The Material label
+        // rides the outline and stays.
+        final LinearLayout fields = Utils.dialogFields(dialogContext);
+        final EditText season =
+                Utils.textField(fields, getString(R.string.subtitle_search_season_label));
         season.setInputType(InputType.TYPE_CLASS_NUMBER);
-        season.setSingleLine(true);
         if (current != null && current.season >= 0) {
             season.setText(String.valueOf(current.season));
         }
 
-        final EditText episode = new EditText(dialogContext);
+        final EditText episode =
+                Utils.textField(fields, getString(R.string.subtitle_search_episode_label));
         episode.setInputType(InputType.TYPE_CLASS_NUMBER);
-        episode.setSingleLine(true);
         if (current != null && current.episode >= 1) {
             episode.setText(String.valueOf(current.episode));
         }
-
-        final LinearLayout fields = new LinearLayout(dialogContext);
-        fields.setOrientation(LinearLayout.VERTICAL);
-        final int pad = Utils.dpToPx(16);
-        fields.setPadding(pad, 0, pad, 0);
-        // Labelled above the fields, not only as hints: prefilling is the normal case here — the whole
-        // point is to correct one digit of what is already believed — and a filled field shows no hint,
-        // so both rows read as a bare "1" and "2" with nothing to say which is which.
-        fields.addView(fieldLabel(dialogContext, R.string.subtitle_search_season_label));
-        fields.addView(season);
-        fields.addView(fieldLabel(dialogContext, R.string.subtitle_search_episode_label));
-        fields.addView(episode);
 
         new MaterialAlertDialogBuilder(dialogContext)
                 .setTitle(R.string.subtitle_search_type)
@@ -7805,15 +7792,6 @@ public class PlayerActivity extends Activity {
                         number(episode.getText().toString(), -1), episodes))
                 .setNegativeButton(android.R.string.cancel, null)
                 .show();
-    }
-
-    /** A caption over a text field, in the register the dialog's own hints use. */
-    private TextView fieldLabel(final Context context, final int textRes) {
-        final TextView label = new TextView(context);
-        label.setText(textRes);
-        label.setTextSize(TypedValue.COMPLEX_UNIT_SP, ui.textCaption());
-        label.setPadding(0, Utils.dpToPx(8), 0, 0);
-        return label;
     }
 
     /** A typed number, or {@code fallback} for anything that is not one. */
@@ -9084,10 +9062,8 @@ public class PlayerActivity extends Activity {
     /** A room from the list said it has a password; the code we already know. */
     private void askRoomPassword(final String code) {
         final Context dialogContext = Utils.dialogContext(this);
-        final EditText input = new EditText(dialogContext);
-        input.setInputType(InputType.TYPE_CLASS_TEXT);
-        input.setSingleLine(true);
-        input.setHint(getString(R.string.together_password_hint));
+        final LinearLayout fields = Utils.dialogFields(dialogContext);
+        final EditText input = Utils.textField(fields, getString(R.string.together_password_hint));
         // The room has said it is locked, so the default is worth offering here exactly as it is offered
         // when creating one: people watching together tend to reuse one password, and this is the only
         // dialog that knows for certain a password is wanted. Not offered when joining by code, where
@@ -9098,7 +9074,7 @@ public class PlayerActivity extends Activity {
         input.setSelection(input.getText().length());
         new MaterialAlertDialogBuilder(dialogContext)
                 .setTitle(code)
-                .setView(input)
+                .setView(fields)
                 .setPositiveButton(android.R.string.ok,
                         (dialog, which) -> joinRoom(code, input.getText().toString()))
                 .setNegativeButton(android.R.string.cancel, null)
@@ -9124,16 +9100,14 @@ public class PlayerActivity extends Activity {
                 ? getString(R.string.together_room_default_name, code)
                 : card.optString("title");
 
-        final EditText name = new EditText(dialogContext);
-        name.setInputType(InputType.TYPE_CLASS_TEXT);
-        name.setSingleLine(true);
+        final LinearLayout fields = Utils.dialogFields(dialogContext);
+
+        final EditText name = Utils.textField(fields, getString(R.string.together_room_name));
         name.setText(suggested);
         name.setSelection(name.getText().length());
 
-        final EditText password = new EditText(dialogContext);
-        password.setInputType(InputType.TYPE_CLASS_TEXT);
-        password.setSingleLine(true);
-        password.setHint(getString(R.string.together_password_hint));
+        final EditText password =
+                Utils.textField(fields, getString(R.string.together_password_hint));
         password.setText(mPrefs.togetherPassword);
 
         final CheckBox listed = new CheckBox(dialogContext);
@@ -9150,12 +9124,6 @@ public class PlayerActivity extends Activity {
         note.setPadding(0, 0, 0, Utils.dpToPx(4));
         note.setVisibility(View.GONE);
 
-        final LinearLayout fields = new LinearLayout(dialogContext);
-        fields.setOrientation(LinearLayout.VERTICAL);
-        final int pad = Utils.dpToPx(16);
-        fields.setPadding(pad, 0, pad, 0);
-        fields.addView(name);
-        fields.addView(password);
         fields.addView(listed);
         fields.addView(note);
 
@@ -9213,27 +9181,17 @@ public class PlayerActivity extends Activity {
      *  nothing is playing yet — the gear menu lives in the player's controls. */
     void askRoomCode() {
         final Context dialogContext = Utils.dialogContext(this);
-        final EditText code = new EditText(dialogContext);
+        final LinearLayout fields = Utils.dialogFields(dialogContext);
         // Text, not digits: a room made in Lampa has a letter code, and the same six characters
         // have to be typeable here.
+        final EditText code = Utils.textField(fields, "ABC234");
         code.setInputType(InputType.TYPE_CLASS_TEXT | InputType.TYPE_TEXT_FLAG_CAP_CHARACTERS);
-        code.setSingleLine(true);
-        code.setHint("ABC234");
 
         // Rooms made in Lampa carry a password whenever that setting is on there, and it goes into
         // the room's address — so without it we would land somewhere else entirely and report, quite
         // truthfully and quite uselessly, that no such room exists.
-        final EditText password = new EditText(dialogContext);
-        password.setInputType(InputType.TYPE_CLASS_TEXT);
-        password.setSingleLine(true);
-        password.setHint(getString(R.string.together_password_hint));
-
-        final LinearLayout fields = new LinearLayout(dialogContext);
-        fields.setOrientation(LinearLayout.VERTICAL);
-        final int pad = Utils.dpToPx(16);
-        fields.setPadding(pad, 0, pad, 0);
-        fields.addView(code);
-        fields.addView(password);
+        final EditText password =
+                Utils.textField(fields, getString(R.string.together_password_hint));
 
         new MaterialAlertDialogBuilder(dialogContext)
                 .setTitle(R.string.together_join)

--- a/app/src/main/java/com/brouken/player/Utils.java
+++ b/app/src/main/java/com/brouken/player/Utils.java
@@ -774,9 +774,20 @@ class Utils {
      * the dialog reads and writes; the box around it needs nothing further said to it.
      */
     static EditText textField(final ViewGroup fields, final CharSequence hint) {
+        return textField(fields, hint, null);
+    }
+
+    /**
+     * The same, with an example of what to type. A label has to be a word or two because it shrinks
+     * onto the outline and stays there for good; an example is longer and is only worth reading with
+     * the field empty and in front of you, which is exactly when a placeholder shows.
+     */
+    static EditText textField(final ViewGroup fields, final CharSequence hint,
+                              final CharSequence placeholder) {
         final TextInputLayout field = (TextInputLayout) LayoutInflater.from(fields.getContext())
                 .inflate(R.layout.dialog_text_field, fields, false);
         field.setHint(hint);
+        field.setPlaceholderText(placeholder);
         fields.addView(field);
         return field.getEditText();
     }

--- a/app/src/main/java/com/brouken/player/Utils.java
+++ b/app/src/main/java/com/brouken/player/Utils.java
@@ -35,13 +35,17 @@ import android.os.SystemClock;
 import android.util.Log;
 import android.util.Rational;
 import android.view.Display;
+import android.view.LayoutInflater;
 import android.view.View;
+import android.view.ViewGroup;
 import android.view.Window;
 import android.view.WindowInsets;
 import android.view.WindowInsetsController;
 import android.view.WindowManager;
+import android.widget.EditText;
 import android.widget.FrameLayout;
 import android.widget.ImageButton;
+import android.widget.LinearLayout;
 import android.widget.Toast;
 
 import androidx.annotation.RequiresApi;
@@ -53,6 +57,7 @@ import androidx.media3.common.MimeTypes;
 import androidx.media3.common.util.UnstableApi;
 import androidx.media3.common.util.Util;
 
+import com.google.android.material.textfield.TextInputLayout;
 import com.obsez.android.lib.filechooser.ChooserDialog;
 import com.sigpwned.chardet4j.Chardet;
 import com.sigpwned.chardet4j.io.DecodedInputStreamReader;
@@ -750,6 +755,30 @@ class Utils {
         return new android.view.ContextThemeWrapper(base,
                 Prefs.THEME_LIGHT.equals(mode) ? R.style.Theme_Dialogs_Light
                         : R.style.Theme_Dialogs_Dark);
+    }
+
+    /**
+     * The strip a dialog's fields stand in, inset to the dialog's own text margin so a field lines
+     * up with the title above it.
+     */
+    static LinearLayout dialogFields(final Context context) {
+        final LinearLayout fields = new LinearLayout(context);
+        fields.setOrientation(LinearLayout.VERTICAL);
+        final int pad = dpToPx(24);
+        fields.setPadding(pad, 0, pad, 0);
+        return fields;
+    }
+
+    /**
+     * Adds a Material text field to {@link #dialogFields} and hands back the editor, which is what
+     * the dialog reads and writes; the box around it needs nothing further said to it.
+     */
+    static EditText textField(final ViewGroup fields, final CharSequence hint) {
+        final TextInputLayout field = (TextInputLayout) LayoutInflater.from(fields.getContext())
+                .inflate(R.layout.dialog_text_field, fields, false);
+        field.setHint(hint);
+        fields.addView(field);
+        return field.getEditText();
     }
 
     public static boolean isTvBox(Context context) {

--- a/app/src/main/res/color/dialog_button_dismissive.xml
+++ b/app/src/main/res/color/dialog_button_dismissive.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Cancel, and any neutral third action, in the surface's quieter ink. Both dialog buttons drawn in
+     the brand coral said the two were equal choices; only the confirming one is. Disabled follows the
+     M3 recipe - the surface's own ink at 38% - because the create-a-room dialog greys out OK. -->
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:alpha="0.38" android:color="?attr/colorOnSurface" android:state_enabled="false" />
+    <item android:color="?attr/colorOnSurfaceVariant" />
+</selector>

--- a/app/src/main/res/layout/dialog_text_field.xml
+++ b/app/src/main/res/layout/dialog_text_field.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- One text field of a dialog. Outlined rather than filled because a dialog panel is already a
+     raised surface: a filled box on top of it reads as a second card. The label rides the outline,
+     so a prefilled field still says what it is - which a hint alone cannot do. -->
+<com.google.android.material.textfield.TextInputLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    style="@style/Widget.Material3.TextInputLayout.OutlinedBox"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_marginTop="8dp">
+
+    <com.google.android.material.textfield.TextInputEditText
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:inputType="text" />
+
+</com.google.android.material.textfield.TextInputLayout>

--- a/app/src/main/res/layout/preference_dialog_text_field.xml
+++ b/app/src/main/res/layout/preference_dialog_text_field.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- androidx.preference's own dialog layout is a bare EditText between two 48dp gaps. Same two
+     views, same ids - the fragment finds them by id - on the field the rest of the app now uses. -->
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:paddingStart="24dp"
+    android:paddingEnd="24dp">
+
+    <TextView
+        android:id="@android:id/message"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="16dp"
+        android:textAppearance="?attr/textAppearanceBodyMedium"
+        android:textColor="?android:attr/textColorSecondary" />
+
+    <com.google.android.material.textfield.TextInputLayout
+        style="@style/Widget.Material3.TextInputLayout.OutlinedBox"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+
+        <com.google.android.material.textfield.TextInputEditText
+            android:id="@android:id/edit"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:inputType="text" />
+
+    </com.google.android.material.textfield.TextInputLayout>
+
+</LinearLayout>

--- a/app/src/main/res/layout/preference_dialog_url_field.xml
+++ b/app/src/main/res/layout/preference_dialog_url_field.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- preference_dialog_text_field, for the two settings that hold an address: labelled URL, and typed
+     on the keyboard's URL layout. A separate file because a layout cannot override a child's
+     attributes from the place it is used. -->
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:paddingStart="24dp"
+    android:paddingEnd="24dp">
+
+    <TextView
+        android:id="@android:id/message"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="16dp"
+        android:textAppearance="?attr/textAppearanceBodyMedium"
+        android:textColor="?android:attr/textColorSecondary" />
+
+    <com.google.android.material.textfield.TextInputLayout
+        style="@style/Widget.Material3.TextInputLayout.OutlinedBox"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:hint="@string/field_url">
+
+        <com.google.android.material.textfield.TextInputEditText
+            android:id="@android:id/edit"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:inputType="textUri" />
+
+    </com.google.android.material.textfield.TextInputLayout>
+
+</LinearLayout>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -137,6 +137,7 @@
     <string name="together_public">Показывать комнату в списке</string>
     <string name="together_public_needs_password">Публичная комната должна быть с паролем</string>
     <string name="together_room_default_name">Комната %1$s</string>
+    <string name="together_room_name">Название комнаты</string>
     <string name="together_badge">Комната %1$s · %2$d</string>
     <string name="together_offline">Комната %1$s · переподключение…</string>
     <string name="together_connecting">Комната %1$s · подключение…</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -130,7 +130,8 @@
     <string name="together_searching">Ищем комнаты…</string>
     <string name="together_none_found">Публичных комнат не найдено</string>
     <string name="together_room_summary">%1$s · смотрят: %2$d</string>
-    <string name="together_password_hint">Пароль, если комната с паролем</string>
+    <string name="together_password">Пароль</string>
+    <string name="together_code">Код</string>
     <string name="together_no_room">Комнаты с таким кодом нет — или нужен пароль</string>
     <string name="together_badge_named">%1$s [%2$s] · %3$d</string>
     <string name="together_create_title">Новая комната %1$s</string>
@@ -138,6 +139,7 @@
     <string name="together_public_needs_password">Публичная комната должна быть с паролем</string>
     <string name="together_room_default_name">Комната %1$s</string>
     <string name="together_room_name">Название комнаты</string>
+    <string name="field_url">URL</string>
     <string name="together_badge">Комната %1$s · %2$d</string>
     <string name="together_offline">Комната %1$s · переподключение…</string>
     <string name="together_connecting">Комната %1$s · подключение…</string>
@@ -287,6 +289,7 @@
     <string name="pref_subtitle_search_language_summary">Ручной поиск сначала предлагает список языков — только для этого поиска</string>
     <string name="subtitle_search_found">Найдены субтитры: %1$s</string>
     <string name="subtitle_search_manual">Найти субтитры онлайн</string>
+    <string name="subtitle_search_label">Название или id</string>
     <string name="subtitle_search_hint">Название или id из tmdb / imdb</string>
     <string name="subtitle_search_language_title">Выбор языка</string>
     <string name="subtitle_search_none">Ничего не найдено</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -131,7 +131,8 @@
     <string name="together_searching">Шукаємо кімнати…</string>
     <string name="together_none_found">Публічних кімнат не знайдено</string>
     <string name="together_room_summary">%1$s · дивляться: %2$d</string>
-    <string name="together_password_hint">Пароль, якщо кімната з паролем</string>
+    <string name="together_password">Пароль</string>
+    <string name="together_code">Код</string>
     <string name="together_no_room">Кімнати з таким кодом немає — або потрібен пароль</string>
     <string name="together_badge_named">%1$s [%2$s] · %3$d</string>
     <string name="together_create_title">Нова кімната %1$s</string>
@@ -139,6 +140,7 @@
     <string name="together_public_needs_password">Публічна кімната має бути із паролем</string>
     <string name="together_room_default_name">Кімната %1$s</string>
     <string name="together_room_name">Назва кімнати</string>
+    <string name="field_url">URL</string>
     <string name="together_badge">Кімната %1$s · %2$d</string>
     <string name="together_offline">Кімната %1$s · перепідключення…</string>
     <string name="together_connecting">Кімната %1$s · підключення…</string>
@@ -287,6 +289,7 @@
     <string name="pref_subtitle_search_language_summary">Ручний пошук спершу пропонує список мов — лише для цього пошуку</string>
     <string name="subtitle_search_found">Знайдено субтитри: %1$s</string>
     <string name="subtitle_search_manual">Знайти субтитри онлайн</string>
+    <string name="subtitle_search_label">Назва або id</string>
     <string name="subtitle_search_hint">Назва або id з tmdb / imdb</string>
     <string name="subtitle_search_language_title">Вибір мови</string>
     <string name="subtitle_search_none">Нічого не знайдено</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -138,6 +138,7 @@
     <string name="together_public">Показувати кімнату у списку</string>
     <string name="together_public_needs_password">Публічна кімната має бути із паролем</string>
     <string name="together_room_default_name">Кімната %1$s</string>
+    <string name="together_room_name">Назва кімнати</string>
     <string name="together_badge">Кімната %1$s · %2$d</string>
     <string name="together_offline">Кімната %1$s · перепідключення…</string>
     <string name="together_connecting">Кімната %1$s · підключення…</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -144,6 +144,7 @@
     <string name="together_public">List the room publicly</string>
     <string name="together_public_needs_password">A public room needs a password</string>
     <string name="together_room_default_name">Room %1$s</string>
+    <string name="together_room_name">Room name</string>
     <string name="together_badge">Room %1$s · %2$d</string>
     <string name="together_offline">Room %1$s · reconnecting…</string>
     <string name="together_connecting">Room %1$s · connecting…</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -137,7 +137,8 @@
     <string name="together_searching">Looking for rooms…</string>
     <string name="together_none_found">No public rooms found</string>
     <string name="together_room_summary">%1$s · %2$d watching</string>
-    <string name="together_password_hint">Password, if the room has one</string>
+    <string name="together_password">Password</string>
+    <string name="together_code">Code</string>
     <string name="together_no_room">No room with that code — or it needs a password</string>
     <string name="together_badge_named">%1$s [%2$s] · %3$d</string>
     <string name="together_create_title">New room %1$s</string>
@@ -145,6 +146,7 @@
     <string name="together_public_needs_password">A public room needs a password</string>
     <string name="together_room_default_name">Room %1$s</string>
     <string name="together_room_name">Room name</string>
+    <string name="field_url">URL</string>
     <string name="together_badge">Room %1$s · %2$d</string>
     <string name="together_offline">Room %1$s · reconnecting…</string>
     <string name="together_connecting">Room %1$s · connecting…</string>
@@ -311,6 +313,7 @@
     <string name="pref_subtitle_search_language_summary">A manual search offers the language list first, for that search only</string>
     <string name="subtitle_search_found">Subtitles found: %1$s</string>
     <string name="subtitle_search_manual">Find subtitles online</string>
+    <string name="subtitle_search_label">Title or id</string>
     <string name="subtitle_search_hint">Name, or a tmdb / imdb id</string>
     <string name="subtitle_search_language_title">Choose language</string>
     <string name="subtitle_search_none">Nothing found</string>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -51,6 +51,7 @@
 
     <style name="BaseTheme.Settings" parent="Theme.Material3.DayNight.NoActionBar">
         <item name="alertDialogTheme">@style/ThemeOverlay.JustPlus.AlertDialog</item>
+        <item name="materialAlertDialogTheme">@style/ThemeOverlay.JustPlus.AlertDialog</item>
         <!-- One field with the list below it. Left unset, a Material theme paints the bar from the
              primary colour, which with a coral primary is a red band across the top of the screen.
              SettingsActivity sets the icon appearance to match. -->
@@ -74,9 +75,25 @@
          parked on the right, in a square container. Hand it the Material pieces through the theme.
          The parent must be ThemeOverlay.Material3.MaterialAlertDialog — ThemeOverlay.Material3.Dialog.Alert
          sets only the button style, and m3_alert_dialog_title.xml needs materialAlertDialogTitlePanelStyle,
-         without which the first preference dialog to open throws InflateException. -->
+         without which the first preference dialog to open throws InflateException.
+         Every theme that raises a dialog points both `alertDialogTheme` and `materialAlertDialogTheme`
+         here: a plain AlertDialog.Builder reads the first, while MaterialAlertDialogBuilder never looks
+         at it - it applies the second itself, and whatever that names wins over the theme underneath. -->
     <style name="ThemeOverlay.JustPlus.AlertDialog" parent="ThemeOverlay.Material3.MaterialAlertDialog">
         <item name="android:windowBackground">@drawable/bg_dialog_material3</item>
+        <!-- Only the confirming action is coral. The ripple is left as it was: on a television the
+             focus wash of these buttons comes from it. -->
+        <item name="buttonBarNegativeButtonStyle">@style/Widget.JustPlus.Button.Dialog.Dismissive</item>
+        <item name="buttonBarNeutralButtonStyle">@style/Widget.JustPlus.Button.Dialog.Neutral</item>
+    </style>
+
+    <style name="Widget.JustPlus.Button.Dialog.Dismissive" parent="Widget.Material3.Button.TextButton.Dialog">
+        <item name="android:textColor">@color/dialog_button_dismissive</item>
+    </style>
+
+    <!-- The third action sits at the far edge, so it keeps Material's flush geometry. -->
+    <style name="Widget.JustPlus.Button.Dialog.Neutral" parent="Widget.Material3.Button.TextButton.Dialog.Flush">
+        <item name="android:textColor">@color/dialog_button_dismissive</item>
     </style>
 
     <!-- AMOLED: the M3 dark scheme with its greys taken out, for a panel that costs nothing to leave
@@ -94,6 +111,7 @@
          token, and a dialog built against one cannot add its window at all. -->
     <style name="Theme.Dialogs.Light" parent="Theme.Material3.Light.NoActionBar">
         <item name="alertDialogTheme">@style/ThemeOverlay.JustPlus.AlertDialog</item>
+        <item name="materialAlertDialogTheme">@style/ThemeOverlay.JustPlus.AlertDialog</item>
         <item name="colorPrimary">@color/brand</item>
         <item name="colorPrimaryContainer">@color/brand_container</item>
         <item name="colorOnPrimary">@color/brand_on</item>
@@ -101,6 +119,7 @@
 
     <style name="Theme.Dialogs.Dark" parent="Theme.Material3.Dark.NoActionBar">
         <item name="alertDialogTheme">@style/ThemeOverlay.JustPlus.AlertDialog</item>
+        <item name="materialAlertDialogTheme">@style/ThemeOverlay.JustPlus.AlertDialog</item>
         <item name="colorPrimary">@color/brand</item>
         <item name="colorPrimaryContainer">@color/brand_container</item>
         <item name="colorOnPrimary">@color/brand_on</item>

--- a/app/src/main/res/xml/root_preferences.xml
+++ b/app/src/main/res/xml/root_preferences.xml
@@ -404,6 +404,7 @@
             app:title="@string/together_title">
 
             <EditTextPreference
+                app:dialogLayout="@layout/preference_dialog_text_field"
                 app:key="togetherNick"
                 app:title="@string/pref_together_nick"
                 app:dialogTitle="@string/pref_together_nick"
@@ -415,18 +416,21 @@
                 app:summary="@string/pref_together_nick_random_summary" />
 
             <EditTextPreference
+                app:dialogLayout="@layout/preference_dialog_text_field"
                 app:key="togetherPassword"
                 app:title="@string/pref_together_password"
                 app:dialogTitle="@string/pref_together_password"
                 app:dialogMessage="@string/pref_together_password_summary" />
 
             <EditTextPreference
+                app:dialogLayout="@layout/preference_dialog_text_field"
                 app:key="togetherRelay"
                 app:title="@string/pref_together_relay"
                 app:dialogTitle="@string/pref_together_relay"
                 app:dialogMessage="@string/pref_together_relay_summary" />
 
             <EditTextPreference
+                app:dialogLayout="@layout/preference_dialog_text_field"
                 app:key="togetherInvitePage"
                 app:title="@string/pref_together_invite_page"
                 app:dialogTitle="@string/pref_together_invite_page"

--- a/app/src/main/res/xml/root_preferences.xml
+++ b/app/src/main/res/xml/root_preferences.xml
@@ -423,14 +423,14 @@
                 app:dialogMessage="@string/pref_together_password_summary" />
 
             <EditTextPreference
-                app:dialogLayout="@layout/preference_dialog_text_field"
+                app:dialogLayout="@layout/preference_dialog_url_field"
                 app:key="togetherRelay"
                 app:title="@string/pref_together_relay"
                 app:dialogTitle="@string/pref_together_relay"
                 app:dialogMessage="@string/pref_together_relay_summary" />
 
             <EditTextPreference
-                app:dialogLayout="@layout/preference_dialog_text_field"
+                app:dialogLayout="@layout/preference_dialog_url_field"
                 app:key="togetherInvitePage"
                 app:title="@string/pref_together_invite_page"
                 app:dialogTitle="@string/pref_together_invite_page"


### PR DESCRIPTION
Every text input in the app was a bare `EditText` on a Material panel: a hairline that all but vanishes on a dark surface, and a hint that leaves as soon as the field is filled.

**One field, everywhere.** Nine inputs across six dialogs now come from `Utils.textField(fields, hint)`, which inflates an outlined `TextInputLayout` into a `Utils.dialogFields(context)` strip inset to the dialog's own text margin. Outlined rather than filled: the dialog panel is already a raised surface. Two things fell out — `fieldLabel()`, which drew a caption over the season and episode fields only because a hint cannot survive prefilling, and four copies of the same field container.

`androidx.preference` builds its dialog from a layout of its own, so the four settings fields get `app:dialogLayout` pointing at a replacement carrying the two ids the fragment looks up by hand: `@android:id/edit` and `@android:id/message`.

**Labels are labels, examples are placeholders.** A floating label shrinks onto the outline and stays there, so it has to be a word or two: "Password, if the room has one" took a third of the dialog with it on focus. The labels are Code, Password, URL and Title or id now; the shape of a room code, the `https://` of a link and the tmdb / imdb id moved to the placeholder, which shows inside the empty field and leaves once there is something to read. The relay address and the invite page say URL and open the keyboard's URL layout.

**Only the confirming action is coral.** Cancel and OK were the same colour, so a dialog offered two equal choices where only one is the answer. The dismissive and neutral actions take the surface's quieter ink; the confirming one keeps the brand. Both dialog paths had to be told: a plain `AlertDialog.Builder` reads `alertDialogTheme`, but `MaterialAlertDialogBuilder` never looks at it — it applies `materialAlertDialogTheme` itself, and that overlay carries the button styles.

Seen running on a 720p television emulator in both appearances: the join-a-room dialog, the subtitle search dialog, and the relay-address and room-password preference dialogs.