### PR TITLE
Offer AMOLED black only when the screen is actually dark

### DIFF
--- a/app/src/main/java/com/brouken/player/SettingsActivity.java
+++ b/app/src/main/java/com/brouken/player/SettingsActivity.java
@@ -705,14 +705,15 @@ public class SettingsActivity extends AppCompatActivity
         }
 
         /**
-         * Pure black is something only a dark theme can be, so with Light chosen the row is greyed
-         * rather than hidden: it says the option exists and what it waits for. Under System it stays
-         * live — it takes effect whenever the system turns dark.
+         * Pure black is something only a dark theme can be, so while the screen is not dark the row is
+         * greyed rather than hidden: it says the option exists and what it waits for. Read from the
+         * configuration in force, not from the stored choice — under System with a light system the
+         * option is as inert as it is under Light, and offering it there is offering nothing.
          */
         private void syncAmoledEnabled() {
             final Preference amoled = findPreference("amoledBlack");
             if (amoled != null) {
-                amoled.setEnabled(!Prefs.THEME_LIGHT.equals(Prefs.getThemeMode(requireContext())));
+                amoled.setEnabled(((SettingsActivity) requireActivity()).isNight());
             }
         }
 


### PR DESCRIPTION
With System chosen and the system in light, the AMOLED row stayed live — and remembered being switched on — while doing nothing at all.

The row was greyed on the stored choice (`THEME_LIGHT` only), but the option depends on the configuration in force: both the overlay applied in `onCreate` and `repaintAmoledSurfaces` gate on `isNight()`. Under System with a light system the option is exactly as inert as it is under Light. `syncAmoledEnabled` reads `isNight()` now, so what the row offers and what it does cannot drift apart.

Both ways into the row still update it: a mode change that alters the configuration recreates the activity and rebinds, and a change where light and dark share one configuration calls `syncAmoledEnabled` from the segment listener.

Verified on the phone emulator through `uiautomator dump`: `enabled="false"` for the row under System with a light system, `enabled="true"` with the stored mode set to dark.