### PR TITLE
Sync rc with master (TV bottom scrim fix, v1.4.3)

### DIFF
--- a/app/src/main/java/com/brouken/player/PlayerActivity.java
+++ b/app/src/main/java/com/brouken/player/PlayerActivity.java
@@ -12242,7 +12242,14 @@ public class PlayerActivity extends Activity {
     // guarded by mPrefs.revokedAudioMimes itself, so a repeat failure on the same mime after the
     // switch falls through to the normal error screen instead of looping.
     private boolean recoverByRevokingAudioMime(String mime, boolean persist) {
-        if (mime == null || player == null || audioSink == null
+        // audio/raw is never a passthrough mime: it is what a decoder feeds the sink, and it is also the
+        // format both audio renderers probe the sink with before they will decode anything at all. Denying
+        // it therefore denies decoding itself — every audio track becomes FORMAT_UNSUPPORTED_SUBTYPE, no
+        // audio track is selected, and the device plays every file in silence with no decoder in the
+        // report (JPP-C: a Realtek TV box, persisted, so no codec and no decoder priority brought sound
+        // back). An AudioTrack that failed while carrying decoded PCM reaches here with exactly that mime,
+        // via AudioSink.InitializationException.format, and there is nothing to revoke for it.
+        if (mime == null || MimeTypes.AUDIO_RAW.equals(mime) || player == null || audioSink == null
                 || mPrefs.revokedAudioMimes.contains(mime) || sessionRevokedAudioMimes.contains(mime)) {
             return false;
         }

--- a/app/src/main/java/com/brouken/player/PlayerActivity.java
+++ b/app/src/main/java/com/brouken/player/PlayerActivity.java
@@ -1969,8 +1969,8 @@ public class PlayerActivity extends Activity {
                 int paddingRight = insetH;
                 int marginRight = 0;
 
-                int bottomBarPaddingBottom = 0;
-                int progressBarMarginBottom = 0;
+                final int bottomBarPaddingBottom = windowInsets.getSystemWindowInsetBottom() + overscanV;
+                final int progressBarMarginBottom = bottomBarPaddingBottom;
 
                 // Don't use exo_top (the built-in top scrim): it is a sibling of exo_controls_background and Media3
                 // animates it on a different schedule, so it appears before / lingers after the header. Instead the
@@ -1978,23 +1978,18 @@ public class PlayerActivity extends Activity {
                 // being the header itself, it can never desync from it. Keep exo_top collapsed.
                 findViewById(R.id.exo_top).getLayoutParams().height = 0;
 
+                // Take the bottom inset by growing the bar, never by padding the control view itself: padding
+                // pulls every child up off the screen edge, the two scrims included (the full-screen dim and
+                // the bar's own gradient), and what shows through underneath is a bright strip of raw video.
+                // On TV that inset is pure overscan, so the strip appeared with nothing drawn over it at all.
+                final FrameLayout exoBottomBar = findViewById(R.id.exo_bottom_bar);
+                final ViewGroup.LayoutParams params = exoBottomBar.getLayoutParams();
+                params.height = getResources().getDimensionPixelSize(R.dimen.exo_styled_bottom_bar_height) + bottomBarPaddingBottom;
+                exoBottomBar.setLayoutParams(params);
+
                 if (Build.VERSION.SDK_INT >= 35) {
-                    final int left = windowInsets.getInsets(WindowInsets.Type.navigationBars()).left;
-                    final int right = windowInsets.getInsets(WindowInsets.Type.navigationBars()).right;
-
-                    final FrameLayout exoBottomBar = findViewById(R.id.exo_bottom_bar);
-                    ViewGroup.LayoutParams params = exoBottomBar.getLayoutParams();
-                    params.height = getResources().getDimensionPixelSize(R.dimen.exo_styled_bottom_bar_height) + windowInsets.getSystemWindowInsetBottom() + overscanV;
-                    exoBottomBar.setLayoutParams(params);
-
-                    findViewById(R.id.exo_left).getLayoutParams().width = left;
-                    findViewById(R.id.exo_right).getLayoutParams().width = right;
-
-                    bottomBarPaddingBottom = windowInsets.getSystemWindowInsetBottom() + overscanV;
-                    progressBarMarginBottom = windowInsets.getSystemWindowInsetBottom() + overscanV;
-                } else {
-                    // No top padding: the header panel's background (below) covers the status-bar area instead.
-                    view.setPadding(0, 0, 0, windowInsets.getSystemWindowInsetBottom() + overscanV);
+                    findViewById(R.id.exo_left).getLayoutParams().width = windowInsets.getInsets(WindowInsets.Type.navigationBars()).left;
+                    findViewById(R.id.exo_right).getLayoutParams().width = windowInsets.getInsets(WindowInsets.Type.navigationBars()).right;
                 }
 
                 // Extend the header's background up over the status-bar area (top margin -> 0, top inset moved into

--- a/app/src/main/java/com/brouken/player/Prefs.java
+++ b/app/src/main/java/com/brouken/player/Prefs.java
@@ -12,6 +12,7 @@ import android.preference.PreferenceManager;
 import android.provider.DocumentsContract;
 import android.text.TextUtils;
 
+import androidx.media3.common.MimeTypes;
 import androidx.media3.exoplayer.DefaultRenderersFactory;
 import androidx.media3.ui.AspectRatioFrameLayout;
 import androidx.media3.ui.CaptionStyleCompat;
@@ -452,6 +453,20 @@ class Prefs {
         // process restarted — including for the player rebuild that follows leaving the settings screen.
         revokedAudioMimes = mSharedPreferences.getStringSet(
                 PREF_KEY_REVOKED_AUDIO_MIMES, Collections.emptySet());
+        // A build up to 1.4.2 could write audio/raw here, when an AudioTrack carrying decoded PCM failed
+        // to open. That mime is what both audio renderers probe the sink with before they decode, so the
+        // entry left the device with no selectable audio track at all — silence for every file, every
+        // codec and every decoder priority, remembered for good. Dropped on read (rather than by another
+        // one-shot reset, which would throw away verdicts that are real) and rewritten, so the error
+        // report and the ffmpeg fallback see the same set as the sink.
+        if (revokedAudioMimes.contains(MimeTypes.AUDIO_RAW)) {
+            final Set<String> cleaned = new HashSet<>(revokedAudioMimes);
+            cleaned.remove(MimeTypes.AUDIO_RAW);
+            revokedAudioMimes = cleaned;
+            mSharedPreferences.edit()
+                    .putStringSet(PREF_KEY_REVOKED_AUDIO_MIMES, cleaned)
+                    .apply();
+        }
     }
 
     public void setLanguageAudio(final String languages) {


### PR DESCRIPTION
Bring `rc` up to date with `master` after the v1.4.3 fix release.

Carries #173 — the control scrims are drawn all the way to the bottom edge, so Android TV no longer shows a strip of undimmed video along the bottom of the picture while the controls are up.

Merge only; no new work on this branch.