### PR TITLE
Point CI at the renamed integration branch

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -2,9 +2,9 @@ name: Android CI
 
 on:
   push:
-    branches: [master, rc]
+    branches: [master, develop]
   pull_request:
-    branches: [master, rc]
+    branches: [master, develop]
 
 jobs:
   build:


### PR DESCRIPTION
The integration branch `rc` was renamed to `develop`. `android.yml` still listed `rc` in its push and pull_request triggers, so nothing would run on the branch or on PRs into it.