### PR TITLE
Draw the control scrims all the way to the bottom edge

### DIFF
--- a/app/src/main/java/com/brouken/player/PlayerActivity.java
+++ b/app/src/main/java/com/brouken/player/PlayerActivity.java
@@ -1969,8 +1969,8 @@ public class PlayerActivity extends Activity {
                 int paddingRight = insetH;
                 int marginRight = 0;
 
-                int bottomBarPaddingBottom = 0;
-                int progressBarMarginBottom = 0;
+                final int bottomBarPaddingBottom = windowInsets.getSystemWindowInsetBottom() + overscanV;
+                final int progressBarMarginBottom = bottomBarPaddingBottom;
 
                 // Don't use exo_top (the built-in top scrim): it is a sibling of exo_controls_background and Media3
                 // animates it on a different schedule, so it appears before / lingers after the header. Instead the
@@ -1978,23 +1978,18 @@ public class PlayerActivity extends Activity {
                 // being the header itself, it can never desync from it. Keep exo_top collapsed.
                 findViewById(R.id.exo_top).getLayoutParams().height = 0;
 
+                // Take the bottom inset by growing the bar, never by padding the control view itself: padding
+                // pulls every child up off the screen edge, the two scrims included (the full-screen dim and
+                // the bar's own gradient), and what shows through underneath is a bright strip of raw video.
+                // On TV that inset is pure overscan, so the strip appeared with nothing drawn over it at all.
+                final FrameLayout exoBottomBar = findViewById(R.id.exo_bottom_bar);
+                final ViewGroup.LayoutParams params = exoBottomBar.getLayoutParams();
+                params.height = getResources().getDimensionPixelSize(R.dimen.exo_styled_bottom_bar_height) + bottomBarPaddingBottom;
+                exoBottomBar.setLayoutParams(params);
+
                 if (Build.VERSION.SDK_INT >= 35) {
-                    final int left = windowInsets.getInsets(WindowInsets.Type.navigationBars()).left;
-                    final int right = windowInsets.getInsets(WindowInsets.Type.navigationBars()).right;
-
-                    final FrameLayout exoBottomBar = findViewById(R.id.exo_bottom_bar);
-                    ViewGroup.LayoutParams params = exoBottomBar.getLayoutParams();
-                    params.height = getResources().getDimensionPixelSize(R.dimen.exo_styled_bottom_bar_height) + windowInsets.getSystemWindowInsetBottom() + overscanV;
-                    exoBottomBar.setLayoutParams(params);
-
-                    findViewById(R.id.exo_left).getLayoutParams().width = left;
-                    findViewById(R.id.exo_right).getLayoutParams().width = right;
-
-                    bottomBarPaddingBottom = windowInsets.getSystemWindowInsetBottom() + overscanV;
-                    progressBarMarginBottom = windowInsets.getSystemWindowInsetBottom() + overscanV;
-                } else {
-                    // No top padding: the header panel's background (below) covers the status-bar area instead.
-                    view.setPadding(0, 0, 0, windowInsets.getSystemWindowInsetBottom() + overscanV);
+                    findViewById(R.id.exo_left).getLayoutParams().width = windowInsets.getInsets(WindowInsets.Type.navigationBars()).left;
+                    findViewById(R.id.exo_right).getLayoutParams().width = windowInsets.getInsets(WindowInsets.Type.navigationBars()).right;
                 }
 
                 // Extend the header's background up over the status-bar area (top margin -> 0, top inset moved into


### PR DESCRIPTION
## The bug

On Android TV a bright band runs across the bottom of the picture while the controls are on screen: a 16dp strip of raw, undimmed video with neither the full-screen control dim (`exo_controls_background`, `#66000000`) nor the bottom bar's gradient (`scrim_bottom`) painted over it.

## Cause

The insets listener on `PlayerControlView` took the bottom inset two different ways:

- **API 35+** — grow `exo_bottom_bar` by the inset and pad its contents. Correct: the bar's background still reaches the screen edge.
- **API 34 and below** — `view.setPadding(0, 0, 0, inset + overscanV)` on the control view itself. That pushes *every* child up off the edge, both scrims included, and the strip underneath shows the video untouched.

On phones that inset is the navigation bar, which covers the strip, so nothing was ever visible there. On TV it is pure overscan (`UiMetrics.overscanV()` = 16dp) with no system bar over it — hence the band.

Introduced in 749ff8a, which added `+ overscanV` to the pre-35 branch; before it the term was the system inset alone, which is 0 on TV. Present in every release from v0.1.1.

## Fix

Use the API 35+ approach on every version: grow the bar, pad its contents, leave the control view unpadded. The version check now guards only the navigation-bar side strips, which need the API 30 `WindowInsets.Type` call.

## Verification

TV emulator (1280x720, density 213), flat-grey clip so any overlay is measurable, with the pre-35 branch forced on:

- before — column at the bottom edge reads `690:27  700:141  710:141  718:141`; 141 is the raw video, the 21px strip drawn over by nothing;
- after — `690:39  700:33  710:26  718:21`, the gradient runs to the last row.

Everything else is unchanged: diffing the bottom 160px of the controls before and after the fix leaves only the clock digits.

## Note on scope

Android 14 and below now centre the middle controls in the full screen rather than in the nav-bar-inset area, matching what Android 15+ has always done. Bar contents, seek bar and Skip pill keep their positions.