### PR TITLE
Build the release candidate as well as master

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -2,9 +2,9 @@ name: Android CI
 
 on:
   push:
-    branches: [master]
+    branches: [master, rc]
   pull_request:
-    branches: [master]
+    branches: [master, rc]
 
 jobs:
   build:


### PR DESCRIPTION
Feature branches land on `rc` now, and `rc` is what gets tried as a whole before it goes to master. A build that only watches master would see neither the merges into `rc` nor the pull requests that make them.