### PR TITLE
Player chrome on Material 3: one focus ring, one panel, plainer lists

### DIFF
--- a/app/src/main/java/com/brouken/player/DurationPanel.java
+++ b/app/src/main/java/com/brouken/player/DurationPanel.java
@@ -348,7 +348,7 @@ final class DurationPanel {
         key.setLayoutParams(new LinearLayout.LayoutParams(
                 0, ViewGroup.LayoutParams.MATCH_PARENT, 1f));
         key.setBackground(new RippleDrawable(
-                ColorStateList.valueOf(ContextCompat.getColor(activity, R.color.ripple_strong)),
+                ColorStateList.valueOf(ContextCompat.getColor(activity, R.color.ripple_chrome)),
                 null, null));
         key.setOnClickListener(v -> onTap.run());
         return key;
@@ -373,7 +373,7 @@ final class DurationPanel {
         mask.setCornerRadius(Utils.dpToPx(8));
         mask.setColor(Color.WHITE);
         action.setBackground(new RippleDrawable(
-                ColorStateList.valueOf(ContextCompat.getColor(activity, R.color.ripple_strong)),
+                ColorStateList.valueOf(ContextCompat.getColor(activity, R.color.ripple_chrome)),
                 null, mask));
         return action;
     }

--- a/app/src/main/java/com/brouken/player/DurationPanel.java
+++ b/app/src/main/java/com/brouken/player/DurationPanel.java
@@ -6,7 +6,6 @@ import android.content.res.ColorStateList;
 import android.content.res.Configuration;
 import android.graphics.Color;
 import android.graphics.Typeface;
-import android.graphics.drawable.ColorDrawable;
 import android.graphics.drawable.GradientDrawable;
 import android.graphics.drawable.RippleDrawable;
 import android.text.SpannableStringBuilder;
@@ -17,7 +16,6 @@ import android.view.Gravity;
 import android.view.KeyEvent;
 import android.view.View;
 import android.view.ViewGroup;
-import android.view.Window;
 import android.widget.ImageButton;
 import android.widget.LinearLayout;
 import android.widget.ScrollView;
@@ -264,8 +262,7 @@ final class DurationPanel {
         Utils.padForPickerInsets(activity, ui, insetSource, scrollView, hPad,
                 Utils.dpToPx(16), Utils.dpToPx(20));
 
-        dialog.setContentView(scrollView);
-        dialog.setCanceledOnTouchOutside(true);
+        Utils.pickerWindow(activity, ui, dialog, scrollView);
         // On TV the remote's number keys are the natural way in — arrowing across ten buttons is not.
         dialog.setOnKeyListener((d, keyCode, event) -> {
             if (event.getAction() != KeyEvent.ACTION_DOWN
@@ -275,15 +272,6 @@ final class DurationPanel {
             digitKeys[keyCode - KeyEvent.KEYCODE_0].performClick();
             return true;
         });
-        final Window window = dialog.getWindow();
-        if (window != null) {
-            // Deliberately NOT fullscreen/edge-to-edge — see OffsetPanel: a fullscreen dialog window makes
-            // OxygenOS treat the panel as immersive and demand two back swipes.
-            window.setLayout(ui.pickerWidthPx(cfg), ViewGroup.LayoutParams.MATCH_PARENT);
-            window.setGravity(Gravity.END);
-            window.setBackgroundDrawable(
-                    new ColorDrawable(ContextCompat.getColor(activity, R.color.chrome_surface)));
-        }
         // Only where there is a D-pad. In touch mode this scrolls the title out of sight for nothing, since
         // a focus ring is not drawn there anyway.
         if (firstKey[0] != null && ui.deviceClass == UiMetrics.DeviceClass.TV) {

--- a/app/src/main/java/com/brouken/player/DurationPanel.java
+++ b/app/src/main/java/com/brouken/player/DurationPanel.java
@@ -59,10 +59,9 @@ final class DurationPanel {
     }
 
     /**
-     * @param accent      brand accent for the readout and the Start action
      */
     static Dialog create(final Activity activity, final UiMetrics ui,
-                         final int accent, final String title, final Listener listener) {
+                         final String title, final Listener listener) {
         final int[] typed = {0}; // up to 4 digits, read as HHMM
 
         final Configuration cfg = activity.getResources().getConfiguration();
@@ -82,6 +81,10 @@ final class DurationPanel {
         // OffsetPanel for the same move and Utils.dialogContext for what it resolves.
         final Context ctx = Utils.dialogContext(activity);
         final int onSurface = MaterialColors.getColor(ctx, R.attr.colorOnSurface, Color.WHITE);
+        // The interface accent, not the chrome's: see OffsetPanel and @color/brand_accent.
+        final int accent = MaterialColors.getColor(ctx, R.attr.colorPrimary,
+                ContextCompat.getColor(ctx, R.color.brand_accent));
+
         final LinearLayout root = new LinearLayout(ctx);
         root.setOrientation(LinearLayout.VERTICAL);
 

--- a/app/src/main/java/com/brouken/player/DurationPanel.java
+++ b/app/src/main/java/com/brouken/player/DurationPanel.java
@@ -282,7 +282,7 @@ final class DurationPanel {
             window.setLayout(ui.pickerWidthPx(cfg), ViewGroup.LayoutParams.MATCH_PARENT);
             window.setGravity(Gravity.END);
             window.setBackgroundDrawable(
-                    new ColorDrawable(ContextCompat.getColor(activity, R.color.panel_surface)));
+                    new ColorDrawable(ContextCompat.getColor(activity, R.color.chrome_surface)));
         }
         // Only where there is a D-pad. In touch mode this scrolls the title out of sight for nothing, since
         // a focus ring is not drawn there anyway.

--- a/app/src/main/java/com/brouken/player/DurationPanel.java
+++ b/app/src/main/java/com/brouken/player/DurationPanel.java
@@ -347,10 +347,7 @@ final class DurationPanel {
         // them in pixels instead is what once squeezed this keypad down to its middle column.
         key.setLayoutParams(new LinearLayout.LayoutParams(
                 0, ViewGroup.LayoutParams.MATCH_PARENT, 1f));
-        key.setBackground(new RippleDrawable(
-                ColorStateList.valueOf(MaterialColors.getColor(ctx, R.attr.colorControlHighlight,
-                        ContextCompat.getColor(ctx, R.color.ripple_chrome))),
-                null, null));
+        key.setBackground(Utils.pickerRow(ctx, Color.TRANSPARENT));
         key.setOnClickListener(v -> onTap.run());
         return key;
     }
@@ -370,13 +367,7 @@ final class DurationPanel {
         // short, an ellipsis is a legible failure where a broken word is not.
         action.setSingleLine(true);
         action.setPadding(Utils.dpToPx(12), Utils.dpToPx(11), Utils.dpToPx(12), Utils.dpToPx(11));
-        final GradientDrawable mask = new GradientDrawable();
-        mask.setCornerRadius(Utils.dpToPx(8));
-        mask.setColor(Color.WHITE);
-        action.setBackground(new RippleDrawable(
-                ColorStateList.valueOf(MaterialColors.getColor(ctx, R.attr.colorControlHighlight,
-                        ContextCompat.getColor(ctx, R.color.ripple_chrome))),
-                null, mask));
+        action.setBackground(Utils.pickerRow(ctx, Color.TRANSPARENT));
         return action;
     }
 }

--- a/app/src/main/java/com/brouken/player/DurationPanel.java
+++ b/app/src/main/java/com/brouken/player/DurationPanel.java
@@ -2,6 +2,7 @@ package com.brouken.player;
 
 import android.app.Activity;
 import android.app.Dialog;
+import android.content.Context;
 import android.content.res.ColorStateList;
 import android.content.res.Configuration;
 import android.graphics.Color;
@@ -22,6 +23,8 @@ import android.widget.ScrollView;
 import android.widget.TextView;
 
 import androidx.core.content.ContextCompat;
+
+import com.google.android.material.color.MaterialColors;
 
 import java.util.Date;
 import java.util.Locale;
@@ -75,14 +78,18 @@ final class DurationPanel {
                 ? Math.max(36, Math.min(52, (cfg.screenHeightDp - 110) / 4 - 8))
                 : 52);
 
-        final LinearLayout root = new LinearLayout(activity);
+        // Built against the appearance choice rather than the player's own dark theme — see
+        // OffsetPanel for the same move and Utils.dialogContext for what it resolves.
+        final Context ctx = Utils.dialogContext(activity);
+        final int onSurface = MaterialColors.getColor(ctx, R.attr.colorOnSurface, Color.WHITE);
+        final LinearLayout root = new LinearLayout(ctx);
         root.setOrientation(LinearLayout.VERTICAL);
 
         // Left-aligned 18sp medium, as VLC's BottomSheetTitle is — and as every other picker header in
         // this app already is.
-        final TextView header = new TextView(activity);
+        final TextView header = new TextView(ctx);
         header.setText(title);
-        header.setTextColor(Color.WHITE);
+        header.setTextColor(onSurface);
         header.setTextSize(TypedValue.COMPLEX_UNIT_SP, ui.textTitle());
         header.setTypeface(Typeface.create("sans-serif-medium", Typeface.NORMAL));
         header.setMinHeight(ui.dp(48));
@@ -92,7 +99,7 @@ final class DurationPanel {
         // Laid out top down with plain margins, exactly as VLC's sheet is — no weight, no vertical centring.
         // Those two put a void above the readout and another below the keypad, and gave the scroll view room
         // to carry the title off the top edge. Nothing here needs to stretch.
-        final LinearLayout body = new LinearLayout(activity);
+        final LinearLayout body = new LinearLayout(ctx);
         body.setOrientation(landscape ? LinearLayout.HORIZONTAL : LinearLayout.VERTICAL);
         body.setLayoutParams(new LinearLayout.LayoutParams(
                 ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT));
@@ -100,14 +107,14 @@ final class DurationPanel {
 
         // Side by side the width splits 45/55 in the keypad's favour: it has three columns to seat, the
         // readout only its own digits and the two actions.
-        final LinearLayout readoutColumn = new LinearLayout(activity);
+        final LinearLayout readoutColumn = new LinearLayout(ctx);
         readoutColumn.setOrientation(LinearLayout.VERTICAL);
         readoutColumn.setLayoutParams(new LinearLayout.LayoutParams(
                 landscape ? Math.round(usableW * 0.45f) : ViewGroup.LayoutParams.MATCH_PARENT,
                 ViewGroup.LayoutParams.WRAP_CONTENT));
         body.addView(readoutColumn);
 
-        final LinearLayout valueRow = new LinearLayout(activity);
+        final LinearLayout valueRow = new LinearLayout(ctx);
         valueRow.setOrientation(LinearLayout.HORIZONTAL);
         valueRow.setGravity(Gravity.CENTER_VERTICAL);
         // A key row's height and margin, so the readout and the backspace share the centre line of the
@@ -121,7 +128,7 @@ final class DurationPanel {
         valueRow.setMinimumHeight(rowHeight);
         readoutColumn.addView(valueRow);
 
-        final TextView value = new TextView(activity);
+        final TextView value = new TextView(ctx);
         // 24sp bold, VLC's size for this readout — not the big light numeral of the skip-offset panel. That
         // one owns its whole panel; this one shares a line with a backspace and a narrow landscape column.
         value.setTextSize(TypedValue.COMPLEX_UNIT_SP, ui.sp(24));
@@ -132,7 +139,7 @@ final class DurationPanel {
                 0, ViewGroup.LayoutParams.WRAP_CONTENT, 1f));
         valueRow.addView(value);
 
-        final ImageButton backspace = new ImageButton(activity, null, 0,
+        final ImageButton backspace = new ImageButton(ctx, null, 0,
                 R.style.ExoStyledControls_Button_Bottom);
         backspace.setImageResource(R.drawable.ic_backspace_24dp);
         backspace.setContentDescription(activity.getString(R.string.sleep_timer_backspace));
@@ -140,8 +147,9 @@ final class DurationPanel {
 
         // Where the duration lands in wall-clock terms — the same phrasing the header uses for the end of
         // the video, since it answers the same question.
-        final TextView endsAt = new TextView(activity);
-        endsAt.setTextColor(ContextCompat.getColor(activity, R.color.ink_medium));
+        final TextView endsAt = new TextView(ctx);
+        endsAt.setTextColor(MaterialColors.getColor(ctx, R.attr.colorOnSurfaceVariant,
+                ContextCompat.getColor(ctx, R.color.ink_medium)));
         endsAt.setTextSize(TypedValue.COMPLEX_UNIT_SP, ui.textEndsAt());
         endsAt.setPadding(0, 0, 0, Utils.dpToPx(6));
         readoutColumn.addView(endsAt);
@@ -150,7 +158,8 @@ final class DurationPanel {
         final View divider = new View(activity);
         divider.setLayoutParams(new LinearLayout.LayoutParams(
                 ViewGroup.LayoutParams.MATCH_PARENT, Utils.dpToPx(1)));
-        divider.setBackgroundColor(ContextCompat.getColor(activity, R.color.divider));
+        divider.setBackgroundColor(MaterialColors.getColor(ctx, R.attr.colorOutlineVariant,
+                ContextCompat.getColor(ctx, R.color.divider)));
         readoutColumn.addView(divider);
 
         final Runnable render = () -> {
@@ -159,7 +168,7 @@ final class DurationPanel {
             text.append("  ");
             appendUnit(text, String.format(Locale.US, "%02d", typed[0] % 100), "m");
             value.setText(text);
-            value.setTextColor(typed[0] == 0 ? Color.WHITE : accent);
+            value.setTextColor(typed[0] == 0 ? onSurface : accent);
             backspace.setEnabled(typed[0] != 0);
             backspace.setAlpha(typed[0] != 0 ? 1f : 0.35f);
 
@@ -177,7 +186,7 @@ final class DurationPanel {
 
         final View[] firstKey = new View[1];
         final View[] digitKeys = new View[10];
-        final LinearLayout keypad = new LinearLayout(activity);
+        final LinearLayout keypad = new LinearLayout(ctx);
         keypad.setOrientation(LinearLayout.VERTICAL);
         final LinearLayout.LayoutParams keypadLp = new LinearLayout.LayoutParams(
                 landscape ? Math.round(usableW * 0.55f) : ViewGroup.LayoutParams.MATCH_PARENT,
@@ -187,10 +196,10 @@ final class DurationPanel {
         }
         keypad.setLayoutParams(keypadLp);
         for (int row = 0; row < 3; row++) {
-            final LinearLayout line = keyRow(activity, rowHeight);
+            final LinearLayout line = keyRow(ctx, rowHeight);
             for (int col = 0; col < 3; col++) {
                 final int digit = row * 3 + col + 1;
-                final View key = keyButton(activity, ui, String.valueOf(digit),
+                final View key = keyButton(ctx, ui, String.valueOf(digit),
                         () -> appendDigit(typed, digit, render));
                 digitKeys[digit] = key;
                 if (firstKey[0] == null) {
@@ -201,16 +210,16 @@ final class DurationPanel {
             keypad.addView(line);
         }
         // Last row as VLC has it: the two minute values worth a shortcut, either side of the zero.
-        final LinearLayout lastRow = keyRow(activity, rowHeight);
-        lastRow.addView(keyButton(activity, ui, ":00", () -> appendMinutes(typed, 0, render)));
-        digitKeys[0] = keyButton(activity, ui, "0", () -> appendDigit(typed, 0, render));
+        final LinearLayout lastRow = keyRow(ctx, rowHeight);
+        lastRow.addView(keyButton(ctx, ui, ":00", () -> appendMinutes(typed, 0, render)));
+        digitKeys[0] = keyButton(ctx, ui, "0", () -> appendDigit(typed, 0, render));
         lastRow.addView(digitKeys[0]);
-        lastRow.addView(keyButton(activity, ui, ":30", () -> appendMinutes(typed, 30, render)));
+        lastRow.addView(keyButton(ctx, ui, ":30", () -> appendMinutes(typed, 30, render)));
         keypad.addView(lastRow);
         body.addView(keypad);
 
         // Right-aligned at the foot, the way VLC ends its picker with "remove current" and "ok".
-        final LinearLayout actions = new LinearLayout(activity);
+        final LinearLayout actions = new LinearLayout(ctx);
         actions.setOrientation(LinearLayout.HORIZONTAL);
         actions.setGravity(Gravity.END);
         final LinearLayout.LayoutParams actionsLp = new LinearLayout.LayoutParams(
@@ -220,14 +229,14 @@ final class DurationPanel {
 
         final Dialog dialog = new Dialog(activity, android.R.style.Theme_Translucent_NoTitleBar);
 
-        final TextView stop = actionButton(activity, ui,
-                activity.getString(R.string.sleep_timer_stop), Color.WHITE);
+        final TextView stop = actionButton(ctx, ui,
+                ctx.getString(R.string.sleep_timer_stop), onSurface);
         stop.setOnClickListener(v -> {
             listener.onDurationPicked(0);
             dialog.dismiss();
         });
-        final TextView start = actionButton(activity, ui,
-                activity.getString(R.string.sleep_timer_start), accent);
+        final TextView start = actionButton(ctx, ui,
+                ctx.getString(R.string.sleep_timer_start), accent);
         start.setOnClickListener(v -> {
             final int total = totalMinutes(typed[0]);
             if (total <= 0) {
@@ -255,7 +264,7 @@ final class DurationPanel {
         // Backstop only. The sizing above is meant to make the panel fit outright; this catches what it
         // cannot foresee — a large font scale, split screen, a window shape not thought of — so that no
         // action can ever end up somewhere unreachable. No fillViewport: nothing in here wants to stretch.
-        final ScrollView scrollView = new ScrollView(activity);
+        final ScrollView scrollView = new ScrollView(ctx);
         scrollView.addView(root, new ViewGroup.LayoutParams(
                 ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT));
         // Only the sheet's own padding now — see Utils.pickerWindow for where the bars and the
@@ -309,8 +318,8 @@ final class DurationPanel {
         text.setSpan(new RelativeSizeSpan(0.5f), start, text.length(), 0);
     }
 
-    private static LinearLayout keyRow(final Activity activity, final int rowHeight) {
-        final LinearLayout line = new LinearLayout(activity);
+    private static LinearLayout keyRow(final Context ctx, final int rowHeight) {
+        final LinearLayout line = new LinearLayout(ctx);
         line.setOrientation(LinearLayout.HORIZONTAL);
         line.setWeightSum(3f);
         final LinearLayout.LayoutParams lp = new LinearLayout.LayoutParams(
@@ -321,11 +330,11 @@ final class DurationPanel {
     }
 
     /** A bare key: bold text on nothing, as VLC's are — only the touch ripple marks it out. */
-    private static TextView keyButton(final Activity activity, final UiMetrics ui,
+    private static TextView keyButton(final Context ctx, final UiMetrics ui,
                                       final String label, final Runnable onTap) {
-        final TextView key = new TextView(activity);
+        final TextView key = new TextView(ctx);
         key.setText(label);
-        key.setTextColor(Color.WHITE);
+        key.setTextColor(MaterialColors.getColor(ctx, R.attr.colorOnSurface, Color.WHITE));
         key.setTextSize(TypedValue.COMPLEX_UNIT_SP, ui.sp(18));
         key.setTypeface(Typeface.DEFAULT_BOLD);
         key.setGravity(Gravity.CENTER);
@@ -336,16 +345,17 @@ final class DurationPanel {
         key.setLayoutParams(new LinearLayout.LayoutParams(
                 0, ViewGroup.LayoutParams.MATCH_PARENT, 1f));
         key.setBackground(new RippleDrawable(
-                ColorStateList.valueOf(ContextCompat.getColor(activity, R.color.ripple_chrome)),
+                ColorStateList.valueOf(MaterialColors.getColor(ctx, R.attr.colorControlHighlight,
+                        ContextCompat.getColor(ctx, R.color.ripple_chrome))),
                 null, null));
         key.setOnClickListener(v -> onTap.run());
         return key;
     }
 
     /** One of two equal-width actions sharing the foot of the column. */
-    private static TextView actionButton(final Activity activity, final UiMetrics ui,
+    private static TextView actionButton(final Context ctx, final UiMetrics ui,
                                         final String label, final int color) {
-        final TextView action = new TextView(activity);
+        final TextView action = new TextView(ctx);
         action.setText(label.toUpperCase(Locale.getDefault()));
         action.setTextColor(color);
         action.setTextSize(TypedValue.COMPLEX_UNIT_SP, ui.textAction());
@@ -361,7 +371,8 @@ final class DurationPanel {
         mask.setCornerRadius(Utils.dpToPx(8));
         mask.setColor(Color.WHITE);
         action.setBackground(new RippleDrawable(
-                ColorStateList.valueOf(ContextCompat.getColor(activity, R.color.ripple_chrome)),
+                ColorStateList.valueOf(MaterialColors.getColor(ctx, R.attr.colorControlHighlight,
+                        ContextCompat.getColor(ctx, R.color.ripple_chrome))),
                 null, mask));
         return action;
     }

--- a/app/src/main/java/com/brouken/player/DurationPanel.java
+++ b/app/src/main/java/com/brouken/player/DurationPanel.java
@@ -67,7 +67,7 @@ final class DurationPanel {
         final Configuration cfg = activity.getResources().getConfiguration();
         final boolean landscape = cfg.orientation == Configuration.ORIENTATION_LANDSCAPE;
         final int hPad = Utils.dpToPx(24);
-        final int usableW = ui.pickerWidthPx(cfg) - 2 * hPad;
+        final int usableW = ui.panelWidthPx(cfg) - 2 * hPad;
 
         // Portrait has height to spare, so the rows simply take VLC's own size. Landscape has to divide what
         // is left after the title and the window insets — and only those: with the keypad beside the readout
@@ -274,9 +274,7 @@ final class DurationPanel {
         // overscan went.
         scrollView.setPadding(hPad, Utils.dpToPx(16), hPad, Utils.dpToPx(20));
 
-        // CONTROL: a keypad beside a readout is a layout of fixed proportions, and in landscape it
-        // already wants more height than the window has to give.
-        Utils.pickerWindow(activity, ui, dialog, scrollView, Utils.Panel.CONTROL);
+Utils.pickerWindow(activity, ui, dialog, scrollView);
         // On TV the remote's number keys are the natural way in — arrowing across ten buttons is not.
         dialog.setOnKeyListener((d, keyCode, event) -> {
             if (event.getAction() != KeyEvent.ACTION_DOWN

--- a/app/src/main/java/com/brouken/player/DurationPanel.java
+++ b/app/src/main/java/com/brouken/player/DurationPanel.java
@@ -274,7 +274,9 @@ final class DurationPanel {
         // overscan went.
         scrollView.setPadding(hPad, Utils.dpToPx(16), hPad, Utils.dpToPx(20));
 
-        Utils.pickerWindow(activity, ui, dialog, scrollView);
+        // CONTROL: a keypad beside a readout is a layout of fixed proportions, and in landscape it
+        // already wants more height than the window has to give.
+        Utils.pickerWindow(activity, ui, dialog, scrollView, Utils.Panel.CONTROL);
         // On TV the remote's number keys are the natural way in — arrowing across ten buttons is not.
         dialog.setOnKeyListener((d, keyCode, event) -> {
             if (event.getAction() != KeyEvent.ACTION_DOWN

--- a/app/src/main/java/com/brouken/player/DurationPanel.java
+++ b/app/src/main/java/com/brouken/player/DurationPanel.java
@@ -56,16 +56,15 @@ final class DurationPanel {
     }
 
     /**
-     * @param insetSource view used to read the window insets for the panel padding (any attached view)
      * @param accent      brand accent for the readout and the Start action
      */
-    static Dialog create(final Activity activity, final UiMetrics ui, final View insetSource,
+    static Dialog create(final Activity activity, final UiMetrics ui,
                          final int accent, final String title, final Listener listener) {
         final int[] typed = {0}; // up to 4 digits, read as HHMM
 
         final Configuration cfg = activity.getResources().getConfiguration();
         final boolean landscape = cfg.orientation == Configuration.ORIENTATION_LANDSCAPE;
-        final int hPad = Utils.dpToPx(24) + ui.overscanH();
+        final int hPad = Utils.dpToPx(24);
         final int usableW = ui.pickerWidthPx(cfg) - 2 * hPad;
 
         // Portrait has height to spare, so the rows simply take VLC's own size. Landscape has to divide what
@@ -259,8 +258,9 @@ final class DurationPanel {
         final ScrollView scrollView = new ScrollView(activity);
         scrollView.addView(root, new ViewGroup.LayoutParams(
                 ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT));
-        Utils.padForPickerInsets(activity, ui, insetSource, scrollView, hPad,
-                Utils.dpToPx(16), Utils.dpToPx(20));
+        // Only the sheet's own padding now — see Utils.pickerWindow for where the bars and the
+        // overscan went.
+        scrollView.setPadding(hPad, Utils.dpToPx(16), hPad, Utils.dpToPx(20));
 
         Utils.pickerWindow(activity, ui, dialog, scrollView);
         // On TV the remote's number keys are the natural way in — arrowing across ten buttons is not.

--- a/app/src/main/java/com/brouken/player/OffsetPanel.java
+++ b/app/src/main/java/com/brouken/player/OffsetPanel.java
@@ -7,25 +7,25 @@ import android.content.res.ColorStateList;
 import android.graphics.Color;
 import android.graphics.Typeface;
 import android.graphics.drawable.ColorDrawable;
-import android.graphics.drawable.Drawable;
-import android.graphics.drawable.GradientDrawable;
-import android.graphics.drawable.RippleDrawable;
-import android.graphics.drawable.StateListDrawable;
-import android.util.StateSet;
 import android.util.TypedValue;
 import android.view.Gravity;
+import android.view.KeyEvent;
 import android.view.View;
 import android.view.ViewGroup;
 import android.view.Window;
-import android.widget.ImageButton;
 import android.widget.LinearLayout;
 import android.widget.ScrollView;
-import android.widget.SeekBar;
 import android.widget.TextView;
 
+import androidx.annotation.NonNull;
 import androidx.core.content.ContextCompat;
 import androidx.core.view.ViewCompat;
 import androidx.core.widget.TextViewCompat;
+
+import com.google.android.material.button.MaterialButton;
+import com.google.android.material.button.MaterialButtonToggleGroup;
+import com.google.android.material.slider.LabelFormatter;
+import com.google.android.material.slider.Slider;
 
 import java.text.DecimalFormatSymbols;
 import java.util.ArrayList;
@@ -34,7 +34,9 @@ import java.util.Locale;
 
 /**
  * A reusable end-docked panel for adjusting signed offsets in seconds (skip timing, subtitle timing):
- * a large centred readout, a brand-tinted SeekBar flanked by −/+ icon buttons, and a Reset pill.
+ * a large centred readout, a brand-tinted Material {@link Slider} flanked by −/+ icon buttons, and a
+ * Reset button. What the panel picks rather than nudges is a {@link MaterialButtonToggleGroup}, the
+ * same segmented control the settings screen uses for the appearance choice.
  *
  * <p>A panel can carry more than one of those, which is what {@link Line} is for. Two subtitle lines
  * are two offsets, and two menu rows for one setting is a row too many — so they are stacked here
@@ -44,9 +46,9 @@ import java.util.Locale;
  * Input is split by device idiom, because one step size cannot serve both: a finger crossing the
  * narrow phone panel covers the whole ± range, so a raw drag moves the value in ragged sub-second
  * hops. Dragging therefore snaps to whole seconds, while the fine {@code stepSec} stays reachable
- * through the ± buttons. A remote gets the coarse step instead: a focused {@code SeekBar} answers
- * left and right itself, so the ± buttons beside it cannot be reached by a D-pad at all — the step
- * a press moves is sized for that in {@link #addLine}.
+ * through the ± buttons. A remote gets the coarse step instead: a focused slider answers left and
+ * right itself, so the ± buttons beside it cannot be reached by a D-pad at all — the step a press
+ * moves is sized for that in {@link #addLine}.
  *
  * The panel owns the current values and reports every change through {@link Listener}; the caller
  * only holds the returned dialog so it can dismiss it.
@@ -72,14 +74,14 @@ final class OffsetPanel {
     }
 
     /**
-     * One thing the panel picks rather than nudges: a row of pills, the one in force lit.
+     * One thing the panel picks rather than nudges: a segmented control, the option in force checked.
      *
      * <p>It lives in this panel and not in a menu of its own because what is being picked and what is
-     * being nudged are one thing to the person watching — how this film's skips behave. Pills rather
-     * than a list: four short words fit across the panel, and a choice that shows all of its options at
-     * once is one press to change from a remote as well as from a finger. No caption: the panel's title
-     * already says what is being chosen, and a third label in the same style as the two below it turned
-     * the panel into a list of look-alikes.
+     * being nudged are one thing to the person watching — how this film's skips behave. A segmented
+     * control rather than a list: four short words fit across the panel, and a choice that shows all of
+     * its options at once is one press to change from a remote as well as from a finger. No caption:
+     * the panel's title already says what is being chosen, and a third label in the same style as the
+     * two below it turned the panel into a list of look-alikes.
      */
     static final class Choice {
 
@@ -144,17 +146,17 @@ final class OffsetPanel {
 
         final List<Runnable> resets = new ArrayList<>();
         final boolean picking = choices != null && choices.length > 0;
-        TextView firstPill = null;
+        MaterialButton firstPill = null;
         if (picking) {
             for (final Choice choice : choices) {
-                final TextView lit = addChoice(activity, ui, root, accent, choice, resets);
+                final MaterialButton lit = addChoice(activity, ui, root, choice, resets);
                 if (firstPill == null) {
                     firstPill = lit;
                 }
             }
         }
 
-        SeekBar firstBar = null;
+        Slider firstBar = null;
         // One value gets the big readout it was designed for; two share the height, so they take the
         // clock's size instead. Two 44sp numbers plus their sliders do not fit a phone held sideways,
         // and what fell off the bottom was the second slider — the panel looked like it could only
@@ -165,7 +167,7 @@ final class OffsetPanel {
         final float valueSp = lines.length > 1 || picking ? ui.textClock() : ui.textValue();
         for (final Line line : lines) {
             root.addView(verticalSpacer(activity));
-            final SeekBar bar = addLine(activity, ui, root, accent, line, maxSec, stepSec, valueSp, resets);
+            final Slider bar = addLine(activity, ui, root, accent, line, maxSec, stepSec, valueSp, resets);
             if (firstBar == null) {
                 firstBar = bar;
             }
@@ -173,21 +175,17 @@ final class OffsetPanel {
 
         root.addView(verticalSpacer(activity));
 
-        final TextView reset = new TextView(activity);
+        // Outlined, like the segmented control above it: one button family for the whole panel. Material
+        // draws its own focus and press states, which is what replaced the hand-drawn ring here.
+        final MaterialButton reset = new MaterialButton(activity, null,
+                com.google.android.material.R.attr.materialButtonOutlinedStyle);
         reset.setText(activity.getString(R.string.skip_offset_reset));
-        reset.setTextColor(Color.WHITE);
         reset.setTextSize(TypedValue.COMPLEX_UNIT_SP, ui.textAction());
-        reset.setGravity(Gravity.CENTER);
-        reset.setClickable(true);
-        reset.setFocusable(true);
-        reset.setPadding(Utils.dpToPx(28), Utils.dpToPx(11), Utils.dpToPx(28), Utils.dpToPx(11));
-        reset.setMinHeight(ui.dpS(48)); // a pill this small is missed as often as it is hit
-        // The same focus edge the pills take: a ripple is touch feedback, not something a remote across
-        // a room can find, and this pill is the last stop of the D-pad path through here.
-        final int resetCorner = Utils.dpToPx(22);
-        reset.setBackground(new RippleDrawable(
-                ColorStateList.valueOf(ContextCompat.getColor(activity, R.color.ripple_chrome)),
-                pillFill(activity, accent, false, resetCorner), roundMask(resetCorner)));
+        // Material insets a button by 6dp top and bottom to reach its 48dp touch target from a 36dp
+        // box. This panel sizes its own rows, so the inset only shortens them.
+        reset.setInsetTop(0);
+        reset.setInsetBottom(0);
+        reset.setMinHeight(ui.dpS(48)); // a target this small is missed as often as it is hit
         final LinearLayout.LayoutParams resetLp = new LinearLayout.LayoutParams(
                 ViewGroup.LayoutParams.WRAP_CONTENT, ViewGroup.LayoutParams.WRAP_CONTENT);
         resetLp.gravity = Gravity.CENTER_HORIZONTAL;
@@ -237,86 +235,85 @@ final class OffsetPanel {
     }
 
     /**
-     * A row of pills for one choice, the one in force lit — and lit means the brightest thing in the
-     * row, not a tinted version of it.
+     * One choice as a Material segmented control, the option in force checked.
      *
-     * <p>That is the whole of the second attempt at this row. The first drew the option in force as the
-     * accent at a third of its alpha with accent text, which measured 1.1:1 against its neighbours and
-     * read as the one option that had been switched off. Filled with the accent and lettered in the
-     * panel's own near-black, it is unmistakable, it carries the same colour the readouts use for "you
-     * changed this", and {@code setSelected} says the same thing again to a screen reader — which no
-     * amount of colour can.
+     * <p>Two earlier attempts are worth not repeating. The first drew the option in force as the accent
+     * at a third of its alpha with accent text, which measured 1.1:1 against its neighbours and read as
+     * the one option that had been switched off. The second filled it with the accent and lettered it
+     * in the panel's own near-black — unmistakable, but a shape this app drew by hand and nothing else
+     * in it shared. {@link MaterialButtonToggleGroup} is the same control the settings screen gives the
+     * appearance choice, so the two now say "pick one of these" in one language, and checked state
+     * reaches a screen reader without any of it depending on colour.
      *
-     * @return the pill to hand the first focus to
+     * @return the button to hand the first focus to
      */
-    private static TextView addChoice(final Activity activity, final UiMetrics ui,
-                                      final LinearLayout root, final int accent, final Choice choice,
-                                      final List<Runnable> resets) {
-        final int corner = Utils.dpToPx(16);
-        final LinearLayout row = new LinearLayout(activity);
-        row.setOrientation(LinearLayout.HORIZONTAL);
-        final TextView[] pills = new TextView[choice.values.length];
-        final int[] picked = {indexOf(choice.values, choice.current)};
-        final Runnable render = () -> {
-            for (int i = 0; i < pills.length; i++) {
-                final boolean on = i == picked[0];
-                pills[i].setBackground(new RippleDrawable(
-                        ColorStateList.valueOf(ContextCompat.getColor(activity, R.color.ripple_chrome)),
-                        pillFill(activity, accent, on, corner), roundMask(corner)));
-                pills[i].setTextColor(ContextCompat.getColor(activity,
-                        on ? R.color.ink_on_accent : R.color.ink_medium));
-                pills[i].setTypeface(on ? Typeface.DEFAULT_BOLD : Typeface.DEFAULT);
-                // Said again without colour, for a screen reader and for anyone who cannot tell these
-                // two shades apart.
-                pills[i].setSelected(on);
-            }
-        };
+    private static MaterialButton addChoice(final Activity activity, final UiMetrics ui,
+                                            final LinearLayout root, final Choice choice,
+                                            final List<Runnable> resets) {
+        final MaterialButtonToggleGroup group = new MaterialButtonToggleGroup(activity);
+        group.setSingleSelection(true);
+        // The panel opens with nothing checked when the settings disagree with themselves, and this only
+        // stops a *press* from clearing the last one — it does not force a selection at bind time.
+        group.setSelectionRequired(true);
+
+        final MaterialButton[] pills = new MaterialButton[choice.values.length];
         for (int i = 0; i < choice.values.length; i++) {
-            final TextView pill = new TextView(activity);
+            final MaterialButton pill = new MaterialButton(activity, null,
+                    com.google.android.material.R.attr.materialButtonOutlinedStyle);
+            pill.setId(View.generateViewId()); // the group tracks its buttons by id
             pill.setText(choice.labels[i]);
-            pill.setGravity(Gravity.CENTER);
-            pill.setClickable(true);
-            pill.setFocusable(true);
             pill.setMaxLines(1);
+            pill.setInsetTop(0);
+            pill.setInsetBottom(0);
+            pill.setMinHeight(ui.dpS(48)); // the platform's floor for anything a finger has to hit
+            pill.setPadding(ui.dpS(4), pill.getPaddingTop(), ui.dpS(4), pill.getPaddingBottom());
             // Shrunk rather than wrapped or clipped: the widest label already fills its share of the
             // row at the ordinary size, so a longer language or a system font a notch up used to break
             // one word across two lines and leave the row ragged.
             TextViewCompat.setAutoSizeTextTypeUniformWithConfiguration(
                     pill, (int) ui.textAction() - 4, (int) ui.textAction(), 1,
                     TypedValue.COMPLEX_UNIT_SP);
-            pill.setPadding(ui.dpS(4), ui.dpS(12), ui.dpS(4), ui.dpS(12));
-            pill.setMinHeight(ui.dpS(48)); // the platform's floor for anything a finger has to hit
-            // Equal shares of the row rather than each pill's own width: four words of different
-            // lengths read as a set this way, and the widest of them decides nothing.
-            final LinearLayout.LayoutParams lp = new LinearLayout.LayoutParams(
-                    0, ViewGroup.LayoutParams.MATCH_PARENT, 1f);
-            // Gaps between the pills only: an outer margin here would set the row in from the title
-            // above it by the width of the gap, which is exactly the misalignment it looks like.
-            lp.leftMargin = i == 0 ? 0 : Utils.dpToPx(3);
-            lp.rightMargin = i == choice.values.length - 1 ? 0 : Utils.dpToPx(3);
-            pill.setLayoutParams(lp);
-            final int index = i;
-            pill.setOnClickListener(v -> {
-                if (picked[0] == index) {
+            // Equal shares of the row rather than each button's own width: four words of different
+            // lengths read as a set this way, and the widest of them decides nothing. The group is a
+            // LinearLayout, so weights work and it joins the segments into one control itself.
+            group.addView(pill, new LinearLayout.LayoutParams(
+                    0, ViewGroup.LayoutParams.WRAP_CONTENT, 1f));
+            pills[i] = pill;
+        }
+
+        final int start = indexOf(choice.values, choice.current);
+        if (start >= 0) {
+            group.check(pills[start].getId());
+        }
+        // Reset checks a button itself, and a programmatic check fires the same listener a press does.
+        final boolean[] muted = {false};
+        group.addOnButtonCheckedListener((g, checkedId, isChecked) -> {
+            if (!isChecked || muted[0]) {
+                return;
+            }
+            for (int i = 0; i < pills.length; i++) {
+                if (pills[i].getId() == checkedId) {
+                    choice.listener.onPicked(choice.values[i]);
                     return;
                 }
-                picked[0] = index;
-                render.run();
-                choice.listener.onPicked(choice.values[index]);
-            });
-            pills[i] = pill;
-            row.addView(pill);
-        }
-        render.run();
-        root.addView(row);
+            }
+        });
+
+        root.addView(group);
         resets.add(() -> {
             // Back to whatever the settings say, which is what "reset" means for a panel that only ever
             // held this session's answers. Without it there was no way back from a choice at all.
-            picked[0] = indexOf(choice.values, choice.inherited);
-            render.run();
+            final int inherited = indexOf(choice.values, choice.inherited);
+            muted[0] = true;
+            if (inherited < 0) {
+                group.clearChecked();
+            } else {
+                group.check(pills[inherited].getId());
+            }
+            muted[0] = false;
             choice.listener.onPicked(null);
         });
-        return pills[Math.max(0, picked[0])];
+        return pills[Math.max(0, start)];
     }
 
     private static int indexOf(final String[] values, final String value) {
@@ -328,42 +325,11 @@ final class OffsetPanel {
         return -1; // nothing lit: the panel is not going to guess which one is in force
     }
 
-    /** Pill background: filled with the accent while in force, and edged in white while focused. */
-    private static Drawable pillFill(final Context context, final int accent, final boolean on,
-                                     final int corner) {
-        final StateListDrawable states = new StateListDrawable();
-        states.addState(new int[]{android.R.attr.state_focused},
-                pillShape(context, accent, on, corner, true));
-        states.addState(StateSet.WILD_CARD, pillShape(context, accent, on, corner, false));
-        return states;
-    }
-
-    private static Drawable pillShape(final Context context, final int accent, final boolean on,
-                                      final int corner, final boolean focused) {
-        final GradientDrawable shape = new GradientDrawable();
-        shape.setCornerRadius(corner);
-        shape.setColor(on ? accent : ContextCompat.getColor(context, R.color.pill_off_fill));
-        if (focused) {
-            // The accent, like the Skip pill's own focus ring — and white only on the pill that is
-            // already the accent, where a coral edge would not show. One signal and one language: an
-            // edge appears, nothing moves and nothing changes size, so the row keeps its rhythm.
-            shape.setStroke(Utils.dpToPx(2), on ? Color.WHITE : accent);
-        }
-        return shape;
-    }
-
-    private static Drawable roundMask(final int corner) {
-        final GradientDrawable mask = new GradientDrawable();
-        mask.setCornerRadius(corner);
-        mask.setColor(Color.WHITE);
-        return mask;
-    }
-
-    /** Caption, readout and slider for one offset. Returns its SeekBar; adds its reset to {@code resets}. */
-    private static SeekBar addLine(final Activity activity, final UiMetrics ui, final LinearLayout root,
-                                   final int accent, final Line line, final double maxSec,
-                                   final double stepSec, final float valueSp,
-                                   final List<Runnable> resets) {
+    /** Caption, readout and slider for one offset. Returns its Slider; adds its reset to {@code resets}. */
+    private static Slider addLine(final Activity activity, final UiMetrics ui, final LinearLayout root,
+                                  final int accent, final Line line, final double maxSec,
+                                  final double stepSec, final float valueSp,
+                                  final List<Runnable> resets) {
         final int trackBg = ContextCompat.getColor(activity, R.color.track_white);
         final int progressMax = (int) Math.round(2 * maxSec / stepSec);
         final int mid = progressMax / 2;
@@ -392,27 +358,33 @@ final class OffsetPanel {
         value.setPadding(0, 0, 0, Utils.dpToPx(20));
         root.addView(value);
 
-        final SeekBar seekBar = new SeekBar(activity);
-        seekBar.setMax(progressMax);
-        // D-pad step, scaled to the range instead of fixed at 2 × stepSec. Fixed, it made the wide
-        // subtitle range unreachable from a remote: measured on a television, five presses moved the
-        // value 2.5 s, so ±180 s was 360 presses to one edge with the thumb barely leaving the middle.
-        // A press is now a ninetieth of the range, floored at 2 × stepSec so the narrow skip panel keeps
-        // exactly the step it had. The fine step stays on the ± buttons, which is where it belongs.
-        seekBar.setKeyProgressIncrement(Math.max(2, (int) Math.round(maxSec / 90 / stepSec)));
-        seekBar.setProgress((int) Math.round(line.initialSec / stepSec) + mid);
-        seekBar.setFocusable(true);
-        seekBar.setSplitTrack(false);
-        seekBar.setProgressTintList(ColorStateList.valueOf(accent));
+        // Counted in steps, not in seconds: valueFrom/valueTo/stepSize are floats, and a Slider refuses
+        // a range that is not a whole number of steps — ±180 s at 0.1 s is exactly the sum that does not
+        // survive float division. Whole steps keep the arithmetic that was already here.
+        final Slider seekBar = new Slider(activity);
+        seekBar.setValueFrom(0f);
+        seekBar.setValueTo(progressMax);
+        seekBar.setStepSize(1f);
+        seekBar.setValue(Math.round(line.initialSec / stepSec) + mid);
+        // A tick per step is 3600 dots across the subtitle range.
+        seekBar.setTickVisible(false);
+        // The readout above is the label, and it is four times the size of the bubble.
+        seekBar.setLabelBehavior(LabelFormatter.LABEL_GONE);
         seekBar.setThumbTintList(ColorStateList.valueOf(accent));
-        seekBar.setProgressBackgroundTintList(ColorStateList.valueOf(trackBg));
+        seekBar.setTrackActiveTintList(ColorStateList.valueOf(accent));
+        seekBar.setTrackInactiveTintList(ColorStateList.valueOf(trackBg));
+        seekBar.setHaloTintList(ColorStateList.valueOf(accent));
 
-        final ImageButton minus = new ImageButton(activity, null, 0, R.style.ExoStyledControls_Button_Bottom);
-        minus.setImageResource(R.drawable.ic_remove_24dp);
-        minus.setContentDescription("-");
-        final ImageButton plus = new ImageButton(activity, null, 0, R.style.ExoStyledControls_Button_Bottom);
-        plus.setImageResource(R.drawable.ic_add_24dp);
-        plus.setContentDescription("+");
+        // D-pad step, scaled to the range instead of the slider's own one-step-per-press. Left to
+        // itself it made the wide subtitle range unreachable from a remote: measured on a television,
+        // five presses moved the value 2.5 s, so ±180 s was 360 presses to one edge with the thumb
+        // barely leaving the middle. A press is now a ninetieth of the range, floored at 2 × stepSec so
+        // the narrow skip panel keeps exactly the step it had. The fine step stays on the ± buttons,
+        // which is where it belongs. Slider has no key-increment setter, hence the key listener.
+        final int keyStep = Math.max(2, (int) Math.round(maxSec / 90 / stepSec));
+
+        final MaterialButton minus = iconButton(activity, R.drawable.ic_remove_24dp, "-");
+        final MaterialButton plus = iconButton(activity, R.drawable.ic_add_24dp, "+");
 
         final LinearLayout row = new LinearLayout(activity);
         row.setOrientation(LinearLayout.HORIZONTAL);
@@ -446,49 +418,76 @@ final class OffsetPanel {
         };
 
         final boolean[] dragging = {false};
-        seekBar.setOnSeekBarChangeListener(new SeekBar.OnSeekBarChangeListener() {
-            @Override
-            public void onProgressChanged(SeekBar sb, int progress, boolean fromUser) {
-                if (!fromUser) {
-                    return;
-                }
-                int p = progress;
-                if (dragging[0]) {
-                    // Snap the finger to whole seconds. setProgress re-enters with fromUser=false, so the
-                    // value is applied here and the nested callback is a no-op.
-                    p = Math.round((float) p / dragSnap) * dragSnap;
-                    if (p != progress) {
-                        sb.setProgress(p);
-                    }
-                }
-                current[0] = (p - mid) * stepSec;
-                apply.run();
+        seekBar.addOnChangeListener((sb, v, fromUser) -> {
+            if (!fromUser) {
+                return;
             }
-
+            final int progress = Math.round(v);
+            int p = progress;
+            if (dragging[0]) {
+                // Snap the finger to whole seconds. setValue re-enters with fromUser=false, so the
+                // value is applied here and the nested callback is a no-op.
+                p = Math.round((float) p / dragSnap) * dragSnap;
+                if (p != progress) {
+                    sb.setValue(p);
+                }
+            }
+            current[0] = (p - mid) * stepSec;
+            apply.run();
+        });
+        seekBar.addOnSliderTouchListener(new Slider.OnSliderTouchListener() {
             @Override
-            public void onStartTrackingTouch(SeekBar sb) {
+            public void onStartTrackingTouch(@NonNull Slider sb) {
                 dragging[0] = true;
             }
 
             @Override
-            public void onStopTrackingTouch(SeekBar sb) {
+            public void onStopTrackingTouch(@NonNull Slider sb) {
                 dragging[0] = false;
             }
+        });
+        seekBar.setOnKeyListener((v, keyCode, event) -> {
+            if (event.getAction() != KeyEvent.ACTION_DOWN) {
+                return false;
+            }
+            int dir = keyCode == KeyEvent.KEYCODE_DPAD_LEFT ? -1
+                    : keyCode == KeyEvent.KEYCODE_DPAD_RIGHT ? +1 : 0;
+            if (dir == 0) {
+                return false;
+            }
+            if (v.getLayoutDirection() == View.LAYOUT_DIRECTION_RTL) {
+                dir = -dir; // the slider mirrors, so left is more and right is less
+            }
+            step(seekBar, dir * keyStep, progressMax, mid, stepSec, current, apply);
+            return true;
         });
         minus.setOnClickListener(v -> step(seekBar, -1, progressMax, mid, stepSec, current, apply));
         plus.setOnClickListener(v -> step(seekBar, +1, progressMax, mid, stepSec, current, apply));
         resets.add(() -> {
-            seekBar.setProgress(mid);
+            seekBar.setValue(mid);
             current[0] = 0;
             apply.run();
         });
         return seekBar;
     }
 
-    private static void step(SeekBar seekBar, int delta, int progressMax, int mid, double stepSec,
+    /** A ± button: Material's icon button, in the panel's white rather than its own muted grey. */
+    private static MaterialButton iconButton(final Activity activity, final int icon,
+                                             final String description) {
+        final MaterialButton button = new MaterialButton(activity, null,
+                com.google.android.material.R.attr.materialIconButtonStyle);
+        button.setIconResource(icon);
+        button.setIconTint(ColorStateList.valueOf(Color.WHITE));
+        button.setContentDescription(description);
+        button.setInsetTop(0);
+        button.setInsetBottom(0);
+        return button;
+    }
+
+    private static void step(Slider seekBar, int delta, int progressMax, int mid, double stepSec,
                              double[] current, Runnable apply) {
-        final int p = Math.min(progressMax, Math.max(0, seekBar.getProgress() + delta));
-        seekBar.setProgress(p);
+        final int p = Math.min(progressMax, Math.max(0, Math.round(seekBar.getValue()) + delta));
+        seekBar.setValue(p);
         current[0] = (p - mid) * stepSec;
         apply.run();
     }

--- a/app/src/main/java/com/brouken/player/OffsetPanel.java
+++ b/app/src/main/java/com/brouken/player/OffsetPanel.java
@@ -252,9 +252,7 @@ final class OffsetPanel {
         scroller.addView(root);
 
         final Dialog dialog = new Dialog(activity, android.R.style.Theme_Translucent_NoTitleBar);
-        // CONTROL, not OPTIONS: this panel's sliders retime a line drawn at the bottom of the frame
-        // while it plays, so it must never be the thing covering that line.
-        Utils.pickerWindow(activity, ui, dialog, scroller, Utils.Panel.CONTROL);
+Utils.pickerWindow(activity, ui, dialog, scroller);
         // The theme carries no title bar, so this is the only name a screen reader can announce.
         dialog.setTitle(title);
         // The choice, not the slider: it is the panel's first decision and it is at the top, so a

--- a/app/src/main/java/com/brouken/player/OffsetPanel.java
+++ b/app/src/main/java/com/brouken/player/OffsetPanel.java
@@ -21,6 +21,7 @@ import androidx.core.content.ContextCompat;
 import androidx.core.view.ViewCompat;
 import androidx.core.widget.TextViewCompat;
 
+import com.google.android.material.color.MaterialColors;
 import com.google.android.material.button.MaterialButton;
 import com.google.android.material.button.MaterialButtonToggleGroup;
 import com.google.android.material.slider.LabelFormatter;
@@ -154,27 +155,32 @@ final class OffsetPanel {
     static Dialog create(final Activity activity, final UiMetrics ui,
                          final int accent, final String title, final double maxSec,
                          final double stepSec, final Choice[] choices, final Line... lines) {
+        // Every view in here is built against the appearance choice, not against the player's own dark
+        // theme, so the panel is light when the app is light and black under AMOLED. A
+        // ContextThemeWrapper keeps the activity's window token, which the dialog still needs.
+        final Context ctx = Utils.dialogContext(activity);
+        final int onSurface = MaterialColors.getColor(ctx, R.attr.colorOnSurface, Color.WHITE);
         final Rhythm rhythm = Rhythm.of(activity.getResources().getConfiguration());
-        final LinearLayout root = new LinearLayout(activity);
+        final LinearLayout root = new LinearLayout(ctx);
         root.setOrientation(LinearLayout.VERTICAL);
 
-        final TextView header = new TextView(activity);
+        final TextView header = new TextView(ctx);
         header.setText(title);
         ViewCompat.setAccessibilityHeading(header, true);
-        header.setTextColor(Color.WHITE);
+        header.setTextColor(onSurface);
         header.setTextSize(TypedValue.COMPLEX_UNIT_SP, ui.textTitle());
         header.setTypeface(Typeface.DEFAULT_BOLD);
         // Space, not a rule: the hairline that used to sit here had a caption under it, and once the
         // caption went it landed a few pixels above the row of pills and read as their top border.
         root.addView(header);
-        root.addView(gap(activity, rhythm.title));
+        root.addView(gap(ctx, rhythm.title));
 
         final List<Runnable> resets = new ArrayList<>();
         final boolean picking = choices != null && choices.length > 0;
         MaterialButton firstPill = null;
         if (picking) {
             for (final Choice choice : choices) {
-                final MaterialButton lit = addChoice(activity, ui, root, choice, resets);
+                final MaterialButton lit = addChoice(ctx, ui, root, choice, resets);
                 if (firstPill == null) {
                     firstPill = lit;
                 }
@@ -197,23 +203,23 @@ final class OffsetPanel {
         boolean firstBlock = !picking;
         for (final Line line : lines) {
             if (!firstBlock) {
-                root.addView(gap(activity, rhythm.block));
+                root.addView(gap(ctx, rhythm.block));
             }
             firstBlock = false;
-            final Slider bar = addLine(activity, ui, root, accent, line, maxSec, stepSec, valueSp,
+            final Slider bar = addLine(ctx, ui, root, accent, line, maxSec, stepSec, valueSp,
                     rhythm, resets);
             if (firstBar == null) {
                 firstBar = bar;
             }
         }
 
-        root.addView(gap(activity, rhythm.block));
+        root.addView(gap(ctx, rhythm.block));
 
         // Outlined, like the segmented control above it: one button family for the whole panel. Material
         // draws its own focus and press states, which is what replaced the hand-drawn ring here.
-        final MaterialButton reset = new MaterialButton(activity, null,
+        final MaterialButton reset = new MaterialButton(ctx, null,
                 com.google.android.material.R.attr.materialButtonOutlinedStyle);
-        reset.setText(activity.getString(R.string.skip_offset_reset));
+        reset.setText(ctx.getString(R.string.skip_offset_reset));
         reset.setTextSize(TypedValue.COMPLEX_UNIT_SP, ui.textAction());
         // Material insets a button by 6dp top and bottom to reach its 48dp touch target from a 36dp
         // box. This panel sizes its own rows, so the inset only shortens them.
@@ -240,7 +246,7 @@ final class OffsetPanel {
         // Scrolled, because a clipped panel is a panel that lies: the readouts stayed on screen while
         // the slider under the second one did not. No fillViewport — nothing in here stretches now that
         // the card is sized to its content, and the sliders drag across, so nothing fights the scroll.
-        final ScrollView scroller = new ScrollView(activity);
+        final ScrollView scroller = new ScrollView(ctx);
         scroller.addView(root);
 
         final Dialog dialog = new Dialog(activity, android.R.style.Theme_Translucent_NoTitleBar);
@@ -270,10 +276,10 @@ final class OffsetPanel {
      *
      * @return the button to hand the first focus to
      */
-    private static MaterialButton addChoice(final Activity activity, final UiMetrics ui,
+    private static MaterialButton addChoice(final Context ctx, final UiMetrics ui,
                                             final LinearLayout root, final Choice choice,
                                             final List<Runnable> resets) {
-        final MaterialButtonToggleGroup group = new MaterialButtonToggleGroup(activity);
+        final MaterialButtonToggleGroup group = new MaterialButtonToggleGroup(ctx);
         group.setSingleSelection(true);
         // The panel opens with nothing checked when the settings disagree with themselves, and this only
         // stops a *press* from clearing the last one — it does not force a selection at bind time.
@@ -281,7 +287,7 @@ final class OffsetPanel {
 
         final MaterialButton[] pills = new MaterialButton[choice.values.length];
         for (int i = 0; i < choice.values.length; i++) {
-            final MaterialButton pill = new MaterialButton(activity, null,
+            final MaterialButton pill = new MaterialButton(ctx, null,
                     com.google.android.material.R.attr.materialButtonOutlinedStyle);
             pill.setId(View.generateViewId()); // the group tracks its buttons by id
             pill.setText(choice.labels[i]);
@@ -349,20 +355,24 @@ final class OffsetPanel {
     }
 
     /** Caption, readout and slider for one offset. Returns its Slider; adds its reset to {@code resets}. */
-    private static Slider addLine(final Activity activity, final UiMetrics ui, final LinearLayout root,
+    private static Slider addLine(final Context ctx, final UiMetrics ui, final LinearLayout root,
                                   final int accent, final Line line, final double maxSec,
                                   final double stepSec, final float valueSp, final Rhythm rhythm,
                                   final List<Runnable> resets) {
-        final int trackBg = ContextCompat.getColor(activity, R.color.track_white);
+        // The unplayed half of a track is a surface, not white: white is invisible on a light panel.
+        final int trackBg = MaterialColors.getColor(ctx, R.attr.colorSurfaceVariant,
+                ContextCompat.getColor(ctx, R.color.track_white));
+        final int onSurface = MaterialColors.getColor(ctx, R.attr.colorOnSurface, Color.WHITE);
         final int progressMax = (int) Math.round(2 * maxSec / stepSec);
         final int mid = progressMax / 2;
         final int dragSnap = Math.max(1, (int) Math.round(1 / stepSec)); // drag resolution: 1 s
         final double[] current = {line.initialSec};
 
         if (line.caption != null) {
-            final TextView caption = new TextView(activity);
+            final TextView caption = new TextView(ctx);
             caption.setText(line.caption);
-            caption.setTextColor(ContextCompat.getColor(activity, R.color.ink_medium));
+            caption.setTextColor(MaterialColors.getColor(ctx, R.attr.colorOnSurfaceVariant,
+                    ContextCompat.getColor(ctx, R.color.ink_medium)));
             caption.setTextSize(TypedValue.COMPLEX_UNIT_SP, ui.textAction());
             caption.setGravity(Gravity.CENTER);
             // A caption belongs to what is under it: the gap above it is the block's, drawn by the
@@ -371,7 +381,7 @@ final class OffsetPanel {
             root.addView(caption);
         }
 
-        final TextView value = new TextView(activity);
+        final TextView value = new TextView(ctx);
         value.setTextSize(TypedValue.COMPLEX_UNIT_SP, valueSp);
         value.setTypeface(Typeface.create("sans-serif-light", Typeface.NORMAL));
         value.setFontFeatureSettings("tnum"); // fixed-width digits: the readout stops twitching as it counts
@@ -382,7 +392,7 @@ final class OffsetPanel {
         // Counted in steps, not in seconds: valueFrom/valueTo/stepSize are floats, and a Slider refuses
         // a range that is not a whole number of steps — ±180 s at 0.1 s is exactly the sum that does not
         // survive float division. Whole steps keep the arithmetic that was already here.
-        final Slider seekBar = new Slider(activity);
+        final Slider seekBar = new Slider(ctx);
         seekBar.setValueFrom(0f);
         seekBar.setValueTo(progressMax);
         seekBar.setStepSize(1f);
@@ -404,10 +414,10 @@ final class OffsetPanel {
         // which is where it belongs. Slider has no key-increment setter, hence the key listener.
         final int keyStep = Math.max(2, (int) Math.round(maxSec / 90 / stepSec));
 
-        final MaterialButton minus = iconButton(activity, R.drawable.ic_remove_24dp, "-");
-        final MaterialButton plus = iconButton(activity, R.drawable.ic_add_24dp, "+");
+        final MaterialButton minus = iconButton(ctx, R.drawable.ic_remove_24dp, "-");
+        final MaterialButton plus = iconButton(ctx, R.drawable.ic_add_24dp, "+");
 
-        final LinearLayout row = new LinearLayout(activity);
+        final LinearLayout row = new LinearLayout(ctx);
         row.setOrientation(LinearLayout.HORIZONTAL);
         row.setGravity(Gravity.CENTER_VERTICAL);
         final LinearLayout.LayoutParams seekLp = new LinearLayout.LayoutParams(
@@ -429,8 +439,8 @@ final class OffsetPanel {
 
         // Readout: accent when non-zero, white at rest.
         final Runnable render = () -> {
-            value.setText(format(activity, current[0]));
-            value.setTextColor(isZero(current[0]) ? Color.WHITE : accent);
+            value.setText(format(ctx, current[0]));
+            value.setTextColor(isZero(current[0]) ? onSurface : accent);
         };
         render.run();
         final Runnable apply = () -> {
@@ -492,13 +502,14 @@ final class OffsetPanel {
         return seekBar;
     }
 
-    /** A ± button: Material's icon button, in the panel's white rather than its own muted grey. */
-    private static MaterialButton iconButton(final Activity activity, final int icon,
+    /** A ± button: Material's icon button, as legible on a light panel as on a dark one. */
+    private static MaterialButton iconButton(final Context ctx, final int icon,
                                              final String description) {
-        final MaterialButton button = new MaterialButton(activity, null,
+        final MaterialButton button = new MaterialButton(ctx, null,
                 com.google.android.material.R.attr.materialIconButtonStyle);
         button.setIconResource(icon);
-        button.setIconTint(ColorStateList.valueOf(Color.WHITE));
+        button.setIconTint(ColorStateList.valueOf(
+                MaterialColors.getColor(ctx, R.attr.colorOnSurface, Color.WHITE)));
         button.setContentDescription(description);
         button.setInsetTop(0);
         button.setInsetBottom(0);
@@ -544,8 +555,8 @@ final class OffsetPanel {
         return context.getString(R.string.offset_seconds, number);
     }
 
-    private static View gap(final Activity activity, final int heightPx) {
-        final View spacer = new View(activity);
+    private static View gap(final Context ctx, final int heightPx) {
+        final View spacer = new View(ctx);
         spacer.setLayoutParams(new LinearLayout.LayoutParams(
                 ViewGroup.LayoutParams.MATCH_PARENT, heightPx));
         return spacer;

--- a/app/src/main/java/com/brouken/player/OffsetPanel.java
+++ b/app/src/main/java/com/brouken/player/OffsetPanel.java
@@ -4,6 +4,7 @@ import android.app.Activity;
 import android.app.Dialog;
 import android.content.Context;
 import android.content.res.ColorStateList;
+import android.content.res.Configuration;
 import android.graphics.Color;
 import android.graphics.Typeface;
 import android.util.TypedValue;
@@ -52,6 +53,32 @@ import java.util.Locale;
  * only holds the returned dialog so it can dismiss it.
  */
 final class OffsetPanel {
+
+    /**
+     * The panel's vertical rhythm, on Material's 8dp grid, at two densities.
+     *
+     * <p>Two, because a phone held sideways gives the card about 355dp and the panel at its roomy rhythm
+     * wants some 410dp — the weighted spacers this replaced hid that by collapsing to nothing, which is
+     * how Reset came to sit against the slider. Stated gaps have to admit the shortfall instead, so a
+     * short canvas gets the tight column and everything else gets the roomy one.
+     */
+    private static final class Rhythm {
+        private final int title;    // title to the first control
+        private final int block;    // between two things that are not one thing
+        private final int readout;  // a readout to the slider it belongs to
+        private final int pad;      // the card's own padding
+
+        static Rhythm of(final Configuration cfg) {
+            return cfg.screenHeightDp < 500 ? new Rhythm(16, 16, 4, 16) : new Rhythm(24, 32, 8, 24);
+        }
+
+        private Rhythm(int title, int block, int readout, int pad) {
+            this.title = Utils.dpToPx(title);
+            this.block = Utils.dpToPx(block);
+            this.readout = Utils.dpToPx(readout);
+            this.pad = Utils.dpToPx(pad);
+        }
+    }
 
     interface Listener {
         void onOffsetChanged(double sec);
@@ -113,21 +140,21 @@ final class OffsetPanel {
     }
 
     /**
-     * @param insetSource view used to read the window insets for the panel padding (any attached view)
-     * @param accent      brand accent for the readout, track and thumb
+     * @param accent brand accent for the readout, track and thumb
      */
-    static Dialog create(final Activity activity, final UiMetrics ui, final View insetSource,
+    static Dialog create(final Activity activity, final UiMetrics ui,
                          final int accent, final String title, final double maxSec,
                          final double stepSec, final Line... lines) {
-        return create(activity, ui, insetSource, accent, title, maxSec, stepSec, null, lines);
+        return create(activity, ui, accent, title, maxSec, stepSec, null, lines);
     }
 
     /**
      * @param choices picked rather than nudged, drawn above the sliders; null or empty for none
      */
-    static Dialog create(final Activity activity, final UiMetrics ui, final View insetSource,
+    static Dialog create(final Activity activity, final UiMetrics ui,
                          final int accent, final String title, final double maxSec,
                          final double stepSec, final Choice[] choices, final Line... lines) {
+        final Rhythm rhythm = Rhythm.of(activity.getResources().getConfiguration());
         final LinearLayout root = new LinearLayout(activity);
         root.setOrientation(LinearLayout.VERTICAL);
 
@@ -139,8 +166,8 @@ final class OffsetPanel {
         header.setTypeface(Typeface.DEFAULT_BOLD);
         // Space, not a rule: the hairline that used to sit here had a caption under it, and once the
         // caption went it landed a few pixels above the row of pills and read as their top border.
-        header.setPadding(0, 0, 0, Utils.dpToPx(20));
         root.addView(header);
+        root.addView(gap(activity, rhythm.title));
 
         final List<Runnable> resets = new ArrayList<>();
         final boolean picking = choices != null && choices.length > 0;
@@ -163,15 +190,24 @@ final class OffsetPanel {
         // for it. At the full size the panel did not fit its own window: the title was pushed off the
         // top and the reset pill off the bottom.
         final float valueSp = lines.length > 1 || picking ? ui.textClock() : ui.textValue();
+        // Fixed gaps on an 8dp grid rather than weighted spacers. The spacers shared out whatever the
+        // full-height panel had left over, so the rhythm was a different one on every screen — and on a
+        // phone in landscape what was left over was 8dp, which put Reset against the slider. A card sized
+        // to its content has nothing left over to share, so the gaps have to be stated.
+        boolean firstBlock = !picking;
         for (final Line line : lines) {
-            root.addView(verticalSpacer(activity));
-            final Slider bar = addLine(activity, ui, root, accent, line, maxSec, stepSec, valueSp, resets);
+            if (!firstBlock) {
+                root.addView(gap(activity, rhythm.block));
+            }
+            firstBlock = false;
+            final Slider bar = addLine(activity, ui, root, accent, line, maxSec, stepSec, valueSp,
+                    rhythm, resets);
             if (firstBar == null) {
                 firstBar = bar;
             }
         }
 
-        root.addView(verticalSpacer(activity));
+        root.addView(gap(activity, rhythm.block));
 
         // Outlined, like the segmented control above it: one button family for the whole panel. Material
         // draws its own focus and press states, which is what replaced the hand-drawn ring here.
@@ -197,14 +233,14 @@ final class OffsetPanel {
         });
         root.addView(reset);
 
-        Utils.padForPickerInsets(activity, ui, insetSource, root, Utils.dpToPx(24) + ui.overscanH(),
-                Utils.dpToPx(20), Utils.dpToPx(24));
+        // Only the sheet's own padding now: Utils.pickerWindow insets the card from the system bars
+        // and the overscan, so nothing here has to know about either.
+        root.setPadding(Utils.dpToPx(24), rhythm.pad, Utils.dpToPx(24), rhythm.pad);
 
         // Scrolled, because a clipped panel is a panel that lies: the readouts stayed on screen while
-        // the slider under the second one did not. fillViewport keeps the weighted spacers centring the
-        // content while it still fits, and the SeekBars drag across, so nothing fights the scroll.
+        // the slider under the second one did not. No fillViewport — nothing in here stretches now that
+        // the card is sized to its content, and the sliders drag across, so nothing fights the scroll.
         final ScrollView scroller = new ScrollView(activity);
-        scroller.setFillViewport(true);
         scroller.addView(root);
 
         final Dialog dialog = new Dialog(activity, android.R.style.Theme_Translucent_NoTitleBar);
@@ -315,7 +351,7 @@ final class OffsetPanel {
     /** Caption, readout and slider for one offset. Returns its Slider; adds its reset to {@code resets}. */
     private static Slider addLine(final Activity activity, final UiMetrics ui, final LinearLayout root,
                                   final int accent, final Line line, final double maxSec,
-                                  final double stepSec, final float valueSp,
+                                  final double stepSec, final float valueSp, final Rhythm rhythm,
                                   final List<Runnable> resets) {
         final int trackBg = ContextCompat.getColor(activity, R.color.track_white);
         final int progressMax = (int) Math.round(2 * maxSec / stepSec);
@@ -329,11 +365,9 @@ final class OffsetPanel {
             caption.setTextColor(ContextCompat.getColor(activity, R.color.ink_medium));
             caption.setTextSize(TypedValue.COMPLEX_UNIT_SP, ui.textAction());
             caption.setGravity(Gravity.CENTER);
-            // Asymmetric on purpose, and fixed rather than left to the weighted spacers: a caption
-            // belongs to what is under it, and the block above it needs a gap that does not vanish
-            // when the panel fills up. The spacers only share out what is left over — when there is
-            // nothing left over they collapse to nothing and two blocks end up touching.
-            caption.setPadding(0, ui.dpS(28), 0, Utils.dpToPx(4));
+            // A caption belongs to what is under it: the gap above it is the block's, drawn by the
+            // caller, and all it owns is the hair of space down to its own readout.
+            caption.setPadding(0, 0, 0, Utils.dpToPx(4));
             root.addView(caption);
         }
 
@@ -342,7 +376,7 @@ final class OffsetPanel {
         value.setTypeface(Typeface.create("sans-serif-light", Typeface.NORMAL));
         value.setFontFeatureSettings("tnum"); // fixed-width digits: the readout stops twitching as it counts
         value.setGravity(Gravity.CENTER);
-        value.setPadding(0, 0, 0, Utils.dpToPx(20));
+        value.setPadding(0, 0, 0, rhythm.readout);
         root.addView(value);
 
         // Counted in steps, not in seconds: valueFrom/valueTo/stepSize are floats, and a Slider refuses
@@ -510,10 +544,10 @@ final class OffsetPanel {
         return context.getString(R.string.offset_seconds, number);
     }
 
-    private static View verticalSpacer(Activity activity) {
+    private static View gap(final Activity activity, final int heightPx) {
         final View spacer = new View(activity);
         spacer.setLayoutParams(new LinearLayout.LayoutParams(
-                ViewGroup.LayoutParams.MATCH_PARENT, 0, 1f));
+                ViewGroup.LayoutParams.MATCH_PARENT, heightPx));
         return spacer;
     }
 }

--- a/app/src/main/java/com/brouken/player/OffsetPanel.java
+++ b/app/src/main/java/com/brouken/player/OffsetPanel.java
@@ -227,6 +227,7 @@ final class OffsetPanel {
         reset.setInsetTop(0);
         reset.setInsetBottom(0);
         reset.setMinHeight(ui.dpS(48)); // a target this small is missed as often as it is hit
+        Utils.focusRing(reset);
         final LinearLayout.LayoutParams resetLp = new LinearLayout.LayoutParams(
                 ViewGroup.LayoutParams.WRAP_CONTENT, ViewGroup.LayoutParams.WRAP_CONTENT);
         resetLp.gravity = Gravity.CENTER_HORIZONTAL;
@@ -296,6 +297,7 @@ final class OffsetPanel {
             pill.setInsetTop(0);
             pill.setInsetBottom(0);
             pill.setMinHeight(ui.dpS(48)); // the platform's floor for anything a finger has to hit
+            Utils.focusRing(pill);
             pill.setPadding(ui.dpS(4), pill.getPaddingTop(), ui.dpS(4), pill.getPaddingBottom());
             // Shrunk rather than wrapped or clipped: the widest label already fills its share of the
             // row at the ordinary size, so a longer language or a system font a notch up used to break
@@ -410,6 +412,10 @@ final class OffsetPanel {
         // 1.38:1 against that track, where every other stop in this panel reads 12.99:1.
         seekBar.setHaloTintList(ContextCompat.getColorStateList(ctx, R.color.focus_halo));
         seekBar.setThumbStrokeColor(ContextCompat.getColorStateList(ctx, R.color.focus_ring));
+        // Not @dimen/focus_ring_width, the one place that does not follow it: a Material 3 handle is
+        // 4dp wide, and a rim as thick as the ring elsewhere leaves no thumb between its two edges —
+        // the coral marker turns into a white sliver. What carries this stop on a television is the
+        // halo, which is a shape appearing where there was none.
         seekBar.setThumbStrokeWidth(Utils.dpToPx(2));
 
         // D-pad step, scaled to the range instead of the slider's own one-step-per-press. Left to

--- a/app/src/main/java/com/brouken/player/OffsetPanel.java
+++ b/app/src/main/java/com/brouken/player/OffsetPanel.java
@@ -252,7 +252,9 @@ final class OffsetPanel {
         scroller.addView(root);
 
         final Dialog dialog = new Dialog(activity, android.R.style.Theme_Translucent_NoTitleBar);
-        Utils.pickerWindow(activity, ui, dialog, scroller);
+        // CONTROL, not OPTIONS: this panel's sliders retime a line drawn at the bottom of the frame
+        // while it plays, so it must never be the thing covering that line.
+        Utils.pickerWindow(activity, ui, dialog, scroller, Utils.Panel.CONTROL);
         // The theme carries no title bar, so this is the only name a screen reader can announce.
         dialog.setTitle(title);
         // The choice, not the slider: it is the panel's first decision and it is at the top, so a

--- a/app/src/main/java/com/brouken/player/OffsetPanel.java
+++ b/app/src/main/java/com/brouken/player/OffsetPanel.java
@@ -6,13 +6,11 @@ import android.content.Context;
 import android.content.res.ColorStateList;
 import android.graphics.Color;
 import android.graphics.Typeface;
-import android.graphics.drawable.ColorDrawable;
 import android.util.TypedValue;
 import android.view.Gravity;
 import android.view.KeyEvent;
 import android.view.View;
 import android.view.ViewGroup;
-import android.view.Window;
 import android.widget.LinearLayout;
 import android.widget.ScrollView;
 import android.widget.TextView;
@@ -210,20 +208,9 @@ final class OffsetPanel {
         scroller.addView(root);
 
         final Dialog dialog = new Dialog(activity, android.R.style.Theme_Translucent_NoTitleBar);
-        dialog.setContentView(scroller);
+        Utils.pickerWindow(activity, ui, dialog, scroller);
         // The theme carries no title bar, so this is the only name a screen reader can announce.
         dialog.setTitle(title);
-        dialog.setCanceledOnTouchOutside(true);
-        final Window window = dialog.getWindow();
-        if (window != null) {
-            // Deliberately NOT fullscreen/edge-to-edge: a fullscreen dialog window makes OxygenOS treat the
-            // panel as immersive and apply its two-swipe back-gesture guard. A plain window closes on one back.
-            window.setLayout(ui.pickerWidthPx(activity.getResources().getConfiguration()),
-                    ViewGroup.LayoutParams.MATCH_PARENT);
-            window.setGravity(Gravity.END);
-            window.setBackgroundDrawable(
-                    new ColorDrawable(ContextCompat.getColor(activity, R.color.chrome_surface)));
-        }
         // The choice, not the slider: it is the panel's first decision and it is at the top, so a
         // remote lands on it and the scroller stays where the title is. Focusing the slider scrolled
         // the panel to its own bottom the moment it opened.

--- a/app/src/main/java/com/brouken/player/OffsetPanel.java
+++ b/app/src/main/java/com/brouken/player/OffsetPanel.java
@@ -405,7 +405,12 @@ final class OffsetPanel {
         seekBar.setThumbTintList(ColorStateList.valueOf(accent));
         seekBar.setTrackActiveTintList(ColorStateList.valueOf(accent));
         seekBar.setTrackInactiveTintList(ColorStateList.valueOf(trackBg));
-        seekBar.setHaloTintList(ColorStateList.valueOf(accent));
+        // The one stop on the D-pad path that had no ring. Material rings a focused thumb in the
+        // accent, which here is the colour of the thumb and of the track under it — measured
+        // 1.38:1 against that track, where every other stop in this panel reads 12.99:1.
+        seekBar.setHaloTintList(ContextCompat.getColorStateList(ctx, R.color.focus_halo));
+        seekBar.setThumbStrokeColor(ContextCompat.getColorStateList(ctx, R.color.focus_ring));
+        seekBar.setThumbStrokeWidth(Utils.dpToPx(2));
 
         // D-pad step, scaled to the range instead of the slider's own one-step-per-press. Left to
         // itself it made the wide subtitle range unreachable from a remote: measured on a television,

--- a/app/src/main/java/com/brouken/player/OffsetPanel.java
+++ b/app/src/main/java/com/brouken/player/OffsetPanel.java
@@ -186,7 +186,7 @@ final class OffsetPanel {
         // a room can find, and this pill is the last stop of the D-pad path through here.
         final int resetCorner = Utils.dpToPx(22);
         reset.setBackground(new RippleDrawable(
-                ColorStateList.valueOf(ContextCompat.getColor(activity, R.color.ripple_soft)),
+                ColorStateList.valueOf(ContextCompat.getColor(activity, R.color.ripple_chrome)),
                 pillFill(activity, accent, false, resetCorner), roundMask(resetCorner)));
         final LinearLayout.LayoutParams resetLp = new LinearLayout.LayoutParams(
                 ViewGroup.LayoutParams.WRAP_CONTENT, ViewGroup.LayoutParams.WRAP_CONTENT);
@@ -261,7 +261,7 @@ final class OffsetPanel {
             for (int i = 0; i < pills.length; i++) {
                 final boolean on = i == picked[0];
                 pills[i].setBackground(new RippleDrawable(
-                        ColorStateList.valueOf(ContextCompat.getColor(activity, R.color.ripple_soft)),
+                        ColorStateList.valueOf(ContextCompat.getColor(activity, R.color.ripple_chrome)),
                         pillFill(activity, accent, on, corner), roundMask(corner)));
                 pills[i].setTextColor(ContextCompat.getColor(activity,
                         on ? R.color.ink_on_accent : R.color.ink_medium));

--- a/app/src/main/java/com/brouken/player/OffsetPanel.java
+++ b/app/src/main/java/com/brouken/player/OffsetPanel.java
@@ -140,26 +140,27 @@ final class OffsetPanel {
     private OffsetPanel() {
     }
 
-    /**
-     * @param accent brand accent for the readout, track and thumb
-     */
     static Dialog create(final Activity activity, final UiMetrics ui,
-                         final int accent, final String title, final double maxSec,
+                         final String title, final double maxSec,
                          final double stepSec, final Line... lines) {
-        return create(activity, ui, accent, title, maxSec, stepSec, null, lines);
+        return create(activity, ui, title, maxSec, stepSec, null, lines);
     }
 
     /**
      * @param choices picked rather than nudged, drawn above the sliders; null or empty for none
      */
     static Dialog create(final Activity activity, final UiMetrics ui,
-                         final int accent, final String title, final double maxSec,
+                         final String title, final double maxSec,
                          final double stepSec, final Choice[] choices, final Line... lines) {
         // Every view in here is built against the appearance choice, not against the player's own dark
         // theme, so the panel is light when the app is light and black under AMOLED. A
         // ContextThemeWrapper keeps the activity's window token, which the dialog still needs.
         final Context ctx = Utils.dialogContext(activity);
         final int onSurface = MaterialColors.getColor(ctx, R.attr.colorOnSurface, Color.WHITE);
+        // The interface accent, not the chrome's: this panel is a surface, and @color/brand is the
+        // coral that lives over video. One accent per world — see @color/brand_accent.
+        final int accent = MaterialColors.getColor(ctx, R.attr.colorPrimary,
+                ContextCompat.getColor(ctx, R.color.brand_accent));
         final Rhythm rhythm = Rhythm.of(activity.getResources().getConfiguration());
         final LinearLayout root = new LinearLayout(ctx);
         root.setOrientation(LinearLayout.VERTICAL);

--- a/app/src/main/java/com/brouken/player/OffsetPanel.java
+++ b/app/src/main/java/com/brouken/player/OffsetPanel.java
@@ -224,7 +224,7 @@ final class OffsetPanel {
                     ViewGroup.LayoutParams.MATCH_PARENT);
             window.setGravity(Gravity.END);
             window.setBackgroundDrawable(
-                    new ColorDrawable(ContextCompat.getColor(activity, R.color.panel_surface)));
+                    new ColorDrawable(ContextCompat.getColor(activity, R.color.chrome_surface)));
         }
         // The choice, not the slider: it is the panel's first decision and it is at the top, so a
         // remote lands on it and the scroller stays where the title is. Focusing the slider scrolled

--- a/app/src/main/java/com/brouken/player/PlayerActivity.java
+++ b/app/src/main/java/com/brouken/player/PlayerActivity.java
@@ -5500,16 +5500,7 @@ public class PlayerActivity extends Activity {
             row.setFocusable(true);
             row.setMinimumHeight(ui.rowMinHeight());
             // Rounded row: subtle fill for the current item, plus a rounded ripple for touch/D-pad focus.
-            final GradientDrawable rowContent = new GradientDrawable();
-            rowContent.setCornerRadius(Utils.dpToPx(8));
-            rowContent.setColor(isCurrent ? selectedFill : Color.TRANSPARENT);
-            final GradientDrawable rowMask = new GradientDrawable();
-            rowMask.setCornerRadius(Utils.dpToPx(8));
-            rowMask.setColor(Color.WHITE);
-            row.setBackground(new RippleDrawable(
-                    ColorStateList.valueOf(MaterialColors.getColor(ctx, R.attr.colorControlHighlight,
-                            ContextCompat.getColor(ctx, R.color.ripple_chrome))),
-                    rowContent, rowMask));
+            row.setBackground(Utils.pickerRow(ctx, isCurrent ? selectedFill : Color.TRANSPARENT));
             if (isCurrent) {
                 currentRow[0] = row;
             }
@@ -5786,16 +5777,7 @@ public class PlayerActivity extends Activity {
             row.setClickable(true);
             row.setFocusable(true);
             row.setMinimumHeight(ui.rowMinHeight());
-            final GradientDrawable rowContent = new GradientDrawable();
-            rowContent.setCornerRadius(Utils.dpToPx(8));
-            rowContent.setColor(isCurrent ? selectedFill : Color.TRANSPARENT);
-            final GradientDrawable rowMask = new GradientDrawable();
-            rowMask.setCornerRadius(Utils.dpToPx(8));
-            rowMask.setColor(Color.WHITE);
-            row.setBackground(new RippleDrawable(
-                    ColorStateList.valueOf(MaterialColors.getColor(ctx, R.attr.colorControlHighlight,
-                            ContextCompat.getColor(ctx, R.color.ripple_chrome))),
-                    rowContent, rowMask));
+            row.setBackground(Utils.pickerRow(ctx, isCurrent ? selectedFill : Color.TRANSPARENT));
             if (isCurrent) {
                 currentRow[0] = row;
             }
@@ -6072,16 +6054,7 @@ public class PlayerActivity extends Activity {
             row.setClickable(true);
             row.setFocusable(true);
             row.setMinimumHeight(ui.rowMinHeight());
-            final GradientDrawable rowContent = new GradientDrawable();
-            rowContent.setCornerRadius(Utils.dpToPx(8));
-            rowContent.setColor(isCurrent ? selectedFill : Color.TRANSPARENT);
-            final GradientDrawable rowMask = new GradientDrawable();
-            rowMask.setCornerRadius(Utils.dpToPx(8));
-            rowMask.setColor(Color.WHITE);
-            row.setBackground(new RippleDrawable(
-                    ColorStateList.valueOf(MaterialColors.getColor(ctx, R.attr.colorControlHighlight,
-                            ContextCompat.getColor(ctx, R.color.ripple_chrome))),
-                    rowContent, rowMask));
+            row.setBackground(Utils.pickerRow(ctx, isCurrent ? selectedFill : Color.TRANSPARENT));
             if (isCurrent) {
                 currentRow[0] = row;
             }

--- a/app/src/main/java/com/brouken/player/PlayerActivity.java
+++ b/app/src/main/java/com/brouken/player/PlayerActivity.java
@@ -96,6 +96,8 @@ import androidx.coordinatorlayout.widget.CoordinatorLayout;
 import androidx.core.content.ContextCompat;
 
 import com.google.android.material.color.MaterialColors;
+import com.google.android.material.shape.ShapeAppearanceModel;
+import com.google.android.material.shape.MaterialShapeDrawable;
 import androidx.core.graphics.ColorUtils;
 import androidx.documentfile.provider.DocumentFile;
 import androidx.media3.common.AudioAttributes;
@@ -5454,6 +5456,10 @@ public class PlayerActivity extends Activity {
         // light panel and AMOLED gets a black one.
         final Context ctx = Utils.dialogContext(this);
         final int onSurface = MaterialColors.getColor(ctx, R.attr.colorOnSurface, Color.WHITE);
+        // What "chosen" looks like, shared with the toggle groups and the settings switch.
+        final int selectedFill = MaterialColors.getColor(ctx, R.attr.colorSecondaryContainer,
+                ContextCompat.getColor(ctx, R.color.brand_container));
+        final int onSelected = MaterialColors.getColor(ctx, R.attr.colorOnSecondaryContainer, Color.WHITE);
         final LinearLayout listLayout = new LinearLayout(ctx);
         listLayout.setOrientation(LinearLayout.VERTICAL);
         final int listPad = Utils.dpToPx(10);
@@ -5497,8 +5503,7 @@ public class PlayerActivity extends Activity {
             // Rounded row: subtle fill for the current item, plus a rounded ripple for touch/D-pad focus.
             final GradientDrawable rowContent = new GradientDrawable();
             rowContent.setCornerRadius(Utils.dpToPx(8));
-            rowContent.setColor(isCurrent
-                    ? ContextCompat.getColor(ctx, R.color.brand_container) : Color.TRANSPARENT);
+            rowContent.setColor(isCurrent ? selectedFill : Color.TRANSPARENT);
             final GradientDrawable rowMask = new GradientDrawable();
             rowMask.setCornerRadius(Utils.dpToPx(8));
             rowMask.setColor(Color.WHITE);
@@ -5558,7 +5563,7 @@ public class PlayerActivity extends Activity {
 
             final TextView titleText = new TextView(ctx);
             titleText.setText(title);
-            titleText.setTextColor(isCurrent ? Color.WHITE : onSurface);
+            titleText.setTextColor(isCurrent ? onSelected : onSurface);
             titleText.setTextSize(TypedValue.COMPLEX_UNIT_SP, ui.textList());
             if (isCurrent) {
                 titleText.setTypeface(Typeface.DEFAULT_BOLD);
@@ -5745,6 +5750,10 @@ public class PlayerActivity extends Activity {
         // light panel and AMOLED gets a black one.
         final Context ctx = Utils.dialogContext(this);
         final int onSurface = MaterialColors.getColor(ctx, R.attr.colorOnSurface, Color.WHITE);
+        // What "chosen" looks like, shared with the toggle groups and the settings switch.
+        final int selectedFill = MaterialColors.getColor(ctx, R.attr.colorSecondaryContainer,
+                ContextCompat.getColor(ctx, R.color.brand_container));
+        final int onSelected = MaterialColors.getColor(ctx, R.attr.colorOnSecondaryContainer, Color.WHITE);
         final LinearLayout listLayout = new LinearLayout(ctx);
         listLayout.setOrientation(LinearLayout.VERTICAL);
         final int listPad = Utils.dpToPx(10);
@@ -5780,8 +5789,7 @@ public class PlayerActivity extends Activity {
             row.setMinimumHeight(ui.rowMinHeight());
             final GradientDrawable rowContent = new GradientDrawable();
             rowContent.setCornerRadius(Utils.dpToPx(8));
-            rowContent.setColor(isCurrent
-                    ? ContextCompat.getColor(ctx, R.color.brand_container) : Color.TRANSPARENT);
+            rowContent.setColor(isCurrent ? selectedFill : Color.TRANSPARENT);
             final GradientDrawable rowMask = new GradientDrawable();
             rowMask.setCornerRadius(Utils.dpToPx(8));
             rowMask.setColor(Color.WHITE);
@@ -5802,7 +5810,7 @@ public class PlayerActivity extends Activity {
 
             final TextView title = new TextView(ctx);
             title.setText(qualityChoiceTitle(choice));
-            title.setTextColor(isCurrent ? Color.WHITE : onSurface);
+            title.setTextColor(isCurrent ? onSelected : onSurface);
             title.setTextSize(TypedValue.COMPLEX_UNIT_SP, ui.textBody());
             if (isCurrent) {
                 title.setTypeface(Typeface.DEFAULT_BOLD);
@@ -5954,30 +5962,45 @@ public class PlayerActivity extends Activity {
     }
 
     /** The rule the panel already draws under its title, reused wherever one group of rows ends. */
-    private View menuRule(final Context ctx, int topPx, int bottomPx) {
-        final View rule = new View(ctx);
+    /**
+     * One group of rows as its own rounded card, the way the settings screen draws a preference
+     * category. The card is the tonal step above the sheet it sits on, and the gap to the next card is
+     * what used to be a hairline rule — a boundary you can see without drawing a line for it.
+     */
+    private LinearLayout panelGroup(final Context ctx) {
+        final LinearLayout group = new LinearLayout(ctx);
+        group.setOrientation(LinearLayout.VERTICAL);
+        final MaterialShapeDrawable card = new MaterialShapeDrawable(
+                ShapeAppearanceModel.builder().setAllCornerSizes(Utils.dpToPx(20)).build());
+        card.setFillColor(ColorStateList.valueOf(MaterialColors.getColor(
+                ctx, R.attr.colorSurfaceContainer, ContextCompat.getColor(ctx, R.color.thumb_box))));
+        group.setBackground(card);
+        // So a row's ripple and its lit fill stop at the card's rounded end.
+        group.setClipToOutline(true);
+        // A hair of card showing around each row, which is what tells a lit row from the card under it.
+        final int pad = Utils.dpToPx(4);
+        group.setPadding(pad, pad, pad, pad);
         final LinearLayout.LayoutParams lp = new LinearLayout.LayoutParams(
-                ViewGroup.LayoutParams.MATCH_PARENT, Utils.dpToPx(1));
-        lp.topMargin = topPx;
-        lp.bottomMargin = bottomPx;
-        rule.setLayoutParams(lp);
-        rule.setBackgroundColor(MaterialColors.getColor(ctx, R.attr.colorOutlineVariant,
-                ContextCompat.getColor(ctx, R.color.divider)));
-        return rule;
+                ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT);
+        lp.bottomMargin = Utils.dpToPx(8);
+        group.setLayoutParams(lp);
+        return group;
     }
 
     /**
-     * A caption naming the group under it, in the register the panel already uses for a row's details —
-     * same size, same quiet ink. Indented to where the titles of that group start, not to the icon
-     * column, and given more air above than below so it belongs to what follows it.
+     * A caption naming the card under it, in the accent — the same coral the settings screen gives a
+     * preference category, so a group boundary reads the same in both places. Indented to where the
+     * titles of that group start, not to the icon column, and given more air above than below so it
+     * belongs to what follows it.
      */
     private View menuCaption(final Context ctx, CharSequence text) {
         final TextView caption = new TextView(ctx);
         caption.setText(text);
-        caption.setTextColor(MaterialColors.getColor(ctx, R.attr.colorOnSurfaceVariant,
-                ContextCompat.getColor(ctx, R.color.ink_secondary)));
+        caption.setTextColor(MaterialColors.getColor(ctx, R.attr.colorPrimary,
+                ContextCompat.getColor(ctx, R.color.brand)));
+        caption.setTypeface(Typeface.DEFAULT_BOLD);
         caption.setTextSize(TypedValue.COMPLEX_UNIT_SP, ui.textCaption());
-        caption.setPadding(Utils.dpToPx(12), Utils.dpToPx(8), Utils.dpToPx(12), Utils.dpToPx(2));
+        caption.setPadding(Utils.dpToPx(12), Utils.dpToPx(8), Utils.dpToPx(12), Utils.dpToPx(8));
         return caption;
     }
 
@@ -6006,6 +6029,12 @@ public class PlayerActivity extends Activity {
         // light panel and AMOLED gets a black one.
         final Context ctx = Utils.dialogContext(this);
         final int onSurface = MaterialColors.getColor(ctx, R.attr.colorOnSurface, Color.WHITE);
+        // What "chosen" looks like, shared with the toggle groups and the settings switch.
+        final int selectedFill = MaterialColors.getColor(ctx, R.attr.colorSecondaryContainer,
+                ContextCompat.getColor(ctx, R.color.brand_container));
+        final int onSelected = MaterialColors.getColor(ctx, R.attr.colorOnSecondaryContainer, Color.WHITE);
+        final int accent = MaterialColors.getColor(ctx, R.attr.colorPrimary,
+                ContextCompat.getColor(ctx, R.color.brand));
         final LinearLayout listLayout = new LinearLayout(ctx);
         listLayout.setOrientation(LinearLayout.VERTICAL);
         final int listPad = Utils.dpToPx(10);
@@ -6019,14 +6048,17 @@ public class PlayerActivity extends Activity {
         header.setPadding(Utils.dpToPx(10), Utils.dpToPx(10), Utils.dpToPx(10), Utils.dpToPx(10));
         listLayout.addView(header);
 
-        listLayout.addView(menuRule(ctx, 0, Utils.dpToPx(4)));
+        // Each group of rows is its own card, the way a preference category is one in settings. The
+        // holder is null between groups: the next row opens a new card, and a bare boundary needs no
+        // rule because the gap between two cards already is one.
+        final LinearLayout[] group = new LinearLayout[1];
 
         for (final MenuItem item : items) {
             if (item.chrome) {
-                // Air on both sides of a group boundary: it belongs to neither of the two groups.
-                listLayout.addView(item.title == null
-                        ? menuRule(ctx, Utils.dpToPx(6), Utils.dpToPx(6))
-                        : menuCaption(ctx, item.title));
+                group[0] = null;
+                if (item.title != null) {
+                    listLayout.addView(menuCaption(ctx, item.title));
+                }
                 continue;
             }
             final boolean isCurrent = item.checked;
@@ -6040,8 +6072,7 @@ public class PlayerActivity extends Activity {
             row.setMinimumHeight(ui.rowMinHeight());
             final GradientDrawable rowContent = new GradientDrawable();
             rowContent.setCornerRadius(Utils.dpToPx(8));
-            rowContent.setColor(isCurrent
-                    ? ContextCompat.getColor(ctx, R.color.brand_container) : Color.TRANSPARENT);
+            rowContent.setColor(isCurrent ? selectedFill : Color.TRANSPARENT);
             final GradientDrawable rowMask = new GradientDrawable();
             rowMask.setCornerRadius(Utils.dpToPx(8));
             rowMask.setColor(Color.WHITE);
@@ -6084,8 +6115,10 @@ public class PlayerActivity extends Activity {
             } else if (item.iconRes != 0) {
                 final ImageView icon = new ImageView(ctx);
                 icon.setImageResource(item.iconRes);
-                icon.setImageTintList(ColorStateList.valueOf(
-                        isCurrent ? Color.WHITE : onSurface));
+                // The accent, not the ink: a row of grey glyphs is a list of look-alikes, and the coral
+                // is the one thing in this panel that says which app it belongs to. White on the lit
+                // row, where the accent is already the fill under it.
+                icon.setImageTintList(ColorStateList.valueOf(isCurrent ? onSelected : accent));
                 final int iconSize = Utils.dpToPx(22);
                 final LinearLayout.LayoutParams iconLp = new LinearLayout.LayoutParams(iconSize, iconSize);
                 iconLp.setMarginEnd(Utils.dpToPx(16));
@@ -6102,7 +6135,7 @@ public class PlayerActivity extends Activity {
 
             final TextView title = new TextView(ctx);
             title.setText(item.title);
-            title.setTextColor(isCurrent ? Color.WHITE : onSurface);
+            title.setTextColor(isCurrent ? onSelected : onSurface);
             title.setTextSize(TypedValue.COMPLEX_UNIT_SP, ui.textBody());
             if (isCurrent) {
                 title.setTypeface(Typeface.DEFAULT_BOLD);
@@ -6115,8 +6148,7 @@ public class PlayerActivity extends Activity {
                 if (mark != null) {
                     final int markBox = Math.round(title.getTextSize());
                     mark.setBounds(0, 0, markBox, markBox);
-                    mark.setTintList(ColorStateList.valueOf(
-                            isCurrent ? Color.WHITE : onSurface));
+                    mark.setTintList(ColorStateList.valueOf(isCurrent ? onSelected : accent));
                     title.setCompoundDrawablesRelative(mark, null, null, null);
                     title.setCompoundDrawablePadding(Utils.dpToPx(6));
                 }
@@ -6143,7 +6175,11 @@ public class PlayerActivity extends Activity {
                     item.action.run();
                 }
             });
-            listLayout.addView(row);
+            if (group[0] == null) {
+                group[0] = panelGroup(ctx);
+                listLayout.addView(group[0]);
+            }
+            group[0].addView(row);
         }
 
         final android.widget.ScrollView scrollView = new android.widget.ScrollView(ctx);

--- a/app/src/main/java/com/brouken/player/PlayerActivity.java
+++ b/app/src/main/java/com/brouken/player/PlayerActivity.java
@@ -3542,7 +3542,6 @@ public class PlayerActivity extends Activity {
         final OffsetPanel.Choice[] choices = hasSkipSegment()
                 ? new OffsetPanel.Choice[]{ skipModeChoice() } : new OffsetPanel.Choice[0];
         skipOffsetDialog = OffsetPanel.create(this, ui,
-                brandColor(),   // coral, matches the skip timeline highlight
                 getString(R.string.skip_session_title), OFFSET_MAX_SEC, OFFSET_STEP_SEC, choices,
                 // Captioned only while it shares the panel with the row above it; alone it is the panel.
                 new OffsetPanel.Line(choices.length == 0 ? null : getString(R.string.skip_offset_title),
@@ -3599,7 +3598,7 @@ public class PlayerActivity extends Activity {
         if (lines.isEmpty()) {
             return;
         }
-        subtitleOffsetDialog = OffsetPanel.create(this, ui, brandColor(),
+        subtitleOffsetDialog = OffsetPanel.create(this, ui,
                 getString(R.string.subtitle_offset_title), SUBTITLE_OFFSET_MAX_SEC, OFFSET_STEP_SEC,
                 lines.toArray(new OffsetPanel.Line[0]));
         showPickerDialog(subtitleOffsetDialog);
@@ -6040,13 +6039,16 @@ public class PlayerActivity extends Activity {
         final int listPad = Utils.dpToPx(10);
         listLayout.setPadding(listPad, listPad, listPad, listPad);
 
-        final TextView header = new TextView(ctx);
-        header.setText(menuTitle);
-        header.setTextColor(onSurface);
-        header.setTextSize(TypedValue.COMPLEX_UNIT_SP, ui.textTitle());
-        header.setTypeface(Typeface.DEFAULT_BOLD);
-        header.setPadding(Utils.dpToPx(10), Utils.dpToPx(10), Utils.dpToPx(10), Utils.dpToPx(10));
-        listLayout.addView(header);
+        // A panel whose groups name themselves needs no title of its own — see showMoreMenu.
+        if (menuTitle != null) {
+            final TextView header = new TextView(ctx);
+            header.setText(menuTitle);
+            header.setTextColor(onSurface);
+            header.setTextSize(TypedValue.COMPLEX_UNIT_SP, ui.textTitle());
+            header.setTypeface(Typeface.DEFAULT_BOLD);
+            header.setPadding(Utils.dpToPx(10), Utils.dpToPx(10), Utils.dpToPx(10), Utils.dpToPx(10));
+            listLayout.addView(header);
+        }
 
         // Each group of rows is its own card, the way a preference category is one in settings. The
         // holder is null between groups: the next row opens a new card, and a bare boundary needs no
@@ -8898,7 +8900,7 @@ public class PlayerActivity extends Activity {
         if (sleepTimerDialog != null) {
             sleepTimerDialog.dismiss();
         }
-        sleepTimerDialog = DurationPanel.create(this, ui, brandColor(),
+        sleepTimerDialog = DurationPanel.create(this, ui,
                 getString(R.string.sleep_timer_title), this::armSleepTimer);
         showPickerDialog(sleepTimerDialog);
     }
@@ -8975,7 +8977,9 @@ public class PlayerActivity extends Activity {
         items.add(new MenuItem(R.drawable.ic_folder_open_24dp, getString(R.string.empty_state_open), null, false, () -> openFile(mPrefs.mediaUri)));
         items.add(new MenuItem(R.drawable.ic_link_24dp, getString(R.string.empty_state_link), null, false, emptyState::askForLink));
         items.add(new MenuItem(R.drawable.ic_settings_24dp, getString(R.string.pref_title), null, false, this::openSettings));
-        showSideMenu(getString(R.string.button_more), items);
+        // No title: every group in here already names itself, and "More" only repeated the button
+        // that opened the panel.
+        showSideMenu(null, items);
     }
 
     // --- Watch together -------------------------------------------------------------------------

--- a/app/src/main/java/com/brouken/player/PlayerActivity.java
+++ b/app/src/main/java/com/brouken/player/PlayerActivity.java
@@ -94,6 +94,8 @@ import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.app.AppCompatDelegate;
 import androidx.coordinatorlayout.widget.CoordinatorLayout;
 import androidx.core.content.ContextCompat;
+
+import com.google.android.material.color.MaterialColors;
 import androidx.core.graphics.ColorUtils;
 import androidx.documentfile.provider.DocumentFile;
 import androidx.media3.common.AudioAttributes;
@@ -5447,25 +5449,31 @@ public class PlayerActivity extends Activity {
         final int radius = Utils.dpToPx(4);
         final View[] currentRow = new View[1];
 
-        final LinearLayout listLayout = new LinearLayout(this);
+        // The panels follow the appearance choice, like the dialogs do — see
+        // Utils.dialogContext. Every view below is built against it, so a light app gets a
+        // light panel and AMOLED gets a black one.
+        final Context ctx = Utils.dialogContext(this);
+        final int onSurface = MaterialColors.getColor(ctx, R.attr.colorOnSurface, Color.WHITE);
+        final LinearLayout listLayout = new LinearLayout(ctx);
         listLayout.setOrientation(LinearLayout.VERTICAL);
         final int listPad = Utils.dpToPx(10);
         listLayout.setPadding(listPad, listPad, listPad, listPad);
 
-        final TextView header = new TextView(this);
+        final TextView header = new TextView(ctx);
         header.setText(getString(R.string.playlist));
-        header.setTextColor(Color.WHITE);
+        header.setTextColor(onSurface);
         header.setTextSize(TypedValue.COMPLEX_UNIT_SP, ui.textTitle());
         header.setTypeface(Typeface.DEFAULT_BOLD);
         header.setPadding(Utils.dpToPx(10), Utils.dpToPx(10), Utils.dpToPx(10), Utils.dpToPx(10));
         listLayout.addView(header);
 
-        final View divider = new View(this);
+        final View divider = new View(ctx);
         final LinearLayout.LayoutParams dividerLp = new LinearLayout.LayoutParams(
                 ViewGroup.LayoutParams.MATCH_PARENT, Utils.dpToPx(1));
         dividerLp.bottomMargin = Utils.dpToPx(4);
         divider.setLayoutParams(dividerLp);
-        divider.setBackgroundColor(ContextCompat.getColor(this, R.color.divider));
+        divider.setBackgroundColor(MaterialColors.getColor(ctx, R.attr.colorOutlineVariant,
+                ContextCompat.getColor(ctx, R.color.divider)));
         listLayout.addView(divider);
 
         for (int i = 0; i < count; i++) {
@@ -5479,7 +5487,7 @@ public class PlayerActivity extends Activity {
             final Uri artwork = md != null ? md.artworkUri : null;
             final boolean isCurrent = i == current;
 
-            final LinearLayout row = new LinearLayout(this);
+            final LinearLayout row = new LinearLayout(ctx);
             row.setOrientation(LinearLayout.HORIZONTAL);
             row.setGravity(Gravity.CENTER_VERTICAL);
             row.setPadding(Utils.dpToPx(8), Utils.dpToPx(7), Utils.dpToPx(10), Utils.dpToPx(7));
@@ -5490,25 +5498,27 @@ public class PlayerActivity extends Activity {
             final GradientDrawable rowContent = new GradientDrawable();
             rowContent.setCornerRadius(Utils.dpToPx(8));
             rowContent.setColor(isCurrent
-                    ? ContextCompat.getColor(this, R.color.brand_container) : Color.TRANSPARENT);
+                    ? ContextCompat.getColor(ctx, R.color.brand_container) : Color.TRANSPARENT);
             final GradientDrawable rowMask = new GradientDrawable();
             rowMask.setCornerRadius(Utils.dpToPx(8));
             rowMask.setColor(Color.WHITE);
             row.setBackground(new RippleDrawable(
-                    ColorStateList.valueOf(ContextCompat.getColor(this, R.color.ripple_chrome)),
+                    ColorStateList.valueOf(MaterialColors.getColor(ctx, R.attr.colorControlHighlight,
+                            ContextCompat.getColor(ctx, R.color.ripple_chrome))),
                     rowContent, rowMask));
             if (isCurrent) {
                 currentRow[0] = row;
             }
 
-            final FrameLayout box = new FrameLayout(this);
+            final FrameLayout box = new FrameLayout(ctx);
             final LinearLayout.LayoutParams boxLp = new LinearLayout.LayoutParams(
                     LinearLayout.LayoutParams.WRAP_CONTENT, Utils.dpToPx(56));
             boxLp.setMarginEnd(Utils.dpToPx(12));
             boxLp.gravity = Gravity.CENTER_VERTICAL;
             box.setLayoutParams(boxLp);
             box.setMinimumWidth(Utils.dpToPx(40));
-            box.setBackgroundColor(ContextCompat.getColor(this, R.color.thumb_box));
+            box.setBackgroundColor(MaterialColors.getColor(ctx, R.attr.colorSurfaceContainerHighest,
+                        ContextCompat.getColor(ctx, R.color.thumb_box)));
             box.setClipToOutline(true);
             box.setOutlineProvider(new ViewOutlineProvider() {
                 @Override
@@ -5517,7 +5527,7 @@ public class PlayerActivity extends Activity {
                 }
             });
 
-            final ImageView poster = new ImageView(this);
+            final ImageView poster = new ImageView(ctx);
             poster.setLayoutParams(new FrameLayout.LayoutParams(
                     FrameLayout.LayoutParams.WRAP_CONTENT, FrameLayout.LayoutParams.MATCH_PARENT));
             poster.setAdjustViewBounds(true);
@@ -5532,22 +5542,23 @@ public class PlayerActivity extends Activity {
                 box.addView(numberChip);
             } else {
                 poster.setVisibility(View.GONE);
-                final TextView number = new TextView(this);
+                final TextView number = new TextView(ctx);
                 number.setText(String.valueOf(i + 1));
                 number.setTypeface(Typeface.DEFAULT_BOLD);
                 number.setLayoutParams(new FrameLayout.LayoutParams(
                         FrameLayout.LayoutParams.MATCH_PARENT, FrameLayout.LayoutParams.MATCH_PARENT));
                 number.setGravity(Gravity.CENTER);
                 number.setMinWidth(Utils.dpToPx(40));
-                number.setTextColor(ContextCompat.getColor(this, R.color.ink_secondary));
+                number.setTextColor(MaterialColors.getColor(ctx, R.attr.colorOnSurfaceVariant,
+                    ContextCompat.getColor(ctx, R.color.ink_secondary)));
                 number.setTextSize(TypedValue.COMPLEX_UNIT_SP, ui.textListNumber());
                 box.addView(number);
             }
             row.addView(box);
 
-            final TextView titleText = new TextView(this);
+            final TextView titleText = new TextView(ctx);
             titleText.setText(title);
-            titleText.setTextColor(isCurrent ? Color.WHITE : ContextCompat.getColor(this, R.color.ink_row_inactive));
+            titleText.setTextColor(isCurrent ? Color.WHITE : onSurface);
             titleText.setTextSize(TypedValue.COMPLEX_UNIT_SP, ui.textList());
             if (isCurrent) {
                 titleText.setTypeface(Typeface.DEFAULT_BOLD);
@@ -5583,7 +5594,7 @@ public class PlayerActivity extends Activity {
             listLayout.addView(row);
         }
 
-        final android.widget.ScrollView scrollView = new android.widget.ScrollView(this);
+        final android.widget.ScrollView scrollView = new android.widget.ScrollView(ctx);
         scrollView.addView(listLayout);
         // The dialog spans the full height behind the status/navigation bars, so pad the content clear of
         // them. Use a FIXED inset captured now (the status bar is visible while the controls — and thus this
@@ -5729,32 +5740,38 @@ public class PlayerActivity extends Activity {
         final int selected = selectedQualityIndex(choices);
         final View[] currentRow = new View[1];
 
-        final LinearLayout listLayout = new LinearLayout(this);
+        // The panels follow the appearance choice, like the dialogs do — see
+        // Utils.dialogContext. Every view below is built against it, so a light app gets a
+        // light panel and AMOLED gets a black one.
+        final Context ctx = Utils.dialogContext(this);
+        final int onSurface = MaterialColors.getColor(ctx, R.attr.colorOnSurface, Color.WHITE);
+        final LinearLayout listLayout = new LinearLayout(ctx);
         listLayout.setOrientation(LinearLayout.VERTICAL);
         final int listPad = Utils.dpToPx(10);
         listLayout.setPadding(listPad, listPad, listPad, listPad);
 
-        final TextView header = new TextView(this);
+        final TextView header = new TextView(ctx);
         header.setText(getString(R.string.quality_title));
-        header.setTextColor(Color.WHITE);
+        header.setTextColor(onSurface);
         header.setTextSize(TypedValue.COMPLEX_UNIT_SP, ui.textTitle());
         header.setTypeface(Typeface.DEFAULT_BOLD);
         header.setPadding(Utils.dpToPx(10), Utils.dpToPx(10), Utils.dpToPx(10), Utils.dpToPx(10));
         listLayout.addView(header);
 
-        final View divider = new View(this);
+        final View divider = new View(ctx);
         final LinearLayout.LayoutParams dividerLp = new LinearLayout.LayoutParams(
                 ViewGroup.LayoutParams.MATCH_PARENT, Utils.dpToPx(1));
         dividerLp.bottomMargin = Utils.dpToPx(4);
         divider.setLayoutParams(dividerLp);
-        divider.setBackgroundColor(ContextCompat.getColor(this, R.color.divider));
+        divider.setBackgroundColor(MaterialColors.getColor(ctx, R.attr.colorOutlineVariant,
+                ContextCompat.getColor(ctx, R.color.divider)));
         listLayout.addView(divider);
 
         for (int i = 0; i < choices.size(); i++) {
             final VideoQualityChoice choice = choices.get(i);
             final boolean isCurrent = i == selected;
 
-            final LinearLayout row = new LinearLayout(this);
+            final LinearLayout row = new LinearLayout(ctx);
             row.setOrientation(LinearLayout.HORIZONTAL);
             row.setGravity(Gravity.CENTER_VERTICAL);
             row.setPadding(Utils.dpToPx(12), Utils.dpToPx(10), Utils.dpToPx(12), Utils.dpToPx(10));
@@ -5764,27 +5781,28 @@ public class PlayerActivity extends Activity {
             final GradientDrawable rowContent = new GradientDrawable();
             rowContent.setCornerRadius(Utils.dpToPx(8));
             rowContent.setColor(isCurrent
-                    ? ContextCompat.getColor(this, R.color.brand_container) : Color.TRANSPARENT);
+                    ? ContextCompat.getColor(ctx, R.color.brand_container) : Color.TRANSPARENT);
             final GradientDrawable rowMask = new GradientDrawable();
             rowMask.setCornerRadius(Utils.dpToPx(8));
             rowMask.setColor(Color.WHITE);
             row.setBackground(new RippleDrawable(
-                    ColorStateList.valueOf(ContextCompat.getColor(this, R.color.ripple_chrome)),
+                    ColorStateList.valueOf(MaterialColors.getColor(ctx, R.attr.colorControlHighlight,
+                            ContextCompat.getColor(ctx, R.color.ripple_chrome))),
                     rowContent, rowMask));
             if (isCurrent) {
                 currentRow[0] = row;
             }
 
-            final LinearLayout textBlock = new LinearLayout(this);
+            final LinearLayout textBlock = new LinearLayout(ctx);
             textBlock.setOrientation(LinearLayout.VERTICAL);
             final LinearLayout.LayoutParams blockLp = new LinearLayout.LayoutParams(
                     0, ViewGroup.LayoutParams.WRAP_CONTENT, 1f);
             blockLp.gravity = Gravity.CENTER_VERTICAL;
             textBlock.setLayoutParams(blockLp);
 
-            final TextView title = new TextView(this);
+            final TextView title = new TextView(ctx);
             title.setText(qualityChoiceTitle(choice));
-            title.setTextColor(isCurrent ? Color.WHITE : ContextCompat.getColor(this, R.color.ink_row_inactive));
+            title.setTextColor(isCurrent ? Color.WHITE : onSurface);
             title.setTextSize(TypedValue.COMPLEX_UNIT_SP, ui.textBody());
             if (isCurrent) {
                 title.setTypeface(Typeface.DEFAULT_BOLD);
@@ -5794,9 +5812,10 @@ public class PlayerActivity extends Activity {
             final String subtitle = qualityChoiceSubtitle(choice);
             TextView details = null;
             if (subtitle != null && !subtitle.isEmpty()) {
-                details = new TextView(this);
+                details = new TextView(ctx);
                 details.setText(subtitle);
-                details.setTextColor(ContextCompat.getColor(this, R.color.ink_secondary));
+                details.setTextColor(MaterialColors.getColor(ctx, R.attr.colorOnSurfaceVariant,
+                    ContextCompat.getColor(ctx, R.color.ink_secondary)));
                 details.setTextSize(TypedValue.COMPLEX_UNIT_SP, ui.textCaption());
                 textBlock.addView(details);
             }
@@ -5804,9 +5823,10 @@ public class PlayerActivity extends Activity {
             fitLongText(row, title, details);
 
             if (choice.bitrateText != null && !choice.bitrateText.isEmpty()) {
-                final TextView bitrate = new TextView(this);
+                final TextView bitrate = new TextView(ctx);
                 bitrate.setText(choice.bitrateText);
-                bitrate.setTextColor(ContextCompat.getColor(this, R.color.ink_secondary));
+                bitrate.setTextColor(MaterialColors.getColor(ctx, R.attr.colorOnSurfaceVariant,
+                    ContextCompat.getColor(ctx, R.color.ink_secondary)));
                 bitrate.setTextSize(TypedValue.COMPLEX_UNIT_SP, ui.textCaption());
                 bitrate.setGravity(Gravity.END | Gravity.CENTER_VERTICAL);
                 bitrate.setSingleLine(true);
@@ -5827,7 +5847,7 @@ public class PlayerActivity extends Activity {
             listLayout.addView(row);
         }
 
-        final android.widget.ScrollView scrollView = new android.widget.ScrollView(this);
+        final android.widget.ScrollView scrollView = new android.widget.ScrollView(ctx);
         scrollView.addView(listLayout);
         // The rows carry their own side padding; the card only keeps them off its rounded ends.
         scrollView.setPadding(0, Utils.dpToPx(8), 0, Utils.dpToPx(8));
@@ -5979,14 +5999,19 @@ public class PlayerActivity extends Activity {
         // without this a remote opens onto whatever focus the dialog happened to pick.
         final View[] firstRow = new View[1];
 
-        final LinearLayout listLayout = new LinearLayout(this);
+        // The panels follow the appearance choice, like the dialogs do — see
+        // Utils.dialogContext. Every view below is built against it, so a light app gets a
+        // light panel and AMOLED gets a black one.
+        final Context ctx = Utils.dialogContext(this);
+        final int onSurface = MaterialColors.getColor(ctx, R.attr.colorOnSurface, Color.WHITE);
+        final LinearLayout listLayout = new LinearLayout(ctx);
         listLayout.setOrientation(LinearLayout.VERTICAL);
         final int listPad = Utils.dpToPx(10);
         listLayout.setPadding(listPad, listPad, listPad, listPad);
 
-        final TextView header = new TextView(this);
+        final TextView header = new TextView(ctx);
         header.setText(menuTitle);
-        header.setTextColor(Color.WHITE);
+        header.setTextColor(onSurface);
         header.setTextSize(TypedValue.COMPLEX_UNIT_SP, ui.textTitle());
         header.setTypeface(Typeface.DEFAULT_BOLD);
         header.setPadding(Utils.dpToPx(10), Utils.dpToPx(10), Utils.dpToPx(10), Utils.dpToPx(10));
@@ -6003,7 +6028,7 @@ public class PlayerActivity extends Activity {
             }
             final boolean isCurrent = item.checked;
 
-            final LinearLayout row = new LinearLayout(this);
+            final LinearLayout row = new LinearLayout(ctx);
             row.setOrientation(LinearLayout.HORIZONTAL);
             row.setGravity(Gravity.CENTER_VERTICAL);
             row.setPadding(Utils.dpToPx(12), Utils.dpToPx(10), Utils.dpToPx(12), Utils.dpToPx(10));
@@ -6013,12 +6038,13 @@ public class PlayerActivity extends Activity {
             final GradientDrawable rowContent = new GradientDrawable();
             rowContent.setCornerRadius(Utils.dpToPx(8));
             rowContent.setColor(isCurrent
-                    ? ContextCompat.getColor(this, R.color.brand_container) : Color.TRANSPARENT);
+                    ? ContextCompat.getColor(ctx, R.color.brand_container) : Color.TRANSPARENT);
             final GradientDrawable rowMask = new GradientDrawable();
             rowMask.setCornerRadius(Utils.dpToPx(8));
             rowMask.setColor(Color.WHITE);
             row.setBackground(new RippleDrawable(
-                    ColorStateList.valueOf(ContextCompat.getColor(this, R.color.ripple_chrome)),
+                    ColorStateList.valueOf(MaterialColors.getColor(ctx, R.attr.colorControlHighlight,
+                            ContextCompat.getColor(ctx, R.color.ripple_chrome))),
                     rowContent, rowMask));
             if (isCurrent) {
                 currentRow[0] = row;
@@ -6032,11 +6058,12 @@ public class PlayerActivity extends Activity {
             // readings of "this film" looking like one thing. Cropped, not fitted — a row of posters with
             // ragged widths reads as broken, and losing a sliver of a 2:3 image costs nothing.
             if (item.imageUrl != null && !item.imageUrl.isEmpty()) {
-                final ImageView art = new ImageView(this);
+                final ImageView art = new ImageView(ctx);
                 art.setScaleType(ImageView.ScaleType.CENTER_CROP);
                 // Same placeholder as the header's poster slot, so a slow load is a quiet grey card
                 // rather than a hole that shifts the text when it fills.
-                art.setBackgroundColor(ContextCompat.getColor(this, R.color.placeholder_card));
+                art.setBackgroundColor(MaterialColors.getColor(ctx, R.attr.colorSurfaceContainerHighest,
+                        ContextCompat.getColor(ctx, R.color.placeholder_card)));
                 final int artCorner = Utils.dpToPx(4);
                 art.setClipToOutline(true);
                 art.setOutlineProvider(new ViewOutlineProvider() {
@@ -6052,10 +6079,10 @@ public class PlayerActivity extends Activity {
                 row.addView(art);
                 Glide.with(this).load(item.imageUrl).into(art);
             } else if (item.iconRes != 0) {
-                final ImageView icon = new ImageView(this);
+                final ImageView icon = new ImageView(ctx);
                 icon.setImageResource(item.iconRes);
                 icon.setImageTintList(ColorStateList.valueOf(
-                        isCurrent ? Color.WHITE : ContextCompat.getColor(this, R.color.ink_row_inactive)));
+                        isCurrent ? Color.WHITE : onSurface));
                 final int iconSize = Utils.dpToPx(22);
                 final LinearLayout.LayoutParams iconLp = new LinearLayout.LayoutParams(iconSize, iconSize);
                 iconLp.setMarginEnd(Utils.dpToPx(16));
@@ -6063,16 +6090,16 @@ public class PlayerActivity extends Activity {
                 row.addView(icon);
             }
 
-            final LinearLayout textBlock = new LinearLayout(this);
+            final LinearLayout textBlock = new LinearLayout(ctx);
             textBlock.setOrientation(LinearLayout.VERTICAL);
             final LinearLayout.LayoutParams blockLp = new LinearLayout.LayoutParams(
                     0, ViewGroup.LayoutParams.WRAP_CONTENT, 1f);
             blockLp.gravity = Gravity.CENTER_VERTICAL;
             textBlock.setLayoutParams(blockLp);
 
-            final TextView title = new TextView(this);
+            final TextView title = new TextView(ctx);
             title.setText(item.title);
-            title.setTextColor(isCurrent ? Color.WHITE : ContextCompat.getColor(this, R.color.ink_row_inactive));
+            title.setTextColor(isCurrent ? Color.WHITE : onSurface);
             title.setTextSize(TypedValue.COMPLEX_UNIT_SP, ui.textBody());
             if (isCurrent) {
                 title.setTypeface(Typeface.DEFAULT_BOLD);
@@ -6086,7 +6113,7 @@ public class PlayerActivity extends Activity {
                     final int markBox = Math.round(title.getTextSize());
                     mark.setBounds(0, 0, markBox, markBox);
                     mark.setTintList(ColorStateList.valueOf(
-                            isCurrent ? Color.WHITE : ContextCompat.getColor(this, R.color.ink_row_inactive)));
+                            isCurrent ? Color.WHITE : onSurface));
                     title.setCompoundDrawablesRelative(mark, null, null, null);
                     title.setCompoundDrawablePadding(Utils.dpToPx(6));
                 }
@@ -6095,9 +6122,10 @@ public class PlayerActivity extends Activity {
 
             TextView details = null;
             if (item.subtitle != null && item.subtitle.length() > 0) {
-                details = new TextView(this);
+                details = new TextView(ctx);
                 details.setText(item.subtitle);
-                details.setTextColor(ContextCompat.getColor(this, R.color.ink_secondary));
+                details.setTextColor(MaterialColors.getColor(ctx, R.attr.colorOnSurfaceVariant,
+                    ContextCompat.getColor(ctx, R.color.ink_secondary)));
                 details.setTextSize(TypedValue.COMPLEX_UNIT_SP, ui.textCaption());
                 textBlock.addView(details);
             }
@@ -6115,7 +6143,7 @@ public class PlayerActivity extends Activity {
             listLayout.addView(row);
         }
 
-        final android.widget.ScrollView scrollView = new android.widget.ScrollView(this);
+        final android.widget.ScrollView scrollView = new android.widget.ScrollView(ctx);
         scrollView.addView(listLayout);
         // The rows carry their own side padding; the card only keeps them off its rounded ends.
         scrollView.setPadding(0, Utils.dpToPx(8), 0, Utils.dpToPx(8));

--- a/app/src/main/java/com/brouken/player/PlayerActivity.java
+++ b/app/src/main/java/com/brouken/player/PlayerActivity.java
@@ -1634,7 +1634,9 @@ public class PlayerActivity extends Activity {
         // integrated into the pill rather than a detached bar below it. Label and glyph stay white; only
         // what counts time down — the underline and the seconds inside the label — is on the brand accent,
         // so the timing reads at a glance without costing the wording its contrast over a bright frame.
-        final int skipCornerRadius = Utils.dpToPx(8);
+        // Same token as the cluster pills (UiMetrics.pillCorner) rather than a raw 8dp, so the skip and
+        // speed pills round like everything else on a tablet or a TV instead of staying at phone size.
+        final int skipCornerRadius = ui.pillCorner();
         buttonSkip = new Button(this);
         buttonSkip.setText(R.string.button_skip);
         buttonSkip.setAllCaps(false);

--- a/app/src/main/java/com/brouken/player/PlayerActivity.java
+++ b/app/src/main/java/com/brouken/player/PlayerActivity.java
@@ -5954,26 +5954,28 @@ public class PlayerActivity extends Activity {
     }
 
     /** The rule the panel already draws under its title, reused wherever one group of rows ends. */
-    private View menuRule(int topPx, int bottomPx) {
-        final View rule = new View(this);
+    private View menuRule(final Context ctx, int topPx, int bottomPx) {
+        final View rule = new View(ctx);
         final LinearLayout.LayoutParams lp = new LinearLayout.LayoutParams(
                 ViewGroup.LayoutParams.MATCH_PARENT, Utils.dpToPx(1));
         lp.topMargin = topPx;
         lp.bottomMargin = bottomPx;
         rule.setLayoutParams(lp);
-        rule.setBackgroundColor(ContextCompat.getColor(this, R.color.divider));
+        rule.setBackgroundColor(MaterialColors.getColor(ctx, R.attr.colorOutlineVariant,
+                ContextCompat.getColor(ctx, R.color.divider)));
         return rule;
     }
 
     /**
      * A caption naming the group under it, in the register the panel already uses for a row's details —
-     * same size, same dimmed white. Indented to where the titles of that group start, not to the icon
+     * same size, same quiet ink. Indented to where the titles of that group start, not to the icon
      * column, and given more air above than below so it belongs to what follows it.
      */
-    private View menuCaption(CharSequence text) {
-        final TextView caption = new TextView(this);
+    private View menuCaption(final Context ctx, CharSequence text) {
+        final TextView caption = new TextView(ctx);
         caption.setText(text);
-        caption.setTextColor(ContextCompat.getColor(this, R.color.ink_secondary));
+        caption.setTextColor(MaterialColors.getColor(ctx, R.attr.colorOnSurfaceVariant,
+                ContextCompat.getColor(ctx, R.color.ink_secondary)));
         caption.setTextSize(TypedValue.COMPLEX_UNIT_SP, ui.textCaption());
         caption.setPadding(Utils.dpToPx(12), Utils.dpToPx(8), Utils.dpToPx(12), Utils.dpToPx(2));
         return caption;
@@ -6017,13 +6019,14 @@ public class PlayerActivity extends Activity {
         header.setPadding(Utils.dpToPx(10), Utils.dpToPx(10), Utils.dpToPx(10), Utils.dpToPx(10));
         listLayout.addView(header);
 
-        listLayout.addView(menuRule(0, Utils.dpToPx(4)));
+        listLayout.addView(menuRule(ctx, 0, Utils.dpToPx(4)));
 
         for (final MenuItem item : items) {
             if (item.chrome) {
                 // Air on both sides of a group boundary: it belongs to neither of the two groups.
                 listLayout.addView(item.title == null
-                        ? menuRule(Utils.dpToPx(6), Utils.dpToPx(6)) : menuCaption(item.title));
+                        ? menuRule(ctx, Utils.dpToPx(6), Utils.dpToPx(6))
+                        : menuCaption(ctx, item.title));
                 continue;
             }
             final boolean isCurrent = item.checked;

--- a/app/src/main/java/com/brouken/player/PlayerActivity.java
+++ b/app/src/main/java/com/brouken/player/PlayerActivity.java
@@ -1671,7 +1671,7 @@ public class PlayerActivity extends Activity {
         final int skipBarHeight = Utils.dpToPx(3);
         final int skipBarCorner = Utils.dpToPx(2);
         final GradientDrawable skipPillFill = new GradientDrawable();
-        skipPillFill.setColor(ContextCompat.getColor(this, R.color.pill_surface));
+        skipPillFill.setColor(ContextCompat.getColor(this, R.color.chrome_surface));
         skipPillFill.setCornerRadius(skipCornerRadius);
         skipPillGroove = new GradientDrawable();
         // Faint groove the pill's countdown underline drains along; transparent when there is no underline.
@@ -1769,7 +1769,7 @@ public class PlayerActivity extends Activity {
         speedBoostIndicator.setCompoundDrawableTintList(ColorStateList.valueOf(brandColor()));
 
         final GradientDrawable speedBoostBackground = new GradientDrawable();
-        speedBoostBackground.setColor(ContextCompat.getColor(this, R.color.pill_surface));
+        speedBoostBackground.setColor(ContextCompat.getColor(this, R.color.chrome_surface));
         speedBoostBackground.setCornerRadius(skipCornerRadius);
         speedBoostIndicator.setBackground(speedBoostBackground);
 
@@ -1809,7 +1809,7 @@ public class PlayerActivity extends Activity {
         statsView.setTextSize(TypedValue.COMPLEX_UNIT_SP, ui.textInfo());
         // Same corner as the lock button, the time pill and the poster — a floating box in this UI is rounded.
         final GradientDrawable statsBackground = new GradientDrawable();
-        statsBackground.setColor(ContextCompat.getColor(this, R.color.pill_scrim));
+        statsBackground.setColor(ContextCompat.getColor(this, R.color.ui_controls_background));
         statsBackground.setCornerRadius(ui.pillCorner());
         statsView.setBackground(statsBackground);
         final int statsPadding = Utils.dpToPx(8);
@@ -1832,7 +1832,7 @@ public class PlayerActivity extends Activity {
         roomPill.setTextColor(ContextCompat.getColor(this, R.color.ink_high));
         roomPill.setTextSize(TypedValue.COMPLEX_UNIT_SP, ui.textInfo());
         final GradientDrawable roomPillBackground = new GradientDrawable();
-        roomPillBackground.setColor(ContextCompat.getColor(this, R.color.pill_scrim));
+        roomPillBackground.setColor(ContextCompat.getColor(this, R.color.ui_controls_background));
         roomPillBackground.setCornerRadius(ui.pillCorner());
         roomPill.setBackground(roomPillBackground);
         roomPill.setPadding(Utils.dpToPx(10), Utils.dpToPx(5), Utils.dpToPx(10), Utils.dpToPx(5));
@@ -1860,7 +1860,7 @@ public class PlayerActivity extends Activity {
         roomBadge.setTextColor(ContextCompat.getColor(this, R.color.ink_high));
         roomBadge.setTextSize(TypedValue.COMPLEX_UNIT_SP, ui.textInfo());
         final GradientDrawable roomBackground = new GradientDrawable();
-        roomBackground.setColor(ContextCompat.getColor(this, R.color.pill_scrim));
+        roomBackground.setColor(ContextCompat.getColor(this, R.color.ui_controls_background));
         roomBackground.setCornerRadius(ui.pillCorner());
         roomBadge.setBackground(roomBackground);
         roomBadge.setPadding(Utils.dpToPx(10), Utils.dpToPx(5), Utils.dpToPx(10), Utils.dpToPx(5));
@@ -5612,7 +5612,7 @@ public class PlayerActivity extends Activity {
             window.setLayout(ui.pickerWidthPx(getResources().getConfiguration()), ViewGroup.LayoutParams.MATCH_PARENT);
             window.setGravity(Gravity.END);
             window.setBackgroundDrawable(new android.graphics.drawable.ColorDrawable(
-                    ContextCompat.getColor(this, R.color.panel_surface)));
+                    ContextCompat.getColor(this, R.color.chrome_surface)));
         }
         // Hide the player's overlay (header + bottom controls) so only the playlist panel is shown.
         showPickerDialog(playlistDialog);
@@ -5860,7 +5860,7 @@ public class PlayerActivity extends Activity {
             window.setLayout(ui.pickerWidthPx(getResources().getConfiguration()), ViewGroup.LayoutParams.MATCH_PARENT);
             window.setGravity(Gravity.END);
             window.setBackgroundDrawable(new android.graphics.drawable.ColorDrawable(
-                    ContextCompat.getColor(this, R.color.panel_surface)));
+                    ContextCompat.getColor(this, R.color.chrome_surface)));
         }
         showPickerDialog(qualityDialog);
         if (currentRow[0] != null) {
@@ -6156,7 +6156,7 @@ public class PlayerActivity extends Activity {
             window.setLayout(ui.pickerWidthPx(getResources().getConfiguration()), ViewGroup.LayoutParams.MATCH_PARENT);
             window.setGravity(Gravity.END);
             window.setBackgroundDrawable(new android.graphics.drawable.ColorDrawable(
-                    ContextCompat.getColor(this, R.color.panel_surface)));
+                    ContextCompat.getColor(this, R.color.chrome_surface)));
         }
         showPickerDialog(menuDialog);
         final View focus = currentRow[0] != null ? currentRow[0] : firstRow[0];

--- a/app/src/main/java/com/brouken/player/PlayerActivity.java
+++ b/app/src/main/java/com/brouken/player/PlayerActivity.java
@@ -5828,8 +5828,7 @@ public class PlayerActivity extends Activity {
             playlistDialog.dismiss();
         }
         playlistDialog = new android.app.Dialog(this, android.R.style.Theme_Translucent_NoTitleBar);
-        Utils.pickerWindow(this, ui, playlistDialog, scrollView,
-                grid ? Utils.Panel.RAIL : Utils.Panel.LIST);
+        Utils.pickerWindow(this, ui, playlistDialog, scrollView);
         // Hide the player's overlay (header + bottom controls) so only the playlist panel is shown.
         showPickerDialog(playlistDialog);
         final View currentCell = currentRow[0];
@@ -6088,7 +6087,7 @@ public class PlayerActivity extends Activity {
             qualityDialog.dismiss();
         }
         qualityDialog = new android.app.Dialog(this, android.R.style.Theme_Translucent_NoTitleBar);
-        Utils.pickerWindow(this, ui, qualityDialog, scrollView, Utils.Panel.OPTIONS);
+        Utils.pickerWindow(this, ui, qualityDialog, scrollView);
         showPickerDialog(qualityDialog);
         if (currentRow[0] != null) {
             currentRow[0].post(() -> currentRow[0].requestFocus());
@@ -6230,7 +6229,7 @@ public class PlayerActivity extends Activity {
 
     // The panel every picker shares, matching the quality/playlist menus.
     private void showSideMenu(CharSequence menuTitle, List<MenuItem> items) {
-        showSideMenu(menuTitle, items, 34, 48, Utils.Panel.OPTIONS);
+        showSideMenu(menuTitle, items, 34, 48);
     }
 
     /**
@@ -6238,11 +6237,8 @@ public class PlayerActivity extends Activity {
      *                  name that already says everything; a list where the poster is what tells the
      *                  rows apart — search results for a name typed from across the room — asks for
      *                  bigger, and nothing else about the panel changes.
-     * @param kind      {@link Utils.Panel#LIST} for a panel whose rows carry artwork and a title, which
-     *                  gets the wider card; {@link Utils.Panel#OPTIONS} for a list of words.
      */
-    private void showSideMenu(CharSequence menuTitle, List<MenuItem> items, int posterWDp, int posterHDp,
-                              Utils.Panel kind) {
+    private void showSideMenu(CharSequence menuTitle, List<MenuItem> items, int posterWDp, int posterHDp) {
         if (items == null || items.isEmpty()) {
             return;
         }
@@ -6433,7 +6429,7 @@ public class PlayerActivity extends Activity {
             menuDialog.dismiss();
         }
         menuDialog = new android.app.Dialog(this, android.R.style.Theme_Translucent_NoTitleBar);
-        Utils.pickerWindow(this, ui, menuDialog, scrollView, kind);
+        Utils.pickerWindow(this, ui, menuDialog, scrollView);
         showPickerDialog(menuDialog);
         final View focus = currentRow[0] != null ? currentRow[0] : firstRow[0];
         if (focus != null) {
@@ -8010,7 +8006,7 @@ public class PlayerActivity extends Activity {
         items.add(0, typeNumbersRow(title, episodes));
         // Stills are 16:9, so the row leads with a wide frame rather than a tall poster — and an
         // episode name beside one is what the wider card exists for.
-        showSideMenu(title.name, items, 72, 41, Utils.Panel.LIST);
+        showSideMenu(title.name, items, 72, 41);
     }
 
     /** The way past the catalogues, first in the list because it is what somebody who knows reaches for. */

--- a/app/src/main/java/com/brouken/player/PlayerActivity.java
+++ b/app/src/main/java/com/brouken/player/PlayerActivity.java
@@ -5503,7 +5503,7 @@ public class PlayerActivity extends Activity {
             rowMask.setCornerRadius(Utils.dpToPx(8));
             rowMask.setColor(Color.WHITE);
             row.setBackground(new RippleDrawable(
-                    ColorStateList.valueOf(ContextCompat.getColor(this, R.color.ripple_strong)),
+                    ColorStateList.valueOf(ContextCompat.getColor(this, R.color.ripple_chrome)),
                     rowContent, rowMask));
             if (isCurrent) {
                 currentRow[0] = row;
@@ -5785,7 +5785,7 @@ public class PlayerActivity extends Activity {
             rowMask.setCornerRadius(Utils.dpToPx(8));
             rowMask.setColor(Color.WHITE);
             row.setBackground(new RippleDrawable(
-                    ColorStateList.valueOf(ContextCompat.getColor(this, R.color.ripple_strong)),
+                    ColorStateList.valueOf(ContextCompat.getColor(this, R.color.ripple_chrome)),
                     rowContent, rowMask));
             if (isCurrent) {
                 currentRow[0] = row;
@@ -6042,7 +6042,7 @@ public class PlayerActivity extends Activity {
             rowMask.setCornerRadius(Utils.dpToPx(8));
             rowMask.setColor(Color.WHITE);
             row.setBackground(new RippleDrawable(
-                    ColorStateList.valueOf(ContextCompat.getColor(this, R.color.ripple_strong)),
+                    ColorStateList.valueOf(ContextCompat.getColor(this, R.color.ripple_chrome)),
                     rowContent, rowMask));
             if (isCurrent) {
                 currentRow[0] = row;
@@ -7901,7 +7901,7 @@ public class PlayerActivity extends Activity {
         mask.setCornerRadius(Utils.dpToPx(8));
         mask.setColor(Color.WHITE);
         row.setBackground(new RippleDrawable(
-                ColorStateList.valueOf(ContextCompat.getColor(this, R.color.ripple_strong)), content, mask));
+                ColorStateList.valueOf(ContextCompat.getColor(this, R.color.ripple_chrome)), content, mask));
 
         final ImageView art = new ImageView(this);
         art.setScaleType(ImageView.ScaleType.CENTER_CROP);
@@ -13653,7 +13653,7 @@ public class PlayerActivity extends Activity {
         final GradientDrawable mask = new GradientDrawable();
         mask.setShape(GradientDrawable.OVAL);
         mask.setColor(Color.WHITE);
-        return new RippleDrawable(ColorStateList.valueOf(ContextCompat.getColor(this, R.color.ripple_medium)),
+        return new RippleDrawable(ColorStateList.valueOf(ContextCompat.getColor(this, R.color.ripple_chrome)),
                 new InsetDrawable((Drawable) ring, discInset / 2),
                 new InsetDrawable((Drawable) mask, discInset));
     }

--- a/app/src/main/java/com/brouken/player/PlayerActivity.java
+++ b/app/src/main/java/com/brouken/player/PlayerActivity.java
@@ -174,6 +174,7 @@ import com.brouken.player.update.UpdateInfo;
 import com.brouken.player.update.UpdateUi;
 import com.brouken.player.update.Updater;
 import com.bumptech.glide.Glide;
+import com.google.android.material.button.MaterialButton;
 import com.bumptech.glide.load.DataSource;
 import com.bumptech.glide.load.engine.GlideException;
 import com.bumptech.glide.request.RequestListener;
@@ -5365,6 +5366,178 @@ public class PlayerActivity extends Activity {
         return state.toString().trim();
     }
 
+    /**
+     * The frame beside a playlist name, or above it on a card: the artwork the sender sent and, over it,
+     * the file's number — in the accent when that file is the one playing, which is the whole of how the
+     * panel says so. With no artwork the frame says that with a glyph, and the number stays where it
+     * sits on every frame that does have one.
+     */
+    private FrameLayout playlistFrame(final Context ctx, final int index, final Uri artwork,
+                                      final boolean playing) {
+        final FrameLayout box = new FrameLayout(ctx);
+        box.setBackgroundColor(MaterialColors.getColor(ctx, R.attr.colorSurfaceContainerHighest,
+                ContextCompat.getColor(ctx, R.color.thumb_box)));
+        // The row's own radius, so a frame inside a row reads as one object with it rather than as a
+        // rounded thing sitting on another rounded thing at a different rate.
+        final int corner = Utils.dpToPx(8);
+        box.setClipToOutline(true);
+        box.setOutlineProvider(new ViewOutlineProvider() {
+            @Override
+            public void getOutline(View view, Outline outline) {
+                outline.setRoundRect(0, 0, view.getWidth(), view.getHeight(), corner);
+            }
+        });
+
+        final ImageView poster = new ImageView(ctx);
+        // Fitted, not cropped: a still is 16:9 and fills the frame, and a tall poster keeps its whole
+        // picture with the frame's own colour beside it rather than losing its head and its feet.
+        poster.setScaleType(ImageView.ScaleType.FIT_CENTER);
+        box.addView(poster, new FrameLayout.LayoutParams(
+                FrameLayout.LayoutParams.MATCH_PARENT, FrameLayout.LayoutParams.MATCH_PARENT));
+        if (artwork != null) {
+            Glide.with(this).load(artwork).into(poster);
+        } else {
+            // Nothing was sent for this one. A frame standing empty reads as a fault, and the number
+            // blown up to fill it reads as a stand-in for the picture rather than as the file's place in
+            // the list — so the frame says "no preview" in the quietest way there is, and the number
+            // stays exactly where it sits on every frame that does have one.
+            poster.setVisibility(View.GONE);
+            final ImageView blank = new ImageView(ctx);
+            blank.setImageResource(R.drawable.ic_movie_24dp);
+            blank.setImageTintList(ColorStateList.valueOf(ColorUtils.setAlphaComponent(
+                    MaterialColors.getColor(ctx, R.attr.colorOnSurfaceVariant,
+                            ContextCompat.getColor(ctx, R.color.ink_secondary)), 0x5C)));
+            final FrameLayout.LayoutParams blankLp = new FrameLayout.LayoutParams(
+                    ui.dpS(24), ui.dpS(24));
+            blankLp.gravity = Gravity.CENTER;
+            box.addView(blank, blankLp);
+        }
+        final TextView marker = metaChip(ctx, String.valueOf(index + 1));
+        if (playing) {
+            // The one playing says so in the marker it already has, rather than in a second thing beside
+            // it: the accent, with the ink that belongs to the accent. That pair is 4.88:1 — where the
+            // white this label wears over its own scrim would be 4.31:1 on the coral, under the 4.5 small
+            // text asks for. The word survives for a screen reader, which is what colour alone would
+            // otherwise cost.
+            marker.setTextColor(MaterialColors.getColor(ctx, R.attr.colorOnSecondaryContainer,
+                    ContextCompat.getColor(ctx, R.color.brand_accent_on)));
+            final GradientDrawable accent = new GradientDrawable();
+            accent.setCornerRadius(Utils.dpToPx(6));
+            accent.setColor(MaterialColors.getColor(ctx, R.attr.colorSecondaryContainer,
+                    ContextCompat.getColor(ctx, R.color.brand_accent)));
+            marker.setBackground(accent);
+            marker.setContentDescription(getString(R.string.playlist_playing));
+        }
+        final FrameLayout.LayoutParams markerLp = new FrameLayout.LayoutParams(
+                ViewGroup.LayoutParams.WRAP_CONTENT, ui.dpS(20));
+        markerLp.gravity = Gravity.TOP | Gravity.START;
+        markerLp.setMargins(Utils.dpToPx(6), Utils.dpToPx(6), 0, 0);
+        box.addView(marker, markerLp);
+        return box;
+    }
+
+    /** One playlist row: the frame, the name, and the word for the one playing at the end of it. */
+    private View playlistRow(final Context ctx, final int index, final CharSequence title,
+                             final Uri artwork, final boolean isCurrent) {
+        final LinearLayout row = new LinearLayout(ctx);
+        row.setOrientation(LinearLayout.HORIZONTAL);
+        row.setGravity(Gravity.CENTER_VERTICAL);
+        row.setPadding(Utils.dpToPx(8), Utils.dpToPx(7), Utils.dpToPx(10), Utils.dpToPx(7));
+        row.setMinimumHeight(ui.rowMinHeight());
+
+        // 16:9, the shape of what is inside it, and the shape the episode lists already use.
+        final LinearLayout.LayoutParams frameLp = new LinearLayout.LayoutParams(ui.dpS(88), ui.dpS(50));
+        frameLp.setMarginEnd(Utils.dpToPx(12));
+        frameLp.gravity = Gravity.CENTER_VERTICAL;
+        row.addView(playlistFrame(ctx, index, artwork, isCurrent), frameLp);
+
+        final LinearLayout textBlock = new LinearLayout(ctx);
+        textBlock.setOrientation(LinearLayout.VERTICAL);
+        final TextView titleText = new TextView(ctx);
+        titleText.setText(title);
+        titleText.setTextColor(MaterialColors.getColor(ctx, R.attr.colorOnSurface, Color.WHITE));
+        titleText.setTextSize(TypedValue.COMPLEX_UNIT_SP, ui.textList());
+        if (isCurrent) {
+            titleText.setTypeface(Typeface.DEFAULT_BOLD);
+        }
+        textBlock.addView(titleText);
+        final LinearLayout.LayoutParams blockLp = new LinearLayout.LayoutParams(
+                0, ViewGroup.LayoutParams.WRAP_CONTENT, 1f);
+        blockLp.gravity = Gravity.CENTER_VERTICAL;
+        row.addView(textBlock, blockLp);
+        fitLongText(row, titleText);
+        return row;
+    }
+
+    /**
+     * One playlist card: the frame at a size worth looking at, the number over it, and the name under.
+     * This is what the frames are for — a folder of camera files tells its items apart by what is in
+     * them, where the names are one word and a number.
+     */
+    private View playlistCard(final Context ctx, final int index, final CharSequence title,
+                              final Uri artwork, final boolean isCurrent, final int cellWidthPx) {
+        final LinearLayout card = new LinearLayout(ctx);
+        card.setOrientation(LinearLayout.VERTICAL);
+        final int pad = Utils.dpToPx(6);
+        card.setPadding(pad, pad, pad, Utils.dpToPx(8));
+
+        card.addView(playlistFrame(ctx, index, artwork, isCurrent),
+                new LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT,
+                        (cellWidthPx - 2 * pad) * 9 / 16));
+
+        final TextView titleText = new TextView(ctx);
+        titleText.setText(title);
+        titleText.setTextColor(MaterialColors.getColor(ctx, R.attr.colorOnSurface, Color.WHITE));
+        titleText.setTextSize(TypedValue.COMPLEX_UNIT_SP, ui.textList());
+        if (isCurrent) {
+            titleText.setTypeface(Typeface.DEFAULT_BOLD);
+        }
+        final LinearLayout.LayoutParams titleLp = new LinearLayout.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT);
+        titleLp.topMargin = Utils.dpToPx(8);
+        card.addView(titleText, titleLp);
+
+        // One line, and an ellipsis where it runs out. Two lines kept every card the same height even
+        // when the names were short, but it paid for that with a blank line under most of them; a single
+        // line is the same height for every card without reserving room nothing is going to use. Not
+        // fitLongText's marquee either — in a rail it would leave every card that is not focused cut off
+        // mid-word, where an ellipsis says the name goes on.
+        titleText.setLines(1);
+        titleText.setEllipsize(TextUtils.TruncateAt.END);
+        return card;
+    }
+
+    /**
+     * A label over a frame, Material's way of putting one on an image: the full shape at label size in
+     * the label weight, on a scrim of its own rather than on the theme's surface — what is behind it is
+     * a picture, and a frame with no picture in it yet is the very colour a surface pill would be.
+     */
+    private TextView metaChip(final Context ctx, final CharSequence text) {
+        final TextView chip = new TextView(ctx);
+        chip.setText(text);
+        chip.setTextSize(TypedValue.COMPLEX_UNIT_SP, ui.textBadge());
+        chip.setTypeface(Typeface.create("sans-serif-medium", Typeface.NORMAL));
+        chip.setTextColor(Color.WHITE);
+        final GradientDrawable fill = new GradientDrawable();
+        // 6dp, not the pill the height would give: the frame it sits on is 8dp, and a label rounded to
+        // half of itself beside a corner that gentle reads as a different family. Under the frame's own
+        // radius, because it is the smaller box and sits 6dp inside it.
+        fill.setCornerRadius(Utils.dpToPx(6));
+        fill.setColor(ContextCompat.getColor(ctx, R.color.badge_scrim));
+        chip.setBackground(fill);
+        // A stated height with the radius at half of it: a pill, and every pill in the panel the same
+        // height whatever is in it. Font padding off, so the text sits on the pill's centre line rather
+        // than on the centre of the room the font asks for.
+        chip.setGravity(Gravity.CENTER);
+        chip.setIncludeFontPadding(false);
+        chip.setPadding(Utils.dpToPx(8), 0, Utils.dpToPx(8), 0);
+        final LinearLayout.LayoutParams lp = new LinearLayout.LayoutParams(
+                ViewGroup.LayoutParams.WRAP_CONTENT, ui.dpS(20));
+        lp.setMarginEnd(Utils.dpToPx(4));
+        chip.setLayoutParams(lp);
+        return chip;
+    }
+
     // Small episode-number chip, inset from the poster's top-start corner so its rounded corners don't
     // clash with the poster's rounded clip. Reused by the header poster and the playlist rows.
     private TextView createPosterNumberBadge() {
@@ -5372,11 +5545,13 @@ public class PlayerActivity extends Activity {
         final FrameLayout.LayoutParams lp = new FrameLayout.LayoutParams(
                 FrameLayout.LayoutParams.WRAP_CONTENT, FrameLayout.LayoutParams.WRAP_CONTENT);
         lp.gravity = Gravity.TOP | Gravity.START;
-        lp.setMargins(Utils.dpToPx(3), Utils.dpToPx(3), 0, 0);
+        lp.setMargins(Utils.dpToPx(6), Utils.dpToPx(6), 0, 0);
         badge.setLayoutParams(lp);
         final GradientDrawable bg = new GradientDrawable();
         bg.setColor(ContextCompat.getColor(this, R.color.badge_scrim));
-        bg.setCornerRadius(Utils.dpToPx(3));
+        // The same radius as the panel's labels, and inset clear of the frame's own corner rather than
+        // sitting on the curve of it.
+        bg.setCornerRadius(Utils.dpToPx(6));
         badge.setBackground(bg);
         badge.setGravity(Gravity.CENTER);
         badge.setMinWidth(Utils.dpToPx(18));
@@ -5447,7 +5622,6 @@ public class PlayerActivity extends Activity {
         }
         final int count = mediaItems.size();
         final int current = fromPlayer ? player.getCurrentMediaItemIndex() : apiPlaylistStartIndex;
-        final int radius = Utils.dpToPx(4);
         final View[] currentRow = new View[1];
 
         // The panels follow the appearance choice, like the dialogs do — see
@@ -5455,31 +5629,92 @@ public class PlayerActivity extends Activity {
         // light panel and AMOLED gets a black one.
         final Context ctx = Utils.dialogContext(this);
         final int onSurface = MaterialColors.getColor(ctx, R.attr.colorOnSurface, Color.WHITE);
-        // What "chosen" looks like, shared with the toggle groups and the settings switch.
-        final int selectedFill = MaterialColors.getColor(ctx, R.attr.colorSecondaryContainer,
-                ContextCompat.getColor(ctx, R.color.brand_container));
-        final int onSelected = MaterialColors.getColor(ctx, R.attr.colorOnSecondaryContainer, Color.WHITE);
         final LinearLayout listLayout = new LinearLayout(ctx);
         listLayout.setOrientation(LinearLayout.VERTICAL);
         final int listPad = Utils.dpToPx(10);
         listLayout.setPadding(listPad, listPad, listPad, listPad);
 
+        // Frames are a landscape idea: a rail of them needs width to run along and gives up the height
+        // a list would have used. Held upright there is no width and nothing to scroll sideways, so the
+        // panel is a list and does not offer a choice it cannot honour. The choice itself is remembered
+        // for when the phone is turned back.
+        final boolean landscape = getResources().getConfiguration().orientation
+                == Configuration.ORIENTATION_LANDSCAPE;
+        final boolean grid = landscape && mPrefs != null && mPrefs.playlistGrid;
+
+        // The panel's name, how much is in it, and the one control it has.
+        final LinearLayout headerRow = new LinearLayout(ctx);
+        headerRow.setOrientation(LinearLayout.HORIZONTAL);
+        headerRow.setGravity(Gravity.CENTER_VERTICAL);
+
+        // The name carries the weight and the count follows it in the quieter ink, because one of them
+        // is what the panel is and the other is how much of it there is. Both on one baseline, and the
+        // pair starts on the line the frames below it start on, not on the panel's own padding.
         final TextView header = new TextView(ctx);
         header.setText(getString(R.string.playlist));
         header.setTextColor(onSurface);
         header.setTextSize(TypedValue.COMPLEX_UNIT_SP, ui.textTitle());
         header.setTypeface(Typeface.DEFAULT_BOLD);
-        header.setPadding(Utils.dpToPx(10), Utils.dpToPx(10), Utils.dpToPx(10), Utils.dpToPx(10));
-        listLayout.addView(header);
+        header.setPadding(Utils.dpToPx(8), Utils.dpToPx(10), 0, Utils.dpToPx(10));
+        headerRow.addView(header);
 
-        final View divider = new View(ctx);
-        final LinearLayout.LayoutParams dividerLp = new LinearLayout.LayoutParams(
-                ViewGroup.LayoutParams.MATCH_PARENT, Utils.dpToPx(1));
-        dividerLp.bottomMargin = Utils.dpToPx(4);
-        divider.setLayoutParams(dividerLp);
-        divider.setBackgroundColor(MaterialColors.getColor(ctx, R.attr.colorOutlineVariant,
-                ContextCompat.getColor(ctx, R.color.divider)));
-        listLayout.addView(divider);
+        final TextView headerCount = new TextView(ctx);
+        headerCount.setText(getResources().getQuantityString(R.plurals.playlist_items, count, count));
+        headerCount.setTextColor(MaterialColors.getColor(ctx, R.attr.colorOnSurfaceVariant,
+                ContextCompat.getColor(ctx, R.color.ink_secondary)));
+        headerCount.setTextSize(TypedValue.COMPLEX_UNIT_SP, ui.textCaption());
+        final LinearLayout.LayoutParams countLp = new LinearLayout.LayoutParams(
+                0, ViewGroup.LayoutParams.WRAP_CONTENT, 1f);
+        countLp.setMarginStart(Utils.dpToPx(8));
+        headerRow.addView(headerCount, countLp);
+
+        // Rows or frames, remembered rather than asked again: a viewer who wants pictures wants them for
+        // every playlist, not for this one. The icon shows what the press will give, not where you are.
+        if (landscape) {
+            final MaterialButton modeButton = new MaterialButton(ctx, null,
+                    com.google.android.material.R.attr.materialIconButtonStyle);
+            modeButton.setIconResource(grid ? R.drawable.ic_view_list_24dp : R.drawable.ic_view_grid_24dp);
+            modeButton.setIconTint(ColorStateList.valueOf(MaterialColors.getColor(ctx,
+                    R.attr.colorOnSurfaceVariant, ContextCompat.getColor(ctx, R.color.ink_secondary))));
+            modeButton.setContentDescription(getString(grid
+                    ? R.string.playlist_view_list : R.string.playlist_view_grid));
+            modeButton.setInsetTop(0);
+            modeButton.setInsetBottom(0);
+            modeButton.setIconSize(ui.dpS(24));
+            modeButton.setMinWidth(ui.clusterBox());
+            modeButton.setMinHeight(ui.clusterBox());
+            Utils.focusRing(modeButton);
+            // The panel is built from scratch every time it opens, so switching is opening it again — and
+            // showPlaylistDialog dismisses the one on screen itself before it builds the next.
+            modeButton.setOnClickListener(v -> {
+                mPrefs.updatePlaylistGrid(!grid);
+                showPlaylistDialog();
+            });
+            headerRow.addView(modeButton);
+        }
+        listLayout.addView(headerRow);
+
+        // A card keeps a stated width and lets the next one show past the panel's edge, which is what
+        // says there is more of it; 190dp is about the narrowest a 16:9 frame can be and still be a
+        // picture rather than a stamp, and it grows with the device class like every other box here.
+        final int cellWidth = ui.dpS(190);
+        LinearLayout gridRow = null;
+        HorizontalScrollView railScroller = null;
+        if (grid) {
+            railScroller = new HorizontalScrollView(ctx);
+            railScroller.setHorizontalScrollBarEnabled(false);
+            // The rail is cut by the panel's edge wherever it happens to be scrolled to, so the cut is
+            // faded rather than sliced — that fade is also the only thing saying there is more to the
+            // right. The padding is not clipped, so the first and last cards keep the panel's margin
+            // while the ones between it scroll under it.
+            railScroller.setHorizontalFadingEdgeEnabled(true);
+            railScroller.setFadingEdgeLength(ui.dpS(28));
+            railScroller.setClipToPadding(false);
+            gridRow = new LinearLayout(ctx);
+            gridRow.setOrientation(LinearLayout.HORIZONTAL);
+            railScroller.addView(gridRow);
+            listLayout.addView(railScroller);
+        }
 
         for (int i = 0; i < count; i++) {
             final int index = i;
@@ -5492,78 +5727,24 @@ public class PlayerActivity extends Activity {
             final Uri artwork = md != null ? md.artworkUri : null;
             final boolean isCurrent = i == current;
 
-            final LinearLayout row = new LinearLayout(ctx);
-            row.setOrientation(LinearLayout.HORIZONTAL);
-            row.setGravity(Gravity.CENTER_VERTICAL);
-            row.setPadding(Utils.dpToPx(8), Utils.dpToPx(7), Utils.dpToPx(10), Utils.dpToPx(7));
+            final View row = grid
+                    ? playlistCard(ctx, i, title, artwork, isCurrent, cellWidth)
+                    : playlistRow(ctx, i, title, artwork, isCurrent);
             row.setClickable(true);
             row.setFocusable(true);
-            row.setMinimumHeight(ui.rowMinHeight());
-            // Rounded row: subtle fill for the current item, plus a rounded ripple for touch/D-pad focus.
-            row.setBackground(Utils.pickerRow(ctx, isCurrent ? selectedFill : Color.TRANSPARENT));
+            // Nothing is painted under the one playing. Two attempts said otherwise and both measured
+            // badly: the coral of the other pickers turned the row brown, and the neutral step that
+            // replaced it came out at 1.29:1 in the dark appearance, 1.16:1 in the light one, and at
+            // exactly nothing under AMOLED, where the two container tones are the same colour. What says
+            // it now is the glyph in the picture and the weight of the name — one mark the eye finds and
+            // one that survives a monochrome screenshot — leaving the fill to the focus ring, whose job
+            // "this cell" already was.
+            row.setBackground(Utils.pickerRow(ctx, Color.TRANSPARENT));
+            // What a screen reader needs to hear, and free: the row is the selected one in its list.
+            row.setSelected(isCurrent);
             if (isCurrent) {
                 currentRow[0] = row;
             }
-
-            final FrameLayout box = new FrameLayout(ctx);
-            final LinearLayout.LayoutParams boxLp = new LinearLayout.LayoutParams(
-                    LinearLayout.LayoutParams.WRAP_CONTENT, Utils.dpToPx(56));
-            boxLp.setMarginEnd(Utils.dpToPx(12));
-            boxLp.gravity = Gravity.CENTER_VERTICAL;
-            box.setLayoutParams(boxLp);
-            box.setMinimumWidth(Utils.dpToPx(40));
-            box.setBackgroundColor(MaterialColors.getColor(ctx, R.attr.colorSurfaceContainerHighest,
-                        ContextCompat.getColor(ctx, R.color.thumb_box)));
-            box.setClipToOutline(true);
-            box.setOutlineProvider(new ViewOutlineProvider() {
-                @Override
-                public void getOutline(View view, Outline outline) {
-                    outline.setRoundRect(0, 0, view.getWidth(), view.getHeight(), radius);
-                }
-            });
-
-            final ImageView poster = new ImageView(ctx);
-            poster.setLayoutParams(new FrameLayout.LayoutParams(
-                    FrameLayout.LayoutParams.WRAP_CONTENT, FrameLayout.LayoutParams.MATCH_PARENT));
-            poster.setAdjustViewBounds(true);
-            poster.setScaleType(ImageView.ScaleType.FIT_CENTER);
-            box.addView(poster);
-
-            if (artwork != null) {
-                Glide.with(this).load(artwork).into(poster);
-                final TextView numberChip = createPosterNumberBadge();
-                numberChip.setText(String.valueOf(i + 1));
-                numberChip.setVisibility(View.VISIBLE);
-                box.addView(numberChip);
-            } else {
-                poster.setVisibility(View.GONE);
-                final TextView number = new TextView(ctx);
-                number.setText(String.valueOf(i + 1));
-                number.setTypeface(Typeface.DEFAULT_BOLD);
-                number.setLayoutParams(new FrameLayout.LayoutParams(
-                        FrameLayout.LayoutParams.MATCH_PARENT, FrameLayout.LayoutParams.MATCH_PARENT));
-                number.setGravity(Gravity.CENTER);
-                number.setMinWidth(Utils.dpToPx(40));
-                number.setTextColor(MaterialColors.getColor(ctx, R.attr.colorOnSurfaceVariant,
-                    ContextCompat.getColor(ctx, R.color.ink_secondary)));
-                number.setTextSize(TypedValue.COMPLEX_UNIT_SP, ui.textListNumber());
-                box.addView(number);
-            }
-            row.addView(box);
-
-            final TextView titleText = new TextView(ctx);
-            titleText.setText(title);
-            titleText.setTextColor(isCurrent ? onSelected : onSurface);
-            titleText.setTextSize(TypedValue.COMPLEX_UNIT_SP, ui.textList());
-            if (isCurrent) {
-                titleText.setTypeface(Typeface.DEFAULT_BOLD);
-            }
-            final LinearLayout.LayoutParams titleLp = new LinearLayout.LayoutParams(
-                    0, LinearLayout.LayoutParams.WRAP_CONTENT, 1f);
-            titleLp.gravity = Gravity.CENTER_VERTICAL;
-            titleText.setLayoutParams(titleLp);
-            row.addView(titleText);
-            fitLongText(row, titleText);
 
             row.setOnClickListener(v -> {
                 if (player != null) {
@@ -5586,7 +5767,17 @@ public class PlayerActivity extends Activity {
                 }
             });
 
-            listLayout.addView(row);
+            if (grid) {
+                gridRow.addView(row, new LinearLayout.LayoutParams(
+                        cellWidth, ViewGroup.LayoutParams.WRAP_CONTENT));
+            } else {
+                final LinearLayout.LayoutParams rowLp = new LinearLayout.LayoutParams(
+                        ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT);
+                // Each row carries its own rounded fill, so they are separated rather than stacked into
+                // one column of touching rectangles.
+                rowLp.bottomMargin = Utils.dpToPx(4);
+                listLayout.addView(row, rowLp);
+            }
         }
 
         final android.widget.ScrollView scrollView = new android.widget.ScrollView(ctx);
@@ -5602,11 +5793,25 @@ public class PlayerActivity extends Activity {
             playlistDialog.dismiss();
         }
         playlistDialog = new android.app.Dialog(this, android.R.style.Theme_Translucent_NoTitleBar);
-        Utils.pickerWindow(this, ui, playlistDialog, scrollView);
+        Utils.pickerWindow(this, ui, playlistDialog, scrollView,
+                grid ? Utils.Panel.RAIL : Utils.Panel.LIST);
         // Hide the player's overlay (header + bottom controls) so only the playlist panel is shown.
         showPickerDialog(playlistDialog);
-        if (currentRow[0] != null) {
-            currentRow[0].post(() -> currentRow[0].requestFocus());
+        final View currentCell = currentRow[0];
+        final HorizontalScrollView rail = railScroller;
+        if (currentCell != null) {
+            currentCell.post(() -> {
+                // A remote is brought to the item playing by taking the focus. A finger is not: nothing
+                // is focusable in touch mode, so the focus request is refused and neither scroller moves
+                // — which is why a playlist of two hundred files used to open at the first one however
+                // far in the viewer had got. Scroll it as well, on whichever axis this arrangement runs.
+                currentCell.requestFocus();
+                if (rail != null) {
+                    rail.scrollTo(currentCell.getLeft() - Utils.dpToPx(8), 0);
+                } else {
+                    scrollView.scrollTo(0, currentCell.getTop() - Utils.dpToPx(8));
+                }
+            });
         }
     }
 
@@ -5845,7 +6050,7 @@ public class PlayerActivity extends Activity {
             qualityDialog.dismiss();
         }
         qualityDialog = new android.app.Dialog(this, android.R.style.Theme_Translucent_NoTitleBar);
-        Utils.pickerWindow(this, ui, qualityDialog, scrollView);
+        Utils.pickerWindow(this, ui, qualityDialog, scrollView, Utils.Panel.OPTIONS);
         showPickerDialog(qualityDialog);
         if (currentRow[0] != null) {
             currentRow[0].post(() -> currentRow[0].requestFocus());
@@ -5985,9 +6190,9 @@ public class PlayerActivity extends Activity {
         return caption;
     }
 
-    // Full-height translucent panel docked to the end edge, matching the quality/playlist menus.
+    // The panel every picker shares, matching the quality/playlist menus.
     private void showSideMenu(CharSequence menuTitle, List<MenuItem> items) {
-        showSideMenu(menuTitle, items, 34, 48);
+        showSideMenu(menuTitle, items, 34, 48, Utils.Panel.OPTIONS);
     }
 
     /**
@@ -5995,8 +6200,11 @@ public class PlayerActivity extends Activity {
      *                  name that already says everything; a list where the poster is what tells the
      *                  rows apart — search results for a name typed from across the room — asks for
      *                  bigger, and nothing else about the panel changes.
+     * @param kind      {@link Utils.Panel#LIST} for a panel whose rows carry artwork and a title, which
+     *                  gets the wider card; {@link Utils.Panel#OPTIONS} for a list of words.
      */
-    private void showSideMenu(CharSequence menuTitle, List<MenuItem> items, int posterWDp, int posterHDp) {
+    private void showSideMenu(CharSequence menuTitle, List<MenuItem> items, int posterWDp, int posterHDp,
+                              Utils.Panel kind) {
         if (items == null || items.isEmpty()) {
             return;
         }
@@ -6166,7 +6374,7 @@ public class PlayerActivity extends Activity {
             menuDialog.dismiss();
         }
         menuDialog = new android.app.Dialog(this, android.R.style.Theme_Translucent_NoTitleBar);
-        Utils.pickerWindow(this, ui, menuDialog, scrollView);
+        Utils.pickerWindow(this, ui, menuDialog, scrollView, kind);
         showPickerDialog(menuDialog);
         final View focus = currentRow[0] != null ? currentRow[0] : firstRow[0];
         if (focus != null) {
@@ -7747,8 +7955,9 @@ public class PlayerActivity extends Activity {
         // Here as well as on the season list: a series with one season skips that step entirely, and
         // typing the numbers must not end up being something only multi-season shows offer.
         items.add(0, typeNumbersRow(title, episodes));
-        // Stills are 16:9, so the row leads with a wide frame rather than a tall poster.
-        showSideMenu(title.name, items, 72, 41);
+        // Stills are 16:9, so the row leads with a wide frame rather than a tall poster — and an
+        // episode name beside one is what the wider card exists for.
+        showSideMenu(title.name, items, 72, 41, Utils.Panel.LIST);
     }
 
     /** The way past the catalogues, first in the list because it is what somebody who knows reaches for. */

--- a/app/src/main/java/com/brouken/player/PlayerActivity.java
+++ b/app/src/main/java/com/brouken/player/PlayerActivity.java
@@ -5595,17 +5595,7 @@ public class PlayerActivity extends Activity {
             playlistDialog.dismiss();
         }
         playlistDialog = new android.app.Dialog(this, android.R.style.Theme_Translucent_NoTitleBar);
-        playlistDialog.setContentView(scrollView);
-        playlistDialog.setCanceledOnTouchOutside(true);
-        final Window window = playlistDialog.getWindow();
-        if (window != null) {
-            // Deliberately NOT fullscreen/edge-to-edge: a fullscreen dialog window makes OxygenOS treat the
-            // panel as immersive and apply its two-swipe back-gesture guard. A plain window closes on one back.
-            window.setLayout(ui.pickerWidthPx(getResources().getConfiguration()), ViewGroup.LayoutParams.MATCH_PARENT);
-            window.setGravity(Gravity.END);
-            window.setBackgroundDrawable(new android.graphics.drawable.ColorDrawable(
-                    ContextCompat.getColor(this, R.color.chrome_surface)));
-        }
+        Utils.pickerWindow(this, ui, playlistDialog, scrollView);
         // Hide the player's overlay (header + bottom controls) so only the playlist panel is shown.
         showPickerDialog(playlistDialog);
         if (currentRow[0] != null) {
@@ -5844,17 +5834,7 @@ public class PlayerActivity extends Activity {
             qualityDialog.dismiss();
         }
         qualityDialog = new android.app.Dialog(this, android.R.style.Theme_Translucent_NoTitleBar);
-        qualityDialog.setContentView(scrollView);
-        qualityDialog.setCanceledOnTouchOutside(true);
-        final Window window = qualityDialog.getWindow();
-        if (window != null) {
-            // Deliberately NOT fullscreen/edge-to-edge: a fullscreen dialog window makes OxygenOS treat the
-            // panel as immersive and apply its two-swipe back-gesture guard. A plain window closes on one back.
-            window.setLayout(ui.pickerWidthPx(getResources().getConfiguration()), ViewGroup.LayoutParams.MATCH_PARENT);
-            window.setGravity(Gravity.END);
-            window.setBackgroundDrawable(new android.graphics.drawable.ColorDrawable(
-                    ContextCompat.getColor(this, R.color.chrome_surface)));
-        }
+        Utils.pickerWindow(this, ui, qualityDialog, scrollView);
         showPickerDialog(qualityDialog);
         if (currentRow[0] != null) {
             currentRow[0].post(() -> currentRow[0].requestFocus());
@@ -6141,17 +6121,7 @@ public class PlayerActivity extends Activity {
             menuDialog.dismiss();
         }
         menuDialog = new android.app.Dialog(this, android.R.style.Theme_Translucent_NoTitleBar);
-        menuDialog.setContentView(scrollView);
-        menuDialog.setCanceledOnTouchOutside(true);
-        final Window window = menuDialog.getWindow();
-        if (window != null) {
-            // Deliberately NOT fullscreen/edge-to-edge: a fullscreen dialog window makes OxygenOS treat the
-            // panel as immersive and apply its two-swipe back-gesture guard. A plain window closes on one back.
-            window.setLayout(ui.pickerWidthPx(getResources().getConfiguration()), ViewGroup.LayoutParams.MATCH_PARENT);
-            window.setGravity(Gravity.END);
-            window.setBackgroundDrawable(new android.graphics.drawable.ColorDrawable(
-                    ContextCompat.getColor(this, R.color.chrome_surface)));
-        }
+        Utils.pickerWindow(this, ui, menuDialog, scrollView);
         showPickerDialog(menuDialog);
         final View focus = currentRow[0] != null ? currentRow[0] : firstRow[0];
         if (focus != null) {

--- a/app/src/main/java/com/brouken/player/PlayerActivity.java
+++ b/app/src/main/java/com/brouken/player/PlayerActivity.java
@@ -4856,6 +4856,38 @@ public class PlayerActivity extends Activity {
         return shortSide + "p";
     }
 
+    /**
+     * A track row in two lines: what the track is called, and what it is.
+     *
+     * <p>One line held both, in the shape the header meta line uses — {@code name [AAC 2.0 298k] (lang)}
+     * — and a file whose tracks declare neither a name nor a language turned that into four rows reading
+     * {@code [AAC 2.0 298k]}, three of them identical to the eye and none of them nameable. Brackets in a
+     * list also read as something printed rather than something chosen.
+     *
+     * <p>So the name goes on the first line — the container's own label, else the language, else the
+     * track's number, which is the one thing that always distinguishes one from the next — and the
+     * codec, the channels and the bitrate go on the second in the ink a supporting line is given. It is
+     * the shape the quality panel beside it already uses.
+     *
+     * @return the headline, and the supporting line or null when there is nothing to support it with
+     */
+    private String[] trackRowText(final Format format, final int number) {
+        final String name = trackName(format);
+        final String language = languageDisplayName(format.language);
+        final String headline = name != null && !name.isEmpty() ? name
+                : language != null && !language.isEmpty() ? language
+                : getString(R.string.audio_track_number, number);
+        final StringBuilder detail = new StringBuilder(CustomDefaultTrackNameProvider.techInfo(format));
+        // The language belongs on the second line only when the first one is taken by a name.
+        if (name != null && !name.isEmpty() && language != null && !language.isEmpty()) {
+            if (detail.length() > 0) {
+                detail.append(" \u00b7 ");
+            }
+            detail.append(language);
+        }
+        return new String[]{headline, detail.length() == 0 ? null : detail.toString()};
+    }
+
     private String buildAudioInfo(Format audio) {
         if (audio == null) {
             return null;
@@ -5774,8 +5806,8 @@ public class PlayerActivity extends Activity {
                 final LinearLayout.LayoutParams rowLp = new LinearLayout.LayoutParams(
                         ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT);
                 // Each row carries its own rounded fill, so they are separated rather than stacked into
-                // one column of touching rectangles.
-                rowLp.bottomMargin = Utils.dpToPx(4);
+                // one column of touching rectangles — between them, which is not after the last one.
+                rowLp.bottomMargin = i == count - 1 ? 0 : Utils.dpToPx(4);
                 listLayout.addView(row, rowLp);
             }
         }
@@ -5787,7 +5819,10 @@ public class PlayerActivity extends Activity {
         // dialog — are shown): a dynamic inset listener would drop to 0 when hideController() flips the
         // activity to immersive flags, making the list visibly "jump" up under the still-visible status bar.
         // The rows carry their own side padding; the card only keeps them off its rounded ends.
-        scrollView.setPadding(0, Utils.dpToPx(8), 0, Utils.dpToPx(8));
+        // Nothing at the bottom: the list inside carries its own padding and the panel adds the
+        // navigation bar's inset under that, so a third one here only opened a band of empty sheet
+        // below the last row.
+        scrollView.setPadding(0, Utils.dpToPx(8), 0, 0);
 
         if (playlistDialog != null) {
             playlistDialog.dismiss();
@@ -6044,7 +6079,10 @@ public class PlayerActivity extends Activity {
         final android.widget.ScrollView scrollView = new android.widget.ScrollView(ctx);
         scrollView.addView(listLayout);
         // The rows carry their own side padding; the card only keeps them off its rounded ends.
-        scrollView.setPadding(0, Utils.dpToPx(8), 0, Utils.dpToPx(8));
+        // Nothing at the bottom: the list inside carries its own padding and the panel adds the
+        // navigation bar's inset under that, so a third one here only opened a band of empty sheet
+        // below the last row.
+        scrollView.setPadding(0, Utils.dpToPx(8), 0, 0);
 
         if (qualityDialog != null) {
             qualityDialog.dismiss();
@@ -6149,28 +6187,24 @@ public class PlayerActivity extends Activity {
 
     /** The rule the panel already draws under its title, reused wherever one group of rows ends. */
     /**
-     * One group of rows as its own rounded card, the way the settings screen draws a preference
-     * category. The card is the tonal step above the sheet it sits on, and the gap to the next card is
-     * what used to be a hairline rule — a boundary you can see without drawing a line for it.
+     * The rule between two groups of rows that have no name to separate them: a hairline of the outline
+     * tone, inset to the panel's content edge, with the same air above it as below.
+     *
+     * <p>It replaced a card per group. A card inside a sheet is a container inside a container, and the
+     * two tones it needs are 1.23:1 apart — so it read as noise rather than as structure, and it gave
+     * the panel three different left edges: the group's name on one, the icons on a second, their labels
+     * on a third. A list on the sheet itself has one edge, and a rule is what a boundary between two
+     * groups of a list looks like.
      */
-    private LinearLayout panelGroup(final Context ctx) {
-        final LinearLayout group = new LinearLayout(ctx);
-        group.setOrientation(LinearLayout.VERTICAL);
-        final MaterialShapeDrawable card = new MaterialShapeDrawable(
-                ShapeAppearanceModel.builder().setAllCornerSizes(Utils.dpToPx(20)).build());
-        card.setFillColor(ColorStateList.valueOf(MaterialColors.getColor(
-                ctx, R.attr.colorSurfaceContainer, ContextCompat.getColor(ctx, R.color.thumb_box))));
-        group.setBackground(card);
-        // So a row's ripple and its lit fill stop at the card's rounded end.
-        group.setClipToOutline(true);
-        // A hair of card showing around each row, which is what tells a lit row from the card under it.
-        final int pad = Utils.dpToPx(4);
-        group.setPadding(pad, pad, pad, pad);
+    private View menuDivider(final Context ctx) {
+        final View rule = new View(ctx);
+        rule.setBackgroundColor(MaterialColors.getColor(ctx, R.attr.colorOutlineVariant,
+                ContextCompat.getColor(ctx, R.color.divider)));
         final LinearLayout.LayoutParams lp = new LinearLayout.LayoutParams(
-                ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT);
-        lp.bottomMargin = Utils.dpToPx(8);
-        group.setLayoutParams(lp);
-        return group;
+                ViewGroup.LayoutParams.MATCH_PARENT, Math.max(1, Utils.dpToPx(1)));
+        lp.setMargins(Utils.dpToPx(6), Utils.dpToPx(8), Utils.dpToPx(6), Utils.dpToPx(8));
+        rule.setLayoutParams(lp);
+        return rule;
     }
 
     /**
@@ -6184,9 +6218,13 @@ public class PlayerActivity extends Activity {
         caption.setText(text);
         caption.setTextColor(MaterialColors.getColor(ctx, R.attr.colorPrimary,
                 ContextCompat.getColor(ctx, R.color.brand)));
-        caption.setTypeface(Typeface.DEFAULT_BOLD);
+        // Medium, not bold, at the size Material gives a list subheader — and started on the same line
+        // the icons below it start on, 16dp into the row, so the panel has one left edge instead of
+        // three. It keeps the accent: the settings screen names its sections in it, and one coral line
+        // at the top of a group is a signature where eight coral glyphs under it were noise.
+        caption.setTypeface(Typeface.create("sans-serif-medium", Typeface.NORMAL));
         caption.setTextSize(TypedValue.COMPLEX_UNIT_SP, ui.textCaption());
-        caption.setPadding(Utils.dpToPx(12), Utils.dpToPx(8), Utils.dpToPx(12), Utils.dpToPx(8));
+        caption.setPadding(Utils.dpToPx(6), Utils.dpToPx(16), Utils.dpToPx(6), Utils.dpToPx(8));
         return caption;
     }
 
@@ -6236,20 +6274,22 @@ public class PlayerActivity extends Activity {
             header.setTextColor(onSurface);
             header.setTextSize(TypedValue.COMPLEX_UNIT_SP, ui.textTitle());
             header.setTypeface(Typeface.DEFAULT_BOLD);
-            header.setPadding(Utils.dpToPx(10), Utils.dpToPx(10), Utils.dpToPx(10), Utils.dpToPx(10));
+            header.setPadding(Utils.dpToPx(6), Utils.dpToPx(10), Utils.dpToPx(6), Utils.dpToPx(10));
             listLayout.addView(header);
         }
 
         // Each group of rows is its own card, the way a preference category is one in settings. The
         // holder is null between groups: the next row opens a new card, and a bare boundary needs no
         // rule because the gap between two cards already is one.
-        final LinearLayout[] group = new LinearLayout[1];
+        // Whether anything is above the boundary yet, so the panel never opens on a rule.
+        final boolean[] anyRow = {false};
 
         for (final MenuItem item : items) {
             if (item.chrome) {
-                group[0] = null;
                 if (item.title != null) {
                     listLayout.addView(menuCaption(ctx, item.title));
+                } else if (anyRow[0]) {
+                    listLayout.addView(menuDivider(ctx));
                 }
                 continue;
             }
@@ -6258,10 +6298,18 @@ public class PlayerActivity extends Activity {
             final LinearLayout row = new LinearLayout(ctx);
             row.setOrientation(LinearLayout.HORIZONTAL);
             row.setGravity(Gravity.CENTER_VERTICAL);
-            row.setPadding(Utils.dpToPx(12), Utils.dpToPx(10), Utils.dpToPx(12), Utils.dpToPx(10));
+            // 6dp inside the list's own 10dp, so the icon starts 16dp from the sheet's edge and its
+            // label at 16 + 24 + 16 = 56dp — the two numbers Material states for a list item with a
+            // leading icon. The vertical padding only keeps a two-line row off its own edges; the
+            // height below does the rest.
+            row.setPadding(Utils.dpToPx(6), Utils.dpToPx(8), Utils.dpToPx(6), Utils.dpToPx(8));
             row.setClickable(true);
             row.setFocusable(true);
-            row.setMinimumHeight(ui.rowMinHeight());
+            // A one-line row is 48dp and a one-line row that leads with an icon or a poster is 56dp —
+            // Material states both, and this list has rows of each kind.
+            final boolean leads = item.iconRes != 0
+                    || (item.imageUrl != null && !item.imageUrl.isEmpty());
+            row.setMinimumHeight(leads ? ui.dpS(56) : ui.rowMinHeight());
             row.setBackground(Utils.pickerRow(ctx, isCurrent ? selectedFill : Color.TRANSPARENT));
             if (isCurrent) {
                 currentRow[0] = row;
@@ -6298,11 +6346,18 @@ public class PlayerActivity extends Activity {
             } else if (item.iconRes != 0) {
                 final ImageView icon = new ImageView(ctx);
                 icon.setImageResource(item.iconRes);
-                // The accent, not the ink: a row of grey glyphs is a list of look-alikes, and the coral
-                // is the one thing in this panel that says which app it belongs to. White on the lit
-                // row, where the accent is already the fill under it.
-                icon.setImageTintList(ColorStateList.valueOf(isCurrent ? onSelected : accent));
-                final int iconSize = Utils.dpToPx(22);
+                // The ink a leading icon is given, not the accent. The accent was the argument once —
+                // "the one thing that says which app this is" — and eight of them in a column is not a
+                // signature, it is a list where every row shouts and the colour has stopped meaning
+                // anything: the same coral says "chosen" two rows below, on the row that is. One accent,
+                // one job. On the chosen row the icon takes the ink that belongs to the fill under it.
+                icon.setImageTintList(ColorStateList.valueOf(isCurrent ? onSelected
+                        : MaterialColors.getColor(ctx, R.attr.colorOnSurfaceVariant,
+                                ContextCompat.getColor(ctx, R.color.ink_secondary))));
+                // 24dp, the size Material states for a list item's leading icon — through dpS, because
+                // the row's own height goes through it, and a glyph that stays put in a row that grows
+                // reads as a smaller glyph on every device the chrome scales up for.
+                final int iconSize = ui.dpS(24);
                 final LinearLayout.LayoutParams iconLp = new LinearLayout.LayoutParams(iconSize, iconSize);
                 iconLp.setMarginEnd(Utils.dpToPx(16));
                 icon.setLayoutParams(iconLp);
@@ -6342,8 +6397,12 @@ public class PlayerActivity extends Activity {
             if (item.subtitle != null && item.subtitle.length() > 0) {
                 details = new TextView(ctx);
                 details.setText(item.subtitle);
-                details.setTextColor(MaterialColors.getColor(ctx, R.attr.colorOnSurfaceVariant,
-                    ContextCompat.getColor(ctx, R.color.ink_secondary)));
+                // On the row that is chosen it takes the ink of the fill it sits on: the quiet ink of
+                // the panel measures about 1.6:1 against the accent, which is a second line nobody can
+                // read on the one row the eye goes to first.
+                details.setTextColor(isCurrent ? onSelected
+                        : MaterialColors.getColor(ctx, R.attr.colorOnSurfaceVariant,
+                                ContextCompat.getColor(ctx, R.color.ink_secondary)));
                 details.setTextSize(TypedValue.COMPLEX_UNIT_SP, ui.textCaption());
                 textBlock.addView(details);
             }
@@ -6358,17 +6417,17 @@ public class PlayerActivity extends Activity {
                     item.action.run();
                 }
             });
-            if (group[0] == null) {
-                group[0] = panelGroup(ctx);
-                listLayout.addView(group[0]);
-            }
-            group[0].addView(row);
+            listLayout.addView(row);
+            anyRow[0] = true;
         }
 
         final android.widget.ScrollView scrollView = new android.widget.ScrollView(ctx);
         scrollView.addView(listLayout);
         // The rows carry their own side padding; the card only keeps them off its rounded ends.
-        scrollView.setPadding(0, Utils.dpToPx(8), 0, Utils.dpToPx(8));
+        // Nothing at the bottom: the list inside carries its own padding and the panel adds the
+        // navigation bar's inset under that, so a third one here only opened a band of empty sheet
+        // below the last row.
+        scrollView.setPadding(0, Utils.dpToPx(8), 0, 0);
 
         if (menuDialog != null) {
             menuDialog.dismiss();
@@ -6384,13 +6443,16 @@ public class PlayerActivity extends Activity {
 
     private static class AudioChoice {
         final String label;
+        final String detail; // the codec, channels and bitrate; null when the track declares none
         final TrackGroup group;
         final int trackIndex;
         final boolean selected;
         final String language; // ISO-639-2/T, null when the track declares none
 
-        AudioChoice(String label, TrackGroup group, int trackIndex, boolean selected, String language) {
+        AudioChoice(String label, String detail, TrackGroup group, int trackIndex, boolean selected,
+                    String language) {
             this.label = label;
+            this.detail = detail;
             this.group = group;
             this.trackIndex = trackIndex;
             this.selected = selected;
@@ -6415,12 +6477,8 @@ public class PlayerActivity extends Activity {
                 }
                 final Format format = trackGroup.getFormat(i);
                 number++;
-                // Same descriptor as the header meta line, so the picker matches what is shown up top.
-                String label = buildAudioInfo(format);
-                if (label == null || label.isEmpty()) {
-                    label = getString(R.string.audio_track_number, number);
-                }
-                choices.add(new AudioChoice(label, trackGroup, i, group.isTrackSelected(i),
+                final String[] text = trackRowText(format, number);
+                choices.add(new AudioChoice(text[0], text[1], trackGroup, i, group.isTrackSelected(i),
                         Utils.toIso3Language(format.language)));
             }
         }
@@ -6630,7 +6688,7 @@ public class PlayerActivity extends Activity {
         final List<MenuItem> items = new ArrayList<>();
         String selectedLanguage = null;
         for (final AudioChoice choice : choices) {
-            items.add(new MenuItem(choice.label, null, choice.selected,
+            items.add(new MenuItem(choice.label, choice.detail, choice.selected,
                     () -> applyAudio(choice)));
             if (choice.selected) {
                 selectedLanguage = choice.language;
@@ -7477,14 +7535,12 @@ public class PlayerActivity extends Activity {
                 if (format.equals(secondaryTextTrack.get())) {
                     continue;
                 }
-                String label = buildSubtitleInfo(format);
-                if (label == null || label.isEmpty()) {
-                    label = getString(R.string.audio_track_number, number);
-                }
+                final String[] text = trackRowText(format, number);
                 final int index = i;
                 // !painting: an embedded track can stay selected while the file is painted over it
                 // (SubtitleOffset drops the renderer's cues), and two ticked rows is a lie.
-                items.add(new MenuItem(label, null, textEnabled && !painting && group.isTrackSelected(i),
+                items.add(new MenuItem(text[0], text[1],
+                        textEnabled && !painting && group.isTrackSelected(i),
                         () -> applySubtitle(trackGroup, index)));
             }
         }
@@ -7611,13 +7667,10 @@ public class PlayerActivity extends Activity {
                 if (shownByMainLine(format)) {
                     continue;
                 }
-                String label = buildSubtitleInfo(format);
-                if (label == null || label.isEmpty()) {
-                    label = getString(R.string.audio_track_number, number);
-                }
+                final String[] text = trackRowText(format, number);
                 final TrackGroup mediaGroup = group.getMediaTrackGroup();
                 final int trackIndex = i;
-                items.add(new MenuItem(label, null, format.equals(currentTrack),
+                items.add(new MenuItem(text[0], text[1], format.equals(currentTrack),
                         () -> chooseSecondarySubtitleTrack(mediaGroup, trackIndex, format)));
             }
         }

--- a/app/src/main/java/com/brouken/player/PlayerActivity.java
+++ b/app/src/main/java/com/brouken/player/PlayerActivity.java
@@ -1673,7 +1673,7 @@ public class PlayerActivity extends Activity {
         // Solid dark pill with the neutral white countdown underline baked into its background as inset layers.
         // (A separate MATCH_PARENT underline View resolves to the full screen width inside a wrap-content
         // FrameLayout, which stretched the whole floating unit across the screen — hence layers instead.)
-        final int skipRingWidth = Utils.dpToPx(2);
+        final int skipRingWidth = getResources().getDimensionPixelSize(R.dimen.focus_ring_width);
         final int skipBarHeight = Utils.dpToPx(3);
         final int skipBarCorner = Utils.dpToPx(2);
         final GradientDrawable skipPillFill = new GradientDrawable();

--- a/app/src/main/java/com/brouken/player/PlayerActivity.java
+++ b/app/src/main/java/com/brouken/player/PlayerActivity.java
@@ -3537,7 +3537,7 @@ public class PlayerActivity extends Activity {
         }
         final OffsetPanel.Choice[] choices = hasSkipSegment()
                 ? new OffsetPanel.Choice[]{ skipModeChoice() } : new OffsetPanel.Choice[0];
-        skipOffsetDialog = OffsetPanel.create(this, ui, coordinatorLayout,
+        skipOffsetDialog = OffsetPanel.create(this, ui,
                 brandColor(),   // coral, matches the skip timeline highlight
                 getString(R.string.skip_session_title), OFFSET_MAX_SEC, OFFSET_STEP_SEC, choices,
                 // Captioned only while it shares the panel with the row above it; alone it is the panel.
@@ -3595,7 +3595,7 @@ public class PlayerActivity extends Activity {
         if (lines.isEmpty()) {
             return;
         }
-        subtitleOffsetDialog = OffsetPanel.create(this, ui, coordinatorLayout, brandColor(),
+        subtitleOffsetDialog = OffsetPanel.create(this, ui, brandColor(),
                 getString(R.string.subtitle_offset_title), SUBTITLE_OFFSET_MAX_SEC, OFFSET_STEP_SEC,
                 lines.toArray(new OffsetPanel.Line[0]));
         showPickerDialog(subtitleOffsetDialog);
@@ -5589,7 +5589,8 @@ public class PlayerActivity extends Activity {
         // them. Use a FIXED inset captured now (the status bar is visible while the controls — and thus this
         // dialog — are shown): a dynamic inset listener would drop to 0 when hideController() flips the
         // activity to immersive flags, making the list visibly "jump" up under the still-visible status bar.
-        Utils.padForPickerInsets(this, ui, coordinatorLayout, scrollView, ui.overscanH(), 0, 0);
+        // The rows carry their own side padding; the card only keeps them off its rounded ends.
+        scrollView.setPadding(0, Utils.dpToPx(8), 0, Utils.dpToPx(8));
 
         if (playlistDialog != null) {
             playlistDialog.dismiss();
@@ -5828,7 +5829,8 @@ public class PlayerActivity extends Activity {
 
         final android.widget.ScrollView scrollView = new android.widget.ScrollView(this);
         scrollView.addView(listLayout);
-        Utils.padForPickerInsets(this, ui, coordinatorLayout, scrollView, ui.overscanH(), 0, 0);
+        // The rows carry their own side padding; the card only keeps them off its rounded ends.
+        scrollView.setPadding(0, Utils.dpToPx(8), 0, Utils.dpToPx(8));
 
         if (qualityDialog != null) {
             qualityDialog.dismiss();
@@ -6115,7 +6117,8 @@ public class PlayerActivity extends Activity {
 
         final android.widget.ScrollView scrollView = new android.widget.ScrollView(this);
         scrollView.addView(listLayout);
-        Utils.padForPickerInsets(this, ui, coordinatorLayout, scrollView, ui.overscanH(), 0, 0);
+        // The rows carry their own side padding; the card only keeps them off its rounded ends.
+        scrollView.setPadding(0, Utils.dpToPx(8), 0, Utils.dpToPx(8));
 
         if (menuDialog != null) {
             menuDialog.dismiss();
@@ -8828,7 +8831,7 @@ public class PlayerActivity extends Activity {
         if (sleepTimerDialog != null) {
             sleepTimerDialog.dismiss();
         }
-        sleepTimerDialog = DurationPanel.create(this, ui, coordinatorLayout, brandColor(),
+        sleepTimerDialog = DurationPanel.create(this, ui, brandColor(),
                 getString(R.string.sleep_timer_title), this::armSleepTimer);
         showPickerDialog(sleepTimerDialog);
     }

--- a/app/src/main/java/com/brouken/player/PlayerActivity.java
+++ b/app/src/main/java/com/brouken/player/PlayerActivity.java
@@ -3839,17 +3839,6 @@ public class PlayerActivity extends Activity {
         return (alpha << 24) | (brandColor() & 0x00FFFFFF);
     }
 
-    /** Brand accent at reduced brightness (same hue/saturation) for large selected-row fills, where full
-     *  brand is too intense on the eyes. Scaling RGB proportionally lowers only the value, unlike alpha
-     *  blending which desaturates the color against the dark panel. */
-    private int brandColorDim() {
-        final int c = brandColor();
-        final float f = 0.72f; // tweakable: lower = darker
-        return Color.rgb(Math.round(Color.red(c) * f),
-                Math.round(Color.green(c) * f),
-                Math.round(Color.blue(c) * f));
-    }
-
     // Show a picker panel (audio/subtitle/playlist/quality/skip). OxygenOS/ColorOS applies a fullscreen
     // back-gesture guard (the "swipe again to go back" toast → two swipes) while the app is immersive, i.e.
     // system bars hidden. Our pickers call hideController(), which hides the bars, so keep the bars visible
@@ -5500,7 +5489,8 @@ public class PlayerActivity extends Activity {
             // Rounded row: subtle fill for the current item, plus a rounded ripple for touch/D-pad focus.
             final GradientDrawable rowContent = new GradientDrawable();
             rowContent.setCornerRadius(Utils.dpToPx(8));
-            rowContent.setColor(isCurrent ? brandColorDim() : Color.TRANSPARENT);
+            rowContent.setColor(isCurrent
+                    ? ContextCompat.getColor(this, R.color.brand_container) : Color.TRANSPARENT);
             final GradientDrawable rowMask = new GradientDrawable();
             rowMask.setCornerRadius(Utils.dpToPx(8));
             rowMask.setColor(Color.WHITE);
@@ -5782,7 +5772,8 @@ public class PlayerActivity extends Activity {
             row.setMinimumHeight(ui.rowMinHeight());
             final GradientDrawable rowContent = new GradientDrawable();
             rowContent.setCornerRadius(Utils.dpToPx(8));
-            rowContent.setColor(isCurrent ? brandColorDim() : Color.TRANSPARENT);
+            rowContent.setColor(isCurrent
+                    ? ContextCompat.getColor(this, R.color.brand_container) : Color.TRANSPARENT);
             final GradientDrawable rowMask = new GradientDrawable();
             rowMask.setCornerRadius(Utils.dpToPx(8));
             rowMask.setColor(Color.WHITE);
@@ -6039,7 +6030,8 @@ public class PlayerActivity extends Activity {
             row.setMinimumHeight(ui.rowMinHeight());
             final GradientDrawable rowContent = new GradientDrawable();
             rowContent.setCornerRadius(Utils.dpToPx(8));
-            rowContent.setColor(isCurrent ? brandColorDim() : Color.TRANSPARENT);
+            rowContent.setColor(isCurrent
+                    ? ContextCompat.getColor(this, R.color.brand_container) : Color.TRANSPARENT);
             final GradientDrawable rowMask = new GradientDrawable();
             rowMask.setCornerRadius(Utils.dpToPx(8));
             rowMask.setColor(Color.WHITE);

--- a/app/src/main/java/com/brouken/player/Prefs.java
+++ b/app/src/main/java/com/brouken/player/Prefs.java
@@ -71,6 +71,7 @@ class Prefs {
     private static final String PREF_KEY_FRAMERATE_MATCHING = "frameRateMatching";
     private static final String PREF_KEY_ALLOW_SYSTEM_FRAMERATE = "allowSystemFrameRate";
     private static final String PREF_KEY_REPEAT_TOGGLE = "repeatToggle";
+    private static final String PREF_KEY_PLAYLIST_GRID = "playlistGrid";
     private static final String PREF_KEY_TV_SINGLE_BACK = "tvSingleBack";
     private static final String PREF_KEY_KEEP_AWAKE_ON_PAUSE = "keepAwakeOnPause";
     private static final String PREF_KEY_SPEED = "speed";
@@ -214,6 +215,8 @@ class Prefs {
     public boolean frameRateMatching = false;
     public boolean allowSystemFrameRate = true;
     public boolean repeatToggle = false;
+    /** The playlist panel draws frames in a grid rather than a row per file. Off is the row per file. */
+    public boolean playlistGrid = false;
     public boolean tvSingleBack = false;
     public boolean keepAwakeOnPause = true;
     public String fileAccess = "auto";
@@ -393,6 +396,7 @@ class Prefs {
         frameRateMatching = mSharedPreferences.getBoolean(PREF_KEY_FRAMERATE_MATCHING, frameRateMatching);
         allowSystemFrameRate = mSharedPreferences.getBoolean(PREF_KEY_ALLOW_SYSTEM_FRAMERATE, !Utils.isTvBox(mContext));
         repeatToggle = mSharedPreferences.getBoolean(PREF_KEY_REPEAT_TOGGLE, repeatToggle);
+        playlistGrid = mSharedPreferences.getBoolean(PREF_KEY_PLAYLIST_GRID, playlistGrid);
         tvSingleBack = mSharedPreferences.getBoolean(PREF_KEY_TV_SINGLE_BACK, tvSingleBack);
         keepAwakeOnPause = mSharedPreferences.getBoolean(PREF_KEY_KEEP_AWAKE_ON_PAUSE, keepAwakeOnPause);
         fileAccess = mSharedPreferences.getString(PREF_KEY_FILE_ACCESS, fileAccess);
@@ -756,6 +760,14 @@ class Prefs {
         } else {
             nonPersitentPosition = position;
         }
+    }
+
+    /** Which way the playlist panel is drawn. Remembered, because it is a habit, not a per-film choice. */
+    public void updatePlaylistGrid(final boolean grid) {
+        this.playlistGrid = grid;
+        final SharedPreferences.Editor editor = mSharedPreferences.edit();
+        editor.putBoolean(PREF_KEY_PLAYLIST_GRID, grid);
+        editor.apply();
     }
 
     public void updateBrightness(final int brightness) {

--- a/app/src/main/java/com/brouken/player/SettingsActivity.java
+++ b/app/src/main/java/com/brouken/player/SettingsActivity.java
@@ -52,6 +52,7 @@ import androidx.recyclerview.widget.RecyclerView;
 import androidx.recyclerview.widget.SimpleItemAnimator;
 
 import com.google.android.material.appbar.MaterialToolbar;
+import com.google.android.material.button.MaterialButton;
 import com.google.android.material.button.MaterialButtonToggleGroup;
 import com.google.android.material.color.MaterialColors;
 import com.google.android.material.snackbar.Snackbar;
@@ -686,6 +687,11 @@ public class SettingsActivity extends AppCompatActivity
                 if (Prefs.THEME_SYSTEM.equals(Prefs.getThemeMode(context))) {
                     Prefs.setThemeMode(context, Prefs.THEME_DARK);
                 }
+            }
+            // The same ring the panels' segmented control wears: a border that only changes colour is
+            // a focus event you have to be looking at already.
+            for (int i = 0; i < group.getChildCount(); i++) {
+                Utils.focusRing((MaterialButton) group.getChildAt(i));
             }
             // The holder is recycled, so the listener from its last binding has to go first.
             group.clearOnButtonCheckedListeners();

--- a/app/src/main/java/com/brouken/player/UiMetrics.java
+++ b/app/src/main/java/com/brouken/player/UiMetrics.java
@@ -108,7 +108,6 @@ final class UiMetrics {
 
     /** Adaptive picker side-panel width in px: never covers a narrow phone, docks on tablet/TV. */
     int pickerWidthPx(Configuration cfg) {
-        final int windowW = cfg.screenWidthDp;
         final int preferred;
         switch (deviceClass) {
             case TV:            preferred = 420; break;
@@ -116,11 +115,43 @@ final class UiMetrics {
             case TABLET_MEDIUM: preferred = 400; break;
             default:            preferred = 360; break;
         }
+        return panelWidthPx(cfg, preferred);
+    }
+
+    /**
+     * Width for a panel whose rows carry artwork and a filename, rather than a word.
+     *
+     * <p>The width above is sized for "1.5×" and "Off". A playlist row holds
+     * {@code The.Dark.Knight.2008.BDRemux.2160p.DV.HDR.mkv} — 46 characters — and at 360dp, once the
+     * poster and the paddings have taken their share, some 270dp reach the name: about thirty
+     * characters. That shortfall is why the row has two different ways of coping with a name that does
+     * not fit at all (see PlayerActivity.fitLongText), and no amount of coping invents room.
+     *
+     * <p>640dp is Material's own ceiling for a sheet ({@code material_bottom_sheet_max_width}), and the
+     * caps below still apply, so a phone in landscape lands at 523dp and a television at 576dp. A
+     * narrow phone in portrait is already at its cap and does not move.
+     */
+    int listWidthPx(Configuration cfg) {
+        return panelWidthPx(cfg, 640);
+    }
+
+    /**
+     * Width for a rail of frames docked to the bottom edge. The caps above leave a strip of video beside
+     * a panel because a panel at the end edge takes width from the picture; a rail has already given up
+     * the height instead, so the strip it would leave buys nothing and costs it a frame — measured, the
+     * 60% landscape cap shows 2.7 cards where 85% shows 3.9.
+     */
+    int railWidthPx(Configuration cfg) {
+        return dp(Math.round(cfg.screenWidthDp * 0.85f));
+    }
+
+    private int panelWidthPx(Configuration cfg, int preferredDp) {
+        final int windowW = cfg.screenWidthDp;
         final int capPortrait = windowW - 56;                       // always leave a strip of video/scrim
         final int cap = cfg.orientation == Configuration.ORIENTATION_LANDSCAPE
                 ? Math.min(Math.round(windowW * 0.60f), capPortrait)
                 : capPortrait;
-        return dp(Math.min(preferred, cap));
+        return dp(Math.min(preferredDp, cap));
     }
 
     // ---- typography (sp; keeps user font-scale). Columns: PHONE / sw600 / sw720 / TV ----
@@ -145,7 +176,6 @@ final class UiMetrics {
     float textValue()       { return t(40, 44, 46, 48); }   // skip-offset readout
     float textAction()      { return t(15, 16, 16, 18); }   // reset pill
     float textPlaceholder() { return t(20, 21, 22, 22); }   // poster fallback
-    float textListNumber()  { return t(18, 19, 20, 20); }   // playlist row number
 
     /** True when a config change would not affect any adaptive size (skip the re-apply pass). */
     boolean sameClassAndWidth(UiMetrics other) {

--- a/app/src/main/java/com/brouken/player/UiMetrics.java
+++ b/app/src/main/java/com/brouken/player/UiMetrics.java
@@ -106,42 +106,26 @@ final class UiMetrics {
     int overscanV() { return tv() ? dp(16) : 0; }
     int pickerTopPadLand() { return Math.max(dp(16), overscanV()); }
 
-    /** Adaptive picker side-panel width in px: never covers a narrow phone, docks on tablet/TV. */
-    int pickerWidthPx(Configuration cfg) {
-        final int preferred;
-        switch (deviceClass) {
-            case TV:            preferred = 420; break;
-            case TABLET_LARGE:  preferred = 440; break;
-            case TABLET_MEDIUM: preferred = 400; break;
-            default:            preferred = 360; break;
-        }
-        return panelWidthPx(cfg, preferred);
-    }
-
     /**
-     * Width for a panel whose rows carry artwork and a filename, rather than a word.
+     * The width every player panel gets, whichever button opened it.
      *
-     * <p>The width above is sized for "1.5×" and "Off". A playlist row holds
-     * {@code The.Dark.Knight.2008.BDRemux.2160p.DV.HDR.mkv} — 46 characters — and at 360dp, once the
-     * poster and the paddings have taken their share, some 270dp reach the name: about thirty
-     * characters. That shortfall is why the row has two different ways of coping with a name that does
-     * not fit at all (see PlayerActivity.fitLongText), and no amount of coping invents room.
-     *
-     * <p>640dp is Material's own ceiling for a sheet ({@code material_bottom_sheet_max_width}), and the
-     * caps below still apply, so a phone in landscape lands at 523dp and a television at 576dp. A
-     * narrow phone in portrait is already at its cap and does not move.
+     * <p>One number, because a panel that changes size with the press that opened it reads as several
+     * different panels. It follows the edge the panel is docked to, and that edge follows the window:
+     * a sheet docked to the bottom of a compact-width window is that edge's width, capped at the 640dp
+     * Material states for a sheet; a sheet at the end edge leaves a strip of the picture beside it —
+     * never more than 60% of a window held sideways, and never closer than 56dp to the far edge of one
+     * held upright — capped at the same 640dp.
      */
-    int listWidthPx(Configuration cfg) {
-        return panelWidthPx(cfg, 640);
-    }
-
-    private int panelWidthPx(Configuration cfg, int preferredDp) {
+    int panelWidthPx(Configuration cfg) {
         final int windowW = cfg.screenWidthDp;
-        final int capPortrait = windowW - 56;                       // always leave a strip of video/scrim
+        if (windowW < 600) {
+            return dp(Math.min(windowW - 8, 640));
+        }
+        final int capPortrait = windowW - 56;
         final int cap = cfg.orientation == Configuration.ORIENTATION_LANDSCAPE
                 ? Math.min(Math.round(windowW * 0.60f), capPortrait)
                 : capPortrait;
-        return dp(Math.min(preferredDp, cap));
+        return dp(Math.min(640, cap));
     }
 
     // ---- typography (sp; keeps user font-scale). Columns: PHONE / sw600 / sw720 / TV ----

--- a/app/src/main/java/com/brouken/player/UiMetrics.java
+++ b/app/src/main/java/com/brouken/player/UiMetrics.java
@@ -135,16 +135,6 @@ final class UiMetrics {
         return panelWidthPx(cfg, 640);
     }
 
-    /**
-     * Width for a rail of frames docked to the bottom edge. The caps above leave a strip of video beside
-     * a panel because a panel at the end edge takes width from the picture; a rail has already given up
-     * the height instead, so the strip it would leave buys nothing and costs it a frame — measured, the
-     * 60% landscape cap shows 2.7 cards where 85% shows 3.9.
-     */
-    int railWidthPx(Configuration cfg) {
-        return dp(Math.round(cfg.screenWidthDp * 0.85f));
-    }
-
     private int panelWidthPx(Configuration cfg, int preferredDp) {
         final int windowW = cfg.screenWidthDp;
         final int capPortrait = windowW - 56;                       // always leave a strip of video/scrim

--- a/app/src/main/java/com/brouken/player/Utils.java
+++ b/app/src/main/java/com/brouken/player/Utils.java
@@ -579,7 +579,13 @@ class Utils {
         final boolean bottom = kind == Panel.RAIL
                 ? ui.deviceClass != UiMetrics.DeviceClass.TV
                 : kind != Panel.CONTROL && cfg.screenWidthDp < 600 && cfg.screenHeightDp >= 600;
-        final int panelWidth = kind == Panel.RAIL && bottom ? ui.railWidthPx(cfg)
+        // A sheet docked to an edge is that edge's width, not a card standing near it: full-bleed, and
+        // capped at the 640dp Material states for a bottom sheet, centred once the window is wider than
+        // that. The 8dp it stops short of the screen is the window's own, kept so the dialog never
+        // becomes a fullscreen one — see above; at 4dp a side it reads as the edge.
+        final int screenWidth = activity.getResources().getDisplayMetrics().widthPixels;
+        final int panelWidth = bottom
+                ? Math.min(screenWidth - dpToPx(8), dpToPx(640))
                 : kind == Panel.LIST || kind == Panel.RAIL ? ui.listWidthPx(cfg)
                 : ui.pickerWidthPx(cfg);
         // Material's own margin for a detached sheet is 16dp; 8dp here, because on a phone held sideways
@@ -641,15 +647,27 @@ class Utils {
         final FrameLayout host = new FrameLayout(activity);
         // A sheet must not reach the top edge; the panels hide the status bar, so without a floor here a
         // long playlist would grow into a full-screen dialog that arrived from the bottom.
-        host.setPadding(0, bottom ? Math.max(insetTop, dpToPx(56)) : insetTop, 0, insetBottom);
+        //
+        // At the bottom the inset goes inside the sheet instead of under it, which is what Material's own
+        // bottom sheet does (paddingBottomSystemWindowInsets): the surface reaches the screen's edge and
+        // the rows stop above the navigation bar. Held as a margin it left a strip of video between the
+        // sheet and the edge, and a sheet with a gap under it is a card again.
+        host.setPadding(0, bottom ? Math.max(insetTop, dpToPx(56)) : insetTop, 0,
+                bottom ? 0 : insetBottom);
+        if (bottom && insetBottom > 0) {
+            content.setPadding(content.getPaddingLeft(), content.getPaddingTop(),
+                    content.getPaddingRight(), content.getPaddingBottom() + insetBottom);
+        }
         final FrameLayout.LayoutParams lp = new FrameLayout.LayoutParams(
                 panelWidth, ViewGroup.LayoutParams.WRAP_CONTENT,
                 bottom ? Gravity.BOTTOM | Gravity.CENTER_HORIZONTAL
                         : Gravity.END | Gravity.CENTER_VERTICAL);
         if (bottom) {
-            // Even margins under CENTER_HORIZONTAL, and none at the bottom: the card sits on the edge,
-            // above whatever the navigation bar left of it (that inset is the host's padding).
-            lp.setMargins(hMargin, vMargin, hMargin, 0);
+            // No side margins at all, and none at the bottom: a docked sheet is the width it is given
+            // and sits on the edge, above whatever the navigation bar left of it (that inset is the
+            // host's padding). A margin here is what made the shape read as a card glued to the bottom
+            // rather than as a sheet — detached at the sides, square where it met the screen.
+            lp.setMargins(0, vMargin, 0, 0);
         } else {
             // Horizontal gravity is END, where a margin is a bound and the blocked edge can simply be
             // added.
@@ -665,10 +683,9 @@ class Utils {
         }
         // The window carries the card plus its margins, so the card itself keeps the width the panel was
         // designed at. Capped short of the screen so the window never becomes a fullscreen one.
-        final int screenW = activity.getResources().getDisplayMetrics().widthPixels;
         window.setLayout(
-                bottom ? screenW - dpToPx(8)
-                        : Math.min(screenW - dpToPx(8), panelWidth + 2 * hMargin + insetEnd),
+                bottom ? screenWidth - dpToPx(8)
+                        : Math.min(screenWidth - dpToPx(8), panelWidth + 2 * hMargin + insetEnd),
                 ViewGroup.LayoutParams.MATCH_PARENT);
         window.setGravity(bottom ? Gravity.BOTTOM | Gravity.CENTER_HORIZONTAL : Gravity.END);
         window.setBackgroundDrawable(new ColorDrawable(Color.TRANSPARENT));

--- a/app/src/main/java/com/brouken/player/Utils.java
+++ b/app/src/main/java/com/brouken/player/Utils.java
@@ -17,9 +17,11 @@ import android.content.pm.ApplicationInfo;
 import android.content.pm.PackageManager;
 import android.content.pm.ResolveInfo;
 import android.content.res.Configuration;
+import android.content.res.ColorStateList;
 import android.content.res.Resources;
 import android.database.Cursor;
 import android.graphics.drawable.ColorDrawable;
+import android.graphics.Color;
 import android.media.AudioManager;
 import android.media.MediaExtractor;
 import android.media.MediaFormat;
@@ -62,6 +64,9 @@ import androidx.media3.common.util.Util;
 
 import com.google.android.material.textfield.TextInputLayout;
 import androidx.core.content.ContextCompat;
+
+import com.google.android.material.shape.MaterialShapeDrawable;
+import com.google.android.material.shape.ShapeAppearanceModel;
 
 import com.obsez.android.lib.filechooser.ChooserDialog;
 import com.sigpwned.chardet4j.Chardet;
@@ -507,70 +512,71 @@ class Utils {
     }
 
     /**
-     * Pads a side-panel's content for the system bars, the way every picker in this app wants it.
+     * The one window recipe every end-docked player panel uses: a Material 3 detached side sheet — a card
+     * inset from every edge with 16dp corners all round, over a dimmed picture, dismissible by a tap
+     * outside.
      *
-     * The status bar is hidden while a picker is open (applyPickerBars), so its height is only breathing
-     * room — but breathing room the content genuinely needs, since the window spans the full height and the
-     * camera cutout lives up there. Hence the height is read IGNORING VISIBILITY: {@code getInsets()} reports
-     * zero for a bar that is currently hidden, and a panel opened from another panel (the skip-offset and
-     * sleep-timer panels come off a side menu, which has already turned the bars off) would then get no top
-     * padding at all and put its header under the cutout. The playlist panel only ever escaped this by being
-     * opened straight off the controls, while the bars were still up.
+     * <p>Not {@code SideSheetDialog}, deliberately. That component is a fullscreen window, and a fullscreen
+     * dialog window makes OxygenOS treat the panel as immersive and apply its two-swipe back-gesture guard,
+     * where a plain window closes on one back. The scrim comes from the window's own dim instead.
      *
-     * In portrait the status-bar height reads well; landscape is much shorter (and its status-bar inset can
-     * include the camera cutout), where that same height looks oversized — use a compact fixed inset there.
-     * Pad the bottom for the nav/gesture bar. dp keeps it density/resolution-adaptive.
-     *
-     * @param insetSource any attached view, used to read the window insets
-     * @param target      the view whose padding is set (horizontal padding comes from the caller's own grid)
-     */
-    /**
-     * The one window recipe every end-docked player panel uses: docked to the end edge, one device-classed
-     * width, the chrome surface behind it, and dismissible by a tap outside.
-     *
-     * <p>Deliberately NOT fullscreen/edge-to-edge: a fullscreen dialog window makes OxygenOS treat the panel
-     * as immersive and apply its two-swipe back-gesture guard, where a plain window closes on one back.
+     * <p>The system bars are a margin here, not padding. A flat fill could run under the status bar
+     * unnoticed; a card with a visible corner cannot, so what used to inset the content now insets the
+     * card, and the content keeps only the padding its own design asks for. The heights are read
+     * IGNORING VISIBILITY: a panel opened from another panel arrives with the bars already hidden, and
+     * {@code getInsets()} would report zero and put the card's corner under the cutout.
      */
     public static void pickerWindow(final Activity activity, final UiMetrics ui, final Dialog dialog,
                                     final View content) {
-        dialog.setContentView(content);
+        // 16dp is Material's own margin for a detached sheet. A television wants its overscan instead —
+        // the card has an edge to lose, where the full-bleed fill before it had none.
+        final int hMargin = Math.max(dpToPx(16), ui.overscanH());
+        final int vMargin = Math.max(dpToPx(16), ui.overscanV());
+        int barTop = 0;
+        int barBottom = 0;
+        final WindowInsets insets = activity.getWindow().getDecorView().getRootWindowInsets();
+        if (insets != null) {
+            if (Build.VERSION.SDK_INT >= 30) {
+                barTop = insets.getInsetsIgnoringVisibility(WindowInsets.Type.statusBars()).top;
+                barBottom = insets.getInsetsIgnoringVisibility(WindowInsets.Type.navigationBars()).bottom;
+            } else {
+                barTop = insets.getSystemWindowInsetTop();
+                barBottom = insets.getSystemWindowInsetBottom();
+            }
+        }
+
+        final MaterialShapeDrawable card = new MaterialShapeDrawable(
+                ShapeAppearanceModel.builder().setAllCornerSizes(dpToPx(16)).build());
+        card.setFillColor(ColorStateList.valueOf(
+                ContextCompat.getColor(activity, R.color.sheet_surface)));
+        content.setBackground(card);
+        content.setClipToOutline(true); // so a full-bleed row's ripple stops at the rounded end
+
+        final FrameLayout host = new FrameLayout(activity);
+        final FrameLayout.LayoutParams lp = new FrameLayout.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT,
+                Gravity.CENTER_VERTICAL);
+        lp.setMargins(hMargin, barTop + vMargin, hMargin, barBottom + vMargin);
+        host.addView(content, lp);
+
+        dialog.setContentView(host);
         dialog.setCanceledOnTouchOutside(true);
         final Window window = dialog.getWindow();
         if (window == null) {
             return;
         }
-        window.setLayout(ui.pickerWidthPx(activity.getResources().getConfiguration()),
+        // The window carries the card plus its margins, so the card itself keeps the width the panel was
+        // designed at. Capped short of the screen so the window never becomes a fullscreen one.
+        final int screenW = activity.getResources().getDisplayMetrics().widthPixels;
+        window.setLayout(
+                Math.min(screenW - dpToPx(8),
+                        ui.pickerWidthPx(activity.getResources().getConfiguration()) + 2 * hMargin),
                 ViewGroup.LayoutParams.MATCH_PARENT);
         window.setGravity(Gravity.END);
-        window.setBackgroundDrawable(
-                new ColorDrawable(ContextCompat.getColor(activity, R.color.chrome_surface)));
-    }
-
-    public static void padForPickerInsets(final Activity activity, final UiMetrics ui, final View insetSource,
-                                         final View target, final int hPad,
-                                         final int extraTopPx, final int extraBottomPx) {
-        final boolean landscape = activity.getResources().getConfiguration().orientation
-                == Configuration.ORIENTATION_LANDSCAPE;
-        int padTop = landscape ? ui.pickerTopPadLand() : ui.dp(24);
-        int padBottom = ui.overscanV();
-        final WindowInsets rootInsets = insetSource.getRootWindowInsets();
-        if (rootInsets != null) {
-            if (Build.VERSION.SDK_INT >= 30) {
-                if (!landscape) {
-                    padTop = rootInsets.getInsetsIgnoringVisibility(WindowInsets.Type.statusBars()).top;
-                }
-                padBottom = rootInsets.getInsetsIgnoringVisibility(
-                        WindowInsets.Type.navigationBars()).bottom + ui.overscanV();
-            } else {
-                // No ignoring-visibility variant before 30, and the legacy inset drops to 0 just the same
-                // once the bars are off — so the floor above stands in for it.
-                if (!landscape) {
-                    padTop = Math.max(padTop, rootInsets.getSystemWindowInsetTop());
-                }
-                padBottom = Math.max(padBottom, rootInsets.getSystemWindowInsetBottom() + ui.overscanV());
-            }
-        }
-        target.setPadding(hPad, padTop + extraTopPx, hPad, padBottom + extraBottomPx);
+        window.setBackgroundDrawable(new ColorDrawable(Color.TRANSPARENT));
+        // The picture behind a modal sheet steps back rather than competing with it.
+        window.addFlags(WindowManager.LayoutParams.FLAG_DIM_BEHIND);
+        window.setDimAmount(0.4f);
     }
 
     public static String formatMilis(long time) {

--- a/app/src/main/java/com/brouken/player/Utils.java
+++ b/app/src/main/java/com/brouken/player/Utils.java
@@ -5,6 +5,7 @@ import static android.content.Context.UI_MODE_SERVICE;
 import android.Manifest;
 import android.annotation.SuppressLint;
 import android.app.Activity;
+import android.app.Dialog;
 import android.app.UiModeManager;
 import android.content.ComponentName;
 import android.content.ContentResolver;
@@ -18,6 +19,7 @@ import android.content.pm.ResolveInfo;
 import android.content.res.Configuration;
 import android.content.res.Resources;
 import android.database.Cursor;
+import android.graphics.drawable.ColorDrawable;
 import android.media.AudioManager;
 import android.media.MediaExtractor;
 import android.media.MediaFormat;
@@ -31,6 +33,7 @@ import android.os.storage.StorageVolume;
 import android.provider.DocumentsContract;
 import android.provider.OpenableColumns;
 import android.provider.Settings;
+import android.view.Gravity;
 import android.os.SystemClock;
 import android.util.Log;
 import android.util.Rational;
@@ -58,6 +61,8 @@ import androidx.media3.common.util.UnstableApi;
 import androidx.media3.common.util.Util;
 
 import com.google.android.material.textfield.TextInputLayout;
+import androidx.core.content.ContextCompat;
+
 import com.obsez.android.lib.filechooser.ChooserDialog;
 import com.sigpwned.chardet4j.Chardet;
 import com.sigpwned.chardet4j.io.DecodedInputStreamReader;
@@ -519,6 +524,28 @@ class Utils {
      * @param insetSource any attached view, used to read the window insets
      * @param target      the view whose padding is set (horizontal padding comes from the caller's own grid)
      */
+    /**
+     * The one window recipe every end-docked player panel uses: docked to the end edge, one device-classed
+     * width, the chrome surface behind it, and dismissible by a tap outside.
+     *
+     * <p>Deliberately NOT fullscreen/edge-to-edge: a fullscreen dialog window makes OxygenOS treat the panel
+     * as immersive and apply its two-swipe back-gesture guard, where a plain window closes on one back.
+     */
+    public static void pickerWindow(final Activity activity, final UiMetrics ui, final Dialog dialog,
+                                    final View content) {
+        dialog.setContentView(content);
+        dialog.setCanceledOnTouchOutside(true);
+        final Window window = dialog.getWindow();
+        if (window == null) {
+            return;
+        }
+        window.setLayout(ui.pickerWidthPx(activity.getResources().getConfiguration()),
+                ViewGroup.LayoutParams.MATCH_PARENT);
+        window.setGravity(Gravity.END);
+        window.setBackgroundDrawable(
+                new ColorDrawable(ContextCompat.getColor(activity, R.color.chrome_surface)));
+    }
+
     public static void padForPickerInsets(final Activity activity, final UiMetrics ui, final View insetSource,
                                          final View target, final int hPad,
                                          final int extraTopPx, final int extraBottomPx) {

--- a/app/src/main/java/com/brouken/player/Utils.java
+++ b/app/src/main/java/com/brouken/player/Utils.java
@@ -529,22 +529,36 @@ class Utils {
      */
     public static void pickerWindow(final Activity activity, final UiMetrics ui, final Dialog dialog,
                                     final View content) {
+        final Configuration cfg = activity.getResources().getConfiguration();
         // Material's own margin for a detached sheet is 16dp; 8dp here, because on a phone held sideways
         // the panel is what the viewer came for and the strip of video beside it is not worth the room.
         // A television wants its overscan instead — the card has an edge to lose, where the full-bleed
         // fill before it had none.
         final int hMargin = Math.max(dpToPx(8), ui.overscanH());
         final int vMargin = Math.max(dpToPx(8), ui.overscanV());
-        int barTop = 0;
-        int barBottom = 0;
+        // What actually blocks pixels while a panel is open, and nothing more. applyPickerBars hides the
+        // status bar and shows the navigation bar, so reserving room for the status bar costs the card
+        // 24dp of height for a bar that is not on screen — which is what clipped the last row of a long
+        // menu while a fifth of the window stood empty. The cutout is there whether or not any bar is,
+        // and the navigation inset is read ignoring visibility because a panel opened from another panel
+        // arrives with the bars already turned off. Per edge, because a cutout on the left of a
+        // sideways phone says nothing about the right edge this panel is docked to.
+        int insetTop = 0;
+        int insetBottom = 0;
+        int insetEnd = 0;
         final WindowInsets insets = activity.getWindow().getDecorView().getRootWindowInsets();
         if (insets != null) {
             if (Build.VERSION.SDK_INT >= 30) {
-                barTop = insets.getInsetsIgnoringVisibility(WindowInsets.Type.statusBars()).top;
-                barBottom = insets.getInsetsIgnoringVisibility(WindowInsets.Type.navigationBars()).bottom;
+                final android.graphics.Insets blocked = android.graphics.Insets.max(
+                        insets.getInsetsIgnoringVisibility(WindowInsets.Type.displayCutout()),
+                        insets.getInsetsIgnoringVisibility(WindowInsets.Type.navigationBars()));
+                insetTop = blocked.top;
+                insetBottom = blocked.bottom;
+                insetEnd = cfg.getLayoutDirection()
+                        == View.LAYOUT_DIRECTION_RTL ? blocked.left : blocked.right;
             } else {
-                barTop = insets.getSystemWindowInsetTop();
-                barBottom = insets.getSystemWindowInsetBottom();
+                // No per-type insets before 30, and no way to ask about a hidden bar either.
+                insetBottom = insets.getSystemWindowInsetBottom();
             }
         }
 
@@ -557,11 +571,16 @@ class Utils {
         content.setBackground(card);
         content.setClipToOutline(true); // so a full-bleed row's ripple stops at the rounded end
 
+        // The blocked edges are the host's padding, not the card's margin: FrameLayout treats a margin
+        // under CENTER_VERTICAL as a shift rather than a bound, so an uneven pair walks the card off the
+        // top of the screen. Padding bounds it, and the margin left on the card is even.
         final FrameLayout host = new FrameLayout(activity);
+        host.setPadding(0, insetTop, 0, insetBottom);
         final FrameLayout.LayoutParams lp = new FrameLayout.LayoutParams(
-                ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT,
-                Gravity.CENTER_VERTICAL);
-        lp.setMargins(hMargin, barTop + vMargin, hMargin, barBottom + vMargin);
+                ui.pickerWidthPx(cfg), ViewGroup.LayoutParams.WRAP_CONTENT,
+                Gravity.END | Gravity.CENTER_VERTICAL);
+        // Horizontal gravity is END, where a margin is a bound and the blocked edge can simply be added.
+        lp.setMargins(hMargin, vMargin, hMargin + insetEnd, vMargin);
         host.addView(content, lp);
 
         dialog.setContentView(host);
@@ -574,8 +593,7 @@ class Utils {
         // designed at. Capped short of the screen so the window never becomes a fullscreen one.
         final int screenW = activity.getResources().getDisplayMetrics().widthPixels;
         window.setLayout(
-                Math.min(screenW - dpToPx(8),
-                        ui.pickerWidthPx(activity.getResources().getConfiguration()) + 2 * hMargin),
+                Math.min(screenW - dpToPx(8), ui.pickerWidthPx(cfg) + 2 * hMargin + insetEnd),
                 ViewGroup.LayoutParams.MATCH_PARENT);
         window.setGravity(Gravity.END);
         window.setBackgroundDrawable(new ColorDrawable(Color.TRANSPARENT));

--- a/app/src/main/java/com/brouken/player/Utils.java
+++ b/app/src/main/java/com/brouken/player/Utils.java
@@ -21,6 +21,9 @@ import android.content.res.ColorStateList;
 import android.content.res.Resources;
 import android.database.Cursor;
 import android.graphics.drawable.ColorDrawable;
+import android.graphics.drawable.Drawable;
+import android.graphics.drawable.GradientDrawable;
+import android.graphics.drawable.RippleDrawable;
 import android.graphics.Color;
 import android.media.AudioManager;
 import android.media.MediaExtractor;
@@ -600,6 +603,30 @@ class Utils {
         // The picture behind a modal sheet steps back rather than competing with it.
         window.addFlags(WindowManager.LayoutParams.FLAG_DIM_BEHIND);
         window.setDimAmount(0.4f);
+    }
+
+    /**
+     * The background every row inside a player panel wears: a rounded fill, a ripple clipped to it, and
+     * the D-pad focus ring.
+     *
+     * <p>The ring is the whole point. A remote used to be shown focus as a white wash, and over a row
+     * lit with the accent the wash took the accent with it — measured 2.21:1 for the label on a focused
+     * current row, against the 4.5 it wants. An edge says the same thing and destroys nothing.
+     *
+     * @param fill the row's own colour, or {@link Color#TRANSPARENT} for a row that is not the current one
+     */
+    public static Drawable pickerRow(final Context ctx, final int fill) {
+        final int corner = dpToPx(8);
+        final GradientDrawable content = new GradientDrawable();
+        content.setCornerRadius(corner);
+        content.setColor(fill);
+        content.setStroke(dpToPx(2), ContextCompat.getColorStateList(ctx, R.color.focus_ring));
+        final GradientDrawable mask = new GradientDrawable();
+        mask.setCornerRadius(corner);
+        mask.setColor(Color.WHITE);
+        return new RippleDrawable(ColorStateList.valueOf(MaterialColors.getColor(
+                ctx, R.attr.colorControlHighlight, ContextCompat.getColor(ctx, R.color.ripple_chrome))),
+                content, mask);
     }
 
     public static String formatMilis(long time) {

--- a/app/src/main/java/com/brouken/player/Utils.java
+++ b/app/src/main/java/com/brouken/player/Utils.java
@@ -68,6 +68,7 @@ import androidx.media3.common.util.Util;
 import com.google.android.material.textfield.TextInputLayout;
 import androidx.core.content.ContextCompat;
 
+import com.google.android.material.button.MaterialButton;
 import com.google.android.material.color.MaterialColors;
 import com.google.android.material.shape.MaterialShapeDrawable;
 import com.google.android.material.shape.ShapeAppearanceModel;
@@ -620,13 +621,51 @@ class Utils {
         final GradientDrawable content = new GradientDrawable();
         content.setCornerRadius(corner);
         content.setColor(fill);
-        content.setStroke(dpToPx(2), ContextCompat.getColorStateList(ctx, R.color.focus_ring));
+        content.setStroke(ctx.getResources().getDimensionPixelSize(R.dimen.focus_ring_width),
+                ContextCompat.getColorStateList(ctx, R.color.focus_ring));
         final GradientDrawable mask = new GradientDrawable();
         mask.setCornerRadius(corner);
         mask.setColor(Color.WHITE);
-        return new RippleDrawable(ColorStateList.valueOf(MaterialColors.getColor(
-                ctx, R.attr.colorControlHighlight, ContextCompat.getColor(ctx, R.color.ripple_chrome))),
+        // Press only: a RippleDrawable washes on focus as well, and over the fill of the current row
+        // that wash lifted the accent to #DB5F54 from #D6493C — the very thing the ring exists to
+        // avoid. The edge says "here" and leaves the colour underneath it alone.
+        final int press = MaterialColors.getColor(ctx, R.attr.colorControlHighlight,
+                ContextCompat.getColor(ctx, R.color.ripple_chrome));
+        return new RippleDrawable(new ColorStateList(
+                new int[][]{{android.R.attr.state_focused, -android.R.attr.state_pressed}, {}},
+                new int[]{Color.TRANSPARENT, press}),
                 content, mask);
+    }
+
+    /**
+     * D-pad focus for an outlined Material button: its own border widens to the focus ring's width and
+     * goes white, and the button draws over its neighbours while it holds it.
+     *
+     * <p>Width, because colour alone is the weakest focus event in the app. Where a picker row grows an
+     * edge out of nothing — measured 16.30:1 between the same pixels focused and not — an outlined
+     * button already has an edge, so focus only recoloured it: grey to white, 2.76:1, under the 3:1 a
+     * non-text indicator wants. An edge that thickens as well is a change in shape, which the eye
+     * catches without being aimed at it.
+     *
+     * <p>Z, because in a segmented control the neighbours' borders are drawn over this one's: the group
+     * collapses adjacent strokes into shared dividers drawn by whoever comes later, so a focused middle
+     * segment was ringed along the top and bottom and left grey down both sides. Lifting it puts it last
+     * in the draw order without moving it in the row, which is what the group already does for the
+     * segment that is checked.
+     */
+    static void focusRing(final MaterialButton button) {
+        final int rest = button.getStrokeWidth();
+        final int ring = Math.max(rest,
+                button.getResources().getDimensionPixelSize(R.dimen.focus_ring_width));
+        // The edge is the whole signal: Material's own focus state layer goes, or a focused segment
+        // that is also the chosen one gets its accent painted over in the dark colour of the text on
+        // it. The press ripple stays exactly as it was.
+        button.setRippleColor(ContextCompat.getColorStateList(button.getContext(),
+                R.color.ripple_button));
+        button.setOnFocusChangeListener((v, focused) -> {
+            button.setStrokeWidth(focused ? ring : rest);
+            button.setTranslationZ(focused ? 1f : 0f);
+        });
     }
 
     public static String formatMilis(long time) {

--- a/app/src/main/java/com/brouken/player/Utils.java
+++ b/app/src/main/java/com/brouken/player/Utils.java
@@ -516,18 +516,6 @@ class Utils {
             return new Rational(format.width, format.height);
     }
 
-    /** What a panel holds, which decides how wide it gets and which edge it arrives from. */
-    public enum Panel {
-        /** A word per row: speed, sleep, audio, subtitles, quality, the overflow menu. */
-        OPTIONS,
-        /** Rows carrying artwork and a filename, which need the width Material allows a sheet. */
-        LIST,
-        /** The same rows turned on their side: one row of frames that scrolls sideways. */
-        RAIL,
-        /** A control layout of fixed proportions — a slider, a keypad — which needs its height. */
-        CONTROL
-    }
-
     /**
      * The one window recipe every player panel uses: a Material 3 card over a dimmed picture,
      * dismissible by a tap outside. Docked to the end edge and centred vertically, or docked to the
@@ -541,20 +529,22 @@ class Utils {
      * swipe-to-dismiss: it is a plain window, and a handle that promised a drag it cannot perform would
      * be worse than no handle. It closes on a tap outside and on back, like every other panel.
      *
-     * <p>The anchor follows the window, which is what Material's size classes ask for: the bottom edge
-     * belongs to a compact width that has the height to spare — in practice a phone held upright, where
-     * the bottom is where the thumb is and where a vertically centred card puts its first row halfway up
-     * a tall screen. Everywhere else the panel stays at the end edge. A phone or tablet held sideways is
-     * a compact-height window, where a sheet from the bottom has less room than this card has now — the
-     * skip panel alone stands 388dp tall on a television and 294dp on a phone in landscape. A tablet
-     * upright is past the compact width, so it keeps the side dock its width was chosen for. And a
-     * television has no bottom sheet in its own component set, an unreserved overscan strip along that
-     * edge, and every piece of its chrome there already.
+     * <p>Every panel in the player is this one shape, this one size and this one place, whichever button
+     * opened it: a panel that arrives from a different edge or at a different width depending on the
+     * press reads as several different panels, and the viewer has to learn each of them. What varies is
+     * the window, not the content. A compact-width window — a phone held upright — takes the bottom
+     * edge, which is what Material's size classes ask for on that class of window and where the thumb
+     * already is. Everything wider takes the end edge: a phone or tablet held sideways is a
+     * compact-height window, where a sheet from the bottom has less room than this card has and the
+     * strip of picture beside it is worth keeping, and a television has no bottom sheet in its own
+     * component set, an unreserved overscan strip along that edge, and every piece of its chrome there
+     * already.
      *
-     * <p>{@link Panel#CONTROL} never takes the bottom edge whatever the window says. The subtitle
-     * offset panel is the reason: it retimes a line that is drawn at the bottom of the frame, live,
-     * while playback runs. A panel that covers the bottom of the picture deletes the very thing the
-     * viewer is reading to know whether the nudge was right.
+     * <p>The one thing that follows from the edge rather than being chosen is the width, and the shape:
+     * a sheet docked to the bottom is that edge's width, capped at the 640dp Material states for a
+     * sheet, with the two corners against the edge square and the navigation bar's inset carried inside
+     * it; a sheet at the end edge is inset from every side with 16dp corners all round. See
+     * {@link UiMetrics#panelWidthPx}.
      *
      * <p>The system bars are a margin here, not padding. A flat fill could run under the status bar
      * unnoticed; a card with a visible corner cannot, so what used to inset the content now insets the
@@ -563,31 +553,18 @@ class Utils {
      * {@code getInsets()} would report zero and put the card's corner under the cutout.
      */
     public static void pickerWindow(final Activity activity, final UiMetrics ui, final Dialog dialog,
-                                    final View content, final Panel kind) {
+                                    final View content) {
         final Configuration cfg = activity.getResources().getConfiguration();
-        // What decides the edge is the axis the content scrolls on, and the window only decides it for
-        // content that scrolls the ordinary way. A RAIL scrolls sideways: it wants width and has already
-        // given up height, and the bottom edge is the only shape that supplies width in a window a
-        // sideways phone's height — measured, a rail stands at 55% of that window where the same panel
-        // as a list stands at 84%, which is not a sheet any more. Everything that scrolls downward keeps
-        // the end edge unless the window is a phone held upright: Material's compact-width class is
-        // below 600dp, and 600 on both edges here means a phone held sideways — Expanded width over
-        // Compact height, the worst window there is for a sheet from the bottom — is never caught, and
-        // neither is a tablet, whose width is past compact either way up. A television never docks to the
-        // bottom: it has no bottom sheet in its own component set, its chrome is all at that edge, and
-        // the overscan strip there is the one this app under-reserves.
-        final boolean bottom = kind == Panel.RAIL
-                ? ui.deviceClass != UiMetrics.DeviceClass.TV
-                : kind != Panel.CONTROL && cfg.screenWidthDp < 600 && cfg.screenHeightDp >= 600;
-        // A sheet docked to an edge is that edge's width, not a card standing near it: full-bleed, and
-        // capped at the 640dp Material states for a bottom sheet, centred once the window is wider than
-        // that. The 8dp it stops short of the screen is the window's own, kept so the dialog never
-        // becomes a fullscreen one — see above; at 4dp a side it reads as the edge.
+        // One edge for every panel, and the window is what picks it — never which button was pressed:
+        // a panel that arrives from a different edge depending on what opened it reads as several
+        // different panels. A compact-width window, which is a phone held upright, gets the bottom edge,
+        // where the thumb is and where Material puts a sheet on that class of window. Everything wider
+        // gets the end edge: there the strip of picture beside the panel is worth having, and a remote's
+        // focus travels along one side of the screen instead of across the bottom of it.
+        final boolean bottom = cfg.screenWidthDp < 600;
+        // And one width, which follows the edge rather than the content — see UiMetrics.panelWidthPx.
         final int screenWidth = activity.getResources().getDisplayMetrics().widthPixels;
-        final int panelWidth = bottom
-                ? Math.min(screenWidth - dpToPx(8), dpToPx(640))
-                : kind == Panel.LIST || kind == Panel.RAIL ? ui.listWidthPx(cfg)
-                : ui.pickerWidthPx(cfg);
+        final int panelWidth = ui.panelWidthPx(cfg);
         // Material's own margin for a detached sheet is 16dp; 8dp here, because on a phone held sideways
         // the panel is what the viewer came for and the strip of video beside it is not worth the room.
         // A television wants its overscan instead — the card has an edge to lose, where the full-bleed

--- a/app/src/main/java/com/brouken/player/Utils.java
+++ b/app/src/main/java/com/brouken/player/Utils.java
@@ -65,6 +65,7 @@ import androidx.media3.common.util.Util;
 import com.google.android.material.textfield.TextInputLayout;
 import androidx.core.content.ContextCompat;
 
+import com.google.android.material.color.MaterialColors;
 import com.google.android.material.shape.MaterialShapeDrawable;
 import com.google.android.material.shape.ShapeAppearanceModel;
 
@@ -528,10 +529,12 @@ class Utils {
      */
     public static void pickerWindow(final Activity activity, final UiMetrics ui, final Dialog dialog,
                                     final View content) {
-        // 16dp is Material's own margin for a detached sheet. A television wants its overscan instead —
-        // the card has an edge to lose, where the full-bleed fill before it had none.
-        final int hMargin = Math.max(dpToPx(16), ui.overscanH());
-        final int vMargin = Math.max(dpToPx(16), ui.overscanV());
+        // Material's own margin for a detached sheet is 16dp; 8dp here, because on a phone held sideways
+        // the panel is what the viewer came for and the strip of video beside it is not worth the room.
+        // A television wants its overscan instead — the card has an edge to lose, where the full-bleed
+        // fill before it had none.
+        final int hMargin = Math.max(dpToPx(8), ui.overscanH());
+        final int vMargin = Math.max(dpToPx(8), ui.overscanV());
         int barTop = 0;
         int barBottom = 0;
         final WindowInsets insets = activity.getWindow().getDecorView().getRootWindowInsets();
@@ -547,8 +550,10 @@ class Utils {
 
         final MaterialShapeDrawable card = new MaterialShapeDrawable(
                 ShapeAppearanceModel.builder().setAllCornerSizes(dpToPx(16)).build());
-        card.setFillColor(ColorStateList.valueOf(
-                ContextCompat.getColor(activity, R.color.sheet_surface)));
+        // From the content's own theme, not the player's: the panels follow the appearance choice, so
+        // the card is light when the app is light and black under AMOLED.
+        card.setFillColor(ColorStateList.valueOf(MaterialColors.getColor(
+                content, R.attr.colorSurface, ContextCompat.getColor(activity, R.color.sheet_surface))));
         content.setBackground(card);
         content.setClipToOutline(true); // so a full-bleed row's ripple stops at the rounded end
 
@@ -785,9 +790,15 @@ class Utils {
         }
         // Wrapped straight around whatever it was handed — an Activity, in every real call — because a
         // ContextThemeWrapper keeps its base's window token and a dialog needs one to exist at all.
-        return new android.view.ContextThemeWrapper(base,
+        final android.view.ContextThemeWrapper themed = new android.view.ContextThemeWrapper(base,
                 Prefs.THEME_LIGHT.equals(mode) ? R.style.Theme_Dialogs_Light
                         : R.style.Theme_Dialogs_Dark);
+        // AMOLED is part of the same appearance choice, and a panel is the largest dark surface the app
+        // ever puts on screen — the one place the option is worth the most.
+        if (!Prefs.THEME_LIGHT.equals(mode) && Prefs.isAmoledBlack(base)) {
+            themed.getTheme().applyStyle(R.style.ThemeOverlay_JustPlus_Amoled, true);
+        }
+        return themed;
     }
 
     /**

--- a/app/src/main/java/com/brouken/player/Utils.java
+++ b/app/src/main/java/com/brouken/player/Utils.java
@@ -516,14 +516,45 @@ class Utils {
             return new Rational(format.width, format.height);
     }
 
+    /** What a panel holds, which decides how wide it gets and which edge it arrives from. */
+    public enum Panel {
+        /** A word per row: speed, sleep, audio, subtitles, quality, the overflow menu. */
+        OPTIONS,
+        /** Rows carrying artwork and a filename, which need the width Material allows a sheet. */
+        LIST,
+        /** The same rows turned on their side: one row of frames that scrolls sideways. */
+        RAIL,
+        /** A control layout of fixed proportions — a slider, a keypad — which needs its height. */
+        CONTROL
+    }
+
     /**
-     * The one window recipe every end-docked player panel uses: a Material 3 detached side sheet — a card
-     * inset from every edge with 16dp corners all round, over a dimmed picture, dismissible by a tap
-     * outside.
+     * The one window recipe every player panel uses: a Material 3 card over a dimmed picture,
+     * dismissible by a tap outside. Docked to the end edge and centred vertically, or docked to the
+     * bottom edge on a tall narrow window — see the anchor rule below.
      *
-     * <p>Not {@code SideSheetDialog}, deliberately. That component is a fullscreen window, and a fullscreen
-     * dialog window makes OxygenOS treat the panel as immersive and apply its two-swipe back-gesture guard,
-     * where a plain window closes on one back. The scrim comes from the window's own dim instead.
+     * <p>Not {@code SideSheetDialog} or {@code BottomSheetDialog}, deliberately. Both are fullscreen
+     * windows, and a fullscreen dialog window makes OxygenOS treat the panel as immersive and apply its
+     * two-swipe back-gesture guard, where a plain window closes on one back. The scrim comes from the
+     * window's own dim instead, and the window stays a hair narrower than the screen so it never becomes
+     * a fullscreen one. That is also why a bottom-docked panel here has no drag handle and no
+     * swipe-to-dismiss: it is a plain window, and a handle that promised a drag it cannot perform would
+     * be worse than no handle. It closes on a tap outside and on back, like every other panel.
+     *
+     * <p>The anchor follows the window, which is what Material's size classes ask for: the bottom edge
+     * belongs to a compact width that has the height to spare — in practice a phone held upright, where
+     * the bottom is where the thumb is and where a vertically centred card puts its first row halfway up
+     * a tall screen. Everywhere else the panel stays at the end edge. A phone or tablet held sideways is
+     * a compact-height window, where a sheet from the bottom has less room than this card has now — the
+     * skip panel alone stands 388dp tall on a television and 294dp on a phone in landscape. A tablet
+     * upright is past the compact width, so it keeps the side dock its width was chosen for. And a
+     * television has no bottom sheet in its own component set, an unreserved overscan strip along that
+     * edge, and every piece of its chrome there already.
+     *
+     * <p>{@link Panel#CONTROL} never takes the bottom edge whatever the window says. The subtitle
+     * offset panel is the reason: it retimes a line that is drawn at the bottom of the frame, live,
+     * while playback runs. A panel that covers the bottom of the picture deletes the very thing the
+     * viewer is reading to know whether the nudge was right.
      *
      * <p>The system bars are a margin here, not padding. A flat fill could run under the status bar
      * unnoticed; a card with a visible corner cannot, so what used to inset the content now insets the
@@ -532,8 +563,25 @@ class Utils {
      * {@code getInsets()} would report zero and put the card's corner under the cutout.
      */
     public static void pickerWindow(final Activity activity, final UiMetrics ui, final Dialog dialog,
-                                    final View content) {
+                                    final View content, final Panel kind) {
         final Configuration cfg = activity.getResources().getConfiguration();
+        // What decides the edge is the axis the content scrolls on, and the window only decides it for
+        // content that scrolls the ordinary way. A RAIL scrolls sideways: it wants width and has already
+        // given up height, and the bottom edge is the only shape that supplies width in a window a
+        // sideways phone's height — measured, a rail stands at 55% of that window where the same panel
+        // as a list stands at 84%, which is not a sheet any more. Everything that scrolls downward keeps
+        // the end edge unless the window is a phone held upright: Material's compact-width class is
+        // below 600dp, and 600 on both edges here means a phone held sideways — Expanded width over
+        // Compact height, the worst window there is for a sheet from the bottom — is never caught, and
+        // neither is a tablet, whose width is past compact either way up. A television never docks to the
+        // bottom: it has no bottom sheet in its own component set, its chrome is all at that edge, and
+        // the overscan strip there is the one this app under-reserves.
+        final boolean bottom = kind == Panel.RAIL
+                ? ui.deviceClass != UiMetrics.DeviceClass.TV
+                : kind != Panel.CONTROL && cfg.screenWidthDp < 600 && cfg.screenHeightDp >= 600;
+        final int panelWidth = kind == Panel.RAIL && bottom ? ui.railWidthPx(cfg)
+                : kind == Panel.LIST || kind == Panel.RAIL ? ui.listWidthPx(cfg)
+                : ui.pickerWidthPx(cfg);
         // Material's own margin for a detached sheet is 16dp; 8dp here, because on a phone held sideways
         // the panel is what the viewer came for and the strip of video beside it is not worth the room.
         // A television wants its overscan instead — the card has an edge to lose, where the full-bleed
@@ -566,8 +614,20 @@ class Utils {
             }
         }
 
-        final MaterialShapeDrawable card = new MaterialShapeDrawable(
-                ShapeAppearanceModel.builder().setAllCornerSizes(dpToPx(16)).build());
+        // Docked at the bottom means docked: the two corners against the edge go square, the way
+        // Material draws a bottom sheet, so the card reads as attached rather than as a card that
+        // happens to be low. And it takes the radius Material gives that shape — 28dp, its extra-large
+        // corner — where a sheet at the end edge takes the large one, 16dp. Two shapes, two numbers,
+        // both Material's own.
+        final int corner = dpToPx(bottom ? 28 : 16);
+        final ShapeAppearanceModel.Builder shape = ShapeAppearanceModel.builder();
+        if (bottom) {
+            shape.setTopLeftCornerSize(corner).setTopRightCornerSize(corner)
+                    .setBottomLeftCornerSize(0).setBottomRightCornerSize(0);
+        } else {
+            shape.setAllCornerSizes(corner);
+        }
+        final MaterialShapeDrawable card = new MaterialShapeDrawable(shape.build());
         // From the content's own theme, not the player's: the panels follow the appearance choice, so
         // the card is light when the app is light and black under AMOLED.
         card.setFillColor(ColorStateList.valueOf(MaterialColors.getColor(
@@ -579,12 +639,22 @@ class Utils {
         // under CENTER_VERTICAL as a shift rather than a bound, so an uneven pair walks the card off the
         // top of the screen. Padding bounds it, and the margin left on the card is even.
         final FrameLayout host = new FrameLayout(activity);
-        host.setPadding(0, insetTop, 0, insetBottom);
+        // A sheet must not reach the top edge; the panels hide the status bar, so without a floor here a
+        // long playlist would grow into a full-screen dialog that arrived from the bottom.
+        host.setPadding(0, bottom ? Math.max(insetTop, dpToPx(56)) : insetTop, 0, insetBottom);
         final FrameLayout.LayoutParams lp = new FrameLayout.LayoutParams(
-                ui.pickerWidthPx(cfg), ViewGroup.LayoutParams.WRAP_CONTENT,
-                Gravity.END | Gravity.CENTER_VERTICAL);
-        // Horizontal gravity is END, where a margin is a bound and the blocked edge can simply be added.
-        lp.setMargins(hMargin, vMargin, hMargin + insetEnd, vMargin);
+                panelWidth, ViewGroup.LayoutParams.WRAP_CONTENT,
+                bottom ? Gravity.BOTTOM | Gravity.CENTER_HORIZONTAL
+                        : Gravity.END | Gravity.CENTER_VERTICAL);
+        if (bottom) {
+            // Even margins under CENTER_HORIZONTAL, and none at the bottom: the card sits on the edge,
+            // above whatever the navigation bar left of it (that inset is the host's padding).
+            lp.setMargins(hMargin, vMargin, hMargin, 0);
+        } else {
+            // Horizontal gravity is END, where a margin is a bound and the blocked edge can simply be
+            // added.
+            lp.setMargins(hMargin, vMargin, hMargin + insetEnd, vMargin);
+        }
         host.addView(content, lp);
 
         dialog.setContentView(host);
@@ -597,9 +667,10 @@ class Utils {
         // designed at. Capped short of the screen so the window never becomes a fullscreen one.
         final int screenW = activity.getResources().getDisplayMetrics().widthPixels;
         window.setLayout(
-                Math.min(screenW - dpToPx(8), ui.pickerWidthPx(cfg) + 2 * hMargin + insetEnd),
+                bottom ? screenW - dpToPx(8)
+                        : Math.min(screenW - dpToPx(8), panelWidth + 2 * hMargin + insetEnd),
                 ViewGroup.LayoutParams.MATCH_PARENT);
-        window.setGravity(Gravity.END);
+        window.setGravity(bottom ? Gravity.BOTTOM | Gravity.CENTER_HORIZONTAL : Gravity.END);
         window.setBackgroundDrawable(new ColorDrawable(Color.TRANSPARENT));
         // The picture behind a modal sheet steps back rather than competing with it.
         window.addFlags(WindowManager.LayoutParams.FLAG_DIM_BEHIND);

--- a/app/src/main/res/color/focus_halo.xml
+++ b/app/src/main/res/color/focus_halo.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- The slider's share of @color/focus_ring. A thumb is too narrow to carry an edge on its own, so
+     focus arrives as a wash around it — white, because Material's own halo is the accent, and an
+     accent halo around an accent thumb on an accent track measured 1.38:1 against the track. -->
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:state_focused="true" android:color="@color/focus_halo_wash" />
+    <item android:color="@android:color/transparent" />
+</selector>

--- a/app/src/main/res/color/focus_halo.xml
+++ b/app/src/main/res/color/focus_halo.xml
@@ -1,8 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- The slider's share of @color/focus_ring. A thumb is too narrow to carry an edge on its own, so
-     focus arrives as a wash around it — white, because Material's own halo is the accent, and an
-     accent halo around an accent thumb on an accent track measured 1.38:1 against the track. -->
+     focus arrives as a wash around it — in the surface's own ink rather than the accent, because
+     Material's halo is the accent, and an accent halo around an accent thumb on an accent track
+     measured 1.38:1 against the track. Translucent, because it is drawn over the thumb it rings and
+     the thumb has to stay readable through it. -->
 <selector xmlns:android="http://schemas.android.com/apk/res/android">
-    <item android:state_focused="true" android:color="@color/focus_halo_wash" />
+    <item android:state_focused="true" android:alpha="0.4" android:color="?attr/colorOnSurface" />
     <item android:color="@android:color/transparent" />
 </selector>

--- a/app/src/main/res/color/focus_ring.xml
+++ b/app/src/main/res/color/focus_ring.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- A control that has D-pad focus wears a white edge. Nothing otherwise, and nothing at all in
+     touch mode, where no view is ever focused. This is the ring that replaced a wash: Material's
+     own focus state layer measured 2.51:1 on a television, and where a control carries the accent
+     as a fill the wash washed the accent out with it. -->
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:state_focused="true" android:color="@color/white" />
+    <item android:color="@android:color/transparent" />
+</selector>

--- a/app/src/main/res/color/focus_ring.xml
+++ b/app/src/main/res/color/focus_ring.xml
@@ -1,9 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- A control that has D-pad focus wears a white edge. Nothing otherwise, and nothing at all in
-     touch mode, where no view is ever focused. This is the ring that replaced a wash: Material's
-     own focus state layer measured 2.51:1 on a television, and where a control carries the accent
-     as a fill the wash washed the accent out with it. -->
+<!-- A control that has D-pad focus wears an edge in the ink of the surface it sits on. Nothing
+     otherwise, and nothing at all in touch mode, where no view is ever focused. This is the ring that
+     replaced a wash: Material's own focus state layer measured 2.51:1 on a television, and where a
+     control carries the accent as a fill the wash washed the accent out with it.
+
+     The ink follows the surface rather than being white, because the panels and the settings screen
+     are light when the appearance choice is light — and a white ring on a light card measured 1.15:1,
+     which is no ring at all. On a dark surface colorOnSurface is a near-white that reads the same as
+     the white it replaced. -->
 <selector xmlns:android="http://schemas.android.com/apk/res/android">
-    <item android:state_focused="true" android:color="@color/white" />
+    <item android:state_focused="true" android:color="?attr/colorOnSurface" />
     <item android:color="@android:color/transparent" />
 </selector>

--- a/app/src/main/res/color/focus_ring_outlined.xml
+++ b/app/src/main/res/color/focus_ring_outlined.xml
@@ -2,6 +2,6 @@
 <!-- As @color/focus_ring, for a control that already has an outline to lose: the ring takes the
      outline's place rather than being drawn beside it. -->
 <selector xmlns:android="http://schemas.android.com/apk/res/android">
-    <item android:state_focused="true" android:color="@color/white" />
+    <item android:state_focused="true" android:color="?attr/colorOnSurface" />
     <item android:color="?attr/colorOutline" />
 </selector>

--- a/app/src/main/res/color/focus_ring_outlined.xml
+++ b/app/src/main/res/color/focus_ring_outlined.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- As @color/focus_ring, for a control that already has an outline to lose: the ring takes the
+     outline's place rather than being drawn beside it. -->
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:state_focused="true" android:color="@color/white" />
+    <item android:color="?attr/colorOutline" />
+</selector>

--- a/app/src/main/res/color/ripple_button.xml
+++ b/app/src/main/res/color/ripple_button.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Material's own button ripple with the focus state layer taken out, for the controls that wear
+     @color/focus_ring: on those, focus is the edge and nothing else.
+
+     The layer had to go rather than be left alone, because on a checked segment Material draws it in
+     the colour of the text on the accent — dark, by definition — so focusing the chosen pill *darkened* its
+     coral, measured #D6493C to #C04236. Darker on focus reads as pressed, or as switched off, and it is
+     the state a panel opens in: the first focus goes to the option in force. Omitting the entry is not
+     enough either — a RippleDrawable falls through to the catch-all and washes anyway, so focus has to
+     be named and made transparent. Everything else is Material's: press 0.1, hover 0.08, and the 0.16
+     the ripple animation itself draws with. -->
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:state_focused="true" android:state_pressed="false"
+        android:color="@android:color/transparent" />
+
+    <item android:state_checked="true" android:state_pressed="true"
+        android:alpha="0.1" android:color="?attr/colorOnSurface" />
+    <item android:state_pressed="true"
+        android:alpha="0.1" android:color="?attr/colorOnSecondaryContainer" />
+
+    <item android:state_checked="true" android:state_hovered="true"
+        android:alpha="0.08" android:color="?attr/colorOnSecondaryContainer" />
+    <item android:state_hovered="true"
+        android:alpha="0.08" android:color="?attr/colorOnSurface" />
+
+    <item android:alpha="0.16" android:color="?attr/colorOnSurface" />
+</selector>

--- a/app/src/main/res/drawable/ic_movie_24dp.xml
+++ b/app/src/main/res/drawable/ic_movie_24dp.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M18,4l2,4h-3l-2,-4h-2l2,4h-3l-2,-4H8l2,4H7L5,4H4C2.9,4 2.01,4.9 2.01,6L2,18c0,1.1 0.9,2 2,2h16c1.1,0 2,-0.9 2,-2V4h-4z" />
+</vector>

--- a/app/src/main/res/drawable/ic_view_grid_24dp.xml
+++ b/app/src/main/res/drawable/ic_view_grid_24dp.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M4.5,3h5A1.5,1.5 0 0,1 11,4.5v5A1.5,1.5 0 0,1 9.5,11h-5A1.5,1.5 0 0,1 3,9.5v-5A1.5,1.5 0 0,1 4.5,3zM14.5,3h5A1.5,1.5 0 0,1 21,4.5v5A1.5,1.5 0 0,1 19.5,11h-5A1.5,1.5 0 0,1 13,9.5v-5A1.5,1.5 0 0,1 14.5,3zM4.5,13h5A1.5,1.5 0 0,1 11,14.5v5A1.5,1.5 0 0,1 9.5,21h-5A1.5,1.5 0 0,1 3,19.5v-5A1.5,1.5 0 0,1 4.5,13zM14.5,13h5A1.5,1.5 0 0,1 21,14.5v5A1.5,1.5 0 0,1 19.5,21h-5A1.5,1.5 0 0,1 13,19.5v-5A1.5,1.5 0 0,1 14.5,13z" />
+</vector>

--- a/app/src/main/res/drawable/ic_view_list_24dp.xml
+++ b/app/src/main/res/drawable/ic_view_list_24dp.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M4,5h3A1,1 0 0,1 8,6v2A1,1 0 0,1 7,9H4A1,1 0 0,1 3,8V6A1,1 0 0,1 4,5zM10,5h10A1,1 0 0,1 21,6v2A1,1 0 0,1 20,9H10A1,1 0 0,1 9,8V6A1,1 0 0,1 10,5zM4,10.5h3A1,1 0 0,1 8,11.5v1A1,1 0 0,1 7,13.5H4A1,1 0 0,1 3,12.5v-1A1,1 0 0,1 4,10.5zM10,10.5h10A1,1 0 0,1 21,11.5v1A1,1 0 0,1 20,13.5H10A1,1 0 0,1 9,12.5v-1A1,1 0 0,1 10,10.5zM4,15h3A1,1 0 0,1 8,16v2A1,1 0 0,1 7,19H4A1,1 0 0,1 3,18v-2A1,1 0 0,1 4,15zM10,15h10A1,1 0 0,1 21,16v2A1,1 0 0,1 20,19H10A1,1 0 0,1 9,18v-2A1,1 0 0,1 10,15z" />
+</vector>

--- a/app/src/main/res/values-night/colors.xml
+++ b/app/src/main/res/values-night/colors.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- On a dark scheme the accent is the brand itself: the darker one exists only so a coral can
+         be read on white. See values/colors.xml for the measurements. -->
+    <color name="brand_accent">@color/brand</color>
+    <color name="brand_accent_on">@color/brand_on</color>
+</resources>

--- a/app/src/main/res/values-night/colors.xml
+++ b/app/src/main/res/values-night/colors.xml
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <!-- On a dark scheme the accent is the brand itself: the darker one exists only so a coral can
-         be read on white. See values/colors.xml for the measurements. -->
-    <color name="brand_accent">@color/brand</color>
-    <color name="brand_accent_on">@color/brand_on</color>
-</resources>

--- a/app/src/main/res/values-notouch/dimens.xml
+++ b/app/src/main/res/values-notouch/dimens.xml
@@ -1,0 +1,5 @@
+<resources>
+    <!-- Wider than the phone's 2dp: this is the one screen the ring is read from three metres
+         away, and it is the only focus signal the panels have. See values/dimens.xml. -->
+    <dimen name="focus_ring_width">4dp</dimen>
+</resources>

--- a/app/src/main/res/values-notouch/themes.xml
+++ b/app/src/main/res/values-notouch/themes.xml
@@ -10,9 +10,12 @@
         <item name="colorControlHighlight">@color/white</item>
     </style>
     <!-- The settings list is where a remote spends most of its presses, and the default M3
-         highlight is barely a shade over the card it sits on. Same white as the other two. -->
+         highlight is barely a shade over the card it sits on. Not the white the two above use,
+         though: this is the one screen in the app that goes light with the appearance choice, and
+         white on a light card measured 1.09:1 between a focused row and its neighbours. The
+         surface's own ink is the same near-white on a dark screen and legible on a light one. -->
     <style name="Theme.Settings" parent="BaseTheme.Settings">
-        <item name="colorControlHighlight">@color/white</item>
+        <item name="colorControlHighlight">?attr/colorOnSurface</item>
     </style>
 
     <!-- The panels are NOT given the white wash the three screens above get. A wash over a row

--- a/app/src/main/res/values-notouch/themes.xml
+++ b/app/src/main/res/values-notouch/themes.xml
@@ -14,4 +14,13 @@
     <style name="Theme.Settings" parent="BaseTheme.Settings">
         <item name="colorControlHighlight">@color/white</item>
     </style>
+
+    <!-- A player panel is built against these themes now, and a remote needs the same white
+         wash the player, the error screen and the settings list already get here. -->
+    <style name="Theme.Dialogs.Dark" parent="BaseTheme.Dialogs.Dark">
+        <item name="colorControlHighlight">@color/white</item>
+    </style>
+    <style name="Theme.Dialogs.Light" parent="BaseTheme.Dialogs.Light">
+        <item name="colorControlHighlight">@color/white</item>
+    </style>
 </resources>

--- a/app/src/main/res/values-notouch/themes.xml
+++ b/app/src/main/res/values-notouch/themes.xml
@@ -14,13 +14,9 @@
     <style name="Theme.Settings" parent="BaseTheme.Settings">
         <item name="colorControlHighlight">@color/white</item>
     </style>
-
-    <!-- A player panel is built against these themes now, and a remote needs the same white
-         wash the player, the error screen and the settings list already get here. -->
-    <style name="Theme.Dialogs.Dark" parent="BaseTheme.Dialogs.Dark">
-        <item name="colorControlHighlight">@color/white</item>
-    </style>
-    <style name="Theme.Dialogs.Light" parent="BaseTheme.Dialogs.Light">
-        <item name="colorControlHighlight">@color/white</item>
-    </style>
+
+    <!-- The panels are NOT given the white wash the three screens above get. A wash over a row
+         that carries the accent as a fill destroys the fill: measured 2.21:1 for the label on a
+         focused current row. They wear @color/focus_ring instead, on the row and on every
+         button. -->
 </resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -168,6 +168,15 @@
     <string name="time_ends_at_inline">до %1$s</string>
     <string name="time_live">● ЭФИР</string>
     <string name="playlist">Плейлист</string>
+    <plurals name="playlist_items">
+        <item quantity="one">%d файл</item>
+        <item quantity="few">%d файла</item>
+        <item quantity="many">%d файлов</item>
+        <item quantity="other">%d файла</item>
+    </plurals>
+    <string name="playlist_playing">Играет</string>
+    <string name="playlist_view_grid">Сетка</string>
+    <string name="playlist_view_list">Список</string>
     <string name="shortcut_videos">Видео</string>
     <string name="button_open">Открыть</string>
     <string name="button_crop">Изменить размер</string>

--- a/app/src/main/res/values-television/dimens.xml
+++ b/app/src/main/res/values-television/dimens.xml
@@ -1,0 +1,5 @@
+<resources>
+    <!-- Wider than the phone's 2dp: this is the one screen the ring is read from three metres
+         away, and it is the only focus signal the panels have. See values/dimens.xml. -->
+    <dimen name="focus_ring_width">4dp</dimen>
+</resources>

--- a/app/src/main/res/values-television/themes.xml
+++ b/app/src/main/res/values-television/themes.xml
@@ -10,9 +10,12 @@
         <item name="colorControlHighlight">@color/white</item>
     </style>
     <!-- The settings list is where a remote spends most of its presses, and the default M3
-         highlight is barely a shade over the card it sits on. Same white as the other two. -->
+         highlight is barely a shade over the card it sits on. Not the white the two above use,
+         though: this is the one screen in the app that goes light with the appearance choice, and
+         white on a light card measured 1.09:1 between a focused row and its neighbours. The
+         surface's own ink is the same near-white on a dark screen and legible on a light one. -->
     <style name="Theme.Settings" parent="BaseTheme.Settings">
-        <item name="colorControlHighlight">@color/white</item>
+        <item name="colorControlHighlight">?attr/colorOnSurface</item>
     </style>
 
     <!-- The panels are NOT given the white wash the three screens above get. A wash over a row

--- a/app/src/main/res/values-television/themes.xml
+++ b/app/src/main/res/values-television/themes.xml
@@ -14,4 +14,13 @@
     <style name="Theme.Settings" parent="BaseTheme.Settings">
         <item name="colorControlHighlight">@color/white</item>
     </style>
+
+    <!-- A player panel is built against these themes now, and a remote needs the same white
+         wash the player, the error screen and the settings list already get here. -->
+    <style name="Theme.Dialogs.Dark" parent="BaseTheme.Dialogs.Dark">
+        <item name="colorControlHighlight">@color/white</item>
+    </style>
+    <style name="Theme.Dialogs.Light" parent="BaseTheme.Dialogs.Light">
+        <item name="colorControlHighlight">@color/white</item>
+    </style>
 </resources>

--- a/app/src/main/res/values-television/themes.xml
+++ b/app/src/main/res/values-television/themes.xml
@@ -14,13 +14,9 @@
     <style name="Theme.Settings" parent="BaseTheme.Settings">
         <item name="colorControlHighlight">@color/white</item>
     </style>
-
-    <!-- A player panel is built against these themes now, and a remote needs the same white
-         wash the player, the error screen and the settings list already get here. -->
-    <style name="Theme.Dialogs.Dark" parent="BaseTheme.Dialogs.Dark">
-        <item name="colorControlHighlight">@color/white</item>
-    </style>
-    <style name="Theme.Dialogs.Light" parent="BaseTheme.Dialogs.Light">
-        <item name="colorControlHighlight">@color/white</item>
-    </style>
+
+    <!-- The panels are NOT given the white wash the three screens above get. A wash over a row
+         that carries the accent as a fill destroys the fill: measured 2.21:1 for the label on a
+         focused current row. They wear @color/focus_ring instead, on the row and on every
+         button. -->
 </resources>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -169,6 +169,15 @@
     <string name="time_ends_at_inline">до %1$s</string>
     <string name="time_live">● ЕФІР</string>
     <string name="playlist">Список відтворення</string>
+    <plurals name="playlist_items">
+        <item quantity="one">%d файл</item>
+        <item quantity="few">%d файли</item>
+        <item quantity="many">%d файлів</item>
+        <item quantity="other">%d файла</item>
+    </plurals>
+    <string name="playlist_playing">Грає</string>
+    <string name="playlist_view_grid">Сітка</string>
+    <string name="playlist_view_list">Список</string>
     <string name="pref_map_dv7">Резервний варіант Dolby Vision profile 7</string>
     <string name="pref_map_dv7_on">Відтворення контенту Dolby Vision profile 7 на дисплеях HDR</string>
     <string name="pref_map_dv7_off">Відтворення вмісту UHD Blu-ray, що містить Dolby Vision, як є</string>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -49,10 +49,11 @@
     <!-- Ink on a brand-filled control, e.g. a selected offset pill. -->
     <color name="ink_on_accent">#FF141414</color>
 
-    <!-- Player chrome surfaces, all translucent so the picture keeps showing through. -->
-    <color name="panel_surface">#F0141414</color>
-    <color name="pill_surface">#F0161616</color>
-    <color name="pill_scrim">#99000000</color>
+    <!-- Player chrome surfaces, all translucent so the picture keeps showing through. Two families:
+         a near-opaque one the panels and pills are cut from, and the plainly translucent black of
+         @color/ui_controls_background further down. What used to be four names was two pairs 2/255 and
+         1/255 apart — close enough that nothing could have been choosing between them on purpose. -->
+    <color name="chrome_surface">#F0141414</color>
     <color name="badge_scrim">#CC000000</color>
     <color name="placeholder_card">#FF333333</color>
     <color name="thumb_box">#FF2A2A2A</color>
@@ -80,6 +81,8 @@
     <color name="ad_edge">#FFFFD27A</color>
     <color name="ad_fill">#C7FFA000</color>
 
+    <!-- The translucent black chrome: the control cluster, the lock and stats pills, the round discs,
+         swipe-to-unlock, the navigation bar, and the Media3 colours below that alias to it. -->
     <color name="ui_controls_background">#98000000</color>
     <color name="exo_bottom_bar_background" tools:keep="@color/exo_bottom_bar_background">@color/ui_controls_background</color>
     <color name="exo_black_opacity_70" tools:keep="@color/exo_black_opacity_70">@color/ui_controls_background</color>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -48,8 +48,6 @@
     <!-- A row that is not the current one: opaque grey, not white at an alpha, so it stays a step
          below the current row even where the fill behind them differs. -->
     <color name="ink_row_inactive">#FFDDDDDD</color>
-    <!-- Ink on a brand-filled control, e.g. a selected offset pill. -->
-    <color name="ink_on_accent">#FF141414</color>
 
     <!-- Player chrome surfaces, all translucent so the picture keeps showing through. Two families:
          a near-opaque one the panels and pills are cut from, and the plainly translucent black of
@@ -63,7 +61,6 @@
     <!-- Hairlines, grooves and the unfilled part of a track. -->
     <color name="divider">#1AFFFFFF</color>
     <color name="track_white">#33FFFFFF</color>
-    <color name="pill_off_fill">#14FFFFFF</color>
     <!-- Buffered lead ahead of the playhead; used on network sources only, see the call site. -->
     <color name="buffered_white">#C0FFFFFF</color>
 

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -93,9 +93,6 @@
          keyed to how bright the ground is, but they were not: a picker row and an OffsetPanel pill sit
          on the same dark panel — @color/pill_off_fill is barely a fill — and took #40 and #20. -->
     <color name="ripple_chrome">#40FFFFFF</color>
-    <!-- The wash inside @color/focus_halo. Translucent, because it is drawn over the thumb it
-         rings and the thumb has to stay readable through it. -->
-    <color name="focus_halo_wash">#66FFFFFF</color>
 
     <!-- Segment highlights (see CustomDefaultTimeBar): a *_fill band across the segment plus a crisp
          boundary hairline in the lighter *_edge colour. Three-colour timeline system — coral =

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -64,11 +64,10 @@
     <!-- Buffered lead ahead of the playhead; used on network sources only, see the call site. -->
     <color name="buffered_white">#C0FFFFFF</color>
 
-    <!-- Press feedback. Three tones today, one per surface family; they are independent knobs
-         rather than a deliberate scale. -->
-    <color name="ripple_strong">#40FFFFFF</color>
-    <color name="ripple_medium">#33FFFFFF</color>
-    <color name="ripple_soft">#20FFFFFF</color>
+    <!-- Press feedback, one tone for every player surface. The three it replaced looked like a scale
+         keyed to how bright the ground is, but they were not: a picker row and an OffsetPanel pill sit
+         on the same dark panel — @color/pill_off_fill is barely a fill — and took #40 and #20. -->
+    <color name="ripple_chrome">#40FFFFFF</color>
 
     <!-- Segment highlights (see CustomDefaultTimeBar): a *_fill band across the segment plus a crisp
          boundary hairline in the lighter *_edge colour. Three-colour timeline system — coral =

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -7,7 +7,9 @@
     <color name="brand_ramp_start">#FFFF6E3C</color>
     <color name="brand_ramp_end">#FFFF0D63</color>
     <!-- M3 primary container (switch track when on, tonal surfaces): the brand at container tone.
-         One value for both day and night — a deep coral reads on white and on the dark settings list alike. -->
+         One value for both day and night — a deep coral reads on white and on the dark settings list alike.
+         The player's current picker row takes it too, so a selected row and a switch that is on are the
+         same colour rather than two different dimmings of the same accent. -->
     <color name="brand_container">#FF7A2019</color>
     <!-- M3 on-primary: the ink that sits on the brand, e.g. the switch handle when it is on. -->
     <color name="brand_on">#FF5F1411</color>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -6,6 +6,16 @@
     <!-- The mark's ramp (see design/just+.svg); the vector drawables carry these same two stops. -->
     <color name="brand_ramp_start">#FFFF6E3C</color>
     <color name="brand_ramp_end">#FFFF0D63</color>
+    <!-- The accent as it has to be on a LIGHT surface. @color/brand is a coral light enough to sit on
+         black; on a white sheet it measures 2.6:1 as a caption and 2.4:1 as a glyph, under the 4.5 and 3
+         those want. Same hue, same family, taken down until it clears both: 5.1:1 on colorSurface and
+         4.7:1 on colorSurfaceContainer. -->
+    <color name="brand_on_light">#FFC4362A</color>
+    <!-- The pair the one DayNight screen — settings — resolves through, so its section headers and its
+         switch follow the mode. values-night/ swaps both back to the bright coral. -->
+    <color name="brand_accent">@color/brand_on_light</color>
+    <color name="brand_accent_on">@color/white</color>
+
     <!-- M3 primary container (switch track when on, tonal surfaces): the brand at container tone.
          One value for both day and night — a deep coral reads on white and on the dark settings list alike.
          The player's current picker row takes it too, so a selected row and a switch that is on are the

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -6,15 +6,27 @@
     <!-- The mark's ramp (see design/just+.svg); the vector drawables carry these same two stops. -->
     <color name="brand_ramp_start">#FFFF6E3C</color>
     <color name="brand_ramp_end">#FFFF0D63</color>
-    <!-- The accent as it has to be on a LIGHT surface. @color/brand is a coral light enough to sit on
-         black; on a white sheet it measures 2.6:1 as a caption and 2.4:1 as a glyph, under the 4.5 and 3
-         those want. Same hue, same family, taken down until it clears both: 5.1:1 on colorSurface and
-         4.7:1 on colorSurfaceContainer. -->
-    <color name="brand_on_light">#FFC4362A</color>
-    <!-- The pair the one DayNight screen — settings — resolves through, so its section headers and its
-         switch follow the mode. values-night/ swaps both back to the bright coral. -->
-    <color name="brand_accent">@color/brand_on_light</color>
-    <color name="brand_accent_on">@color/white</color>
+    <!-- ONE accent for everything the app draws on a surface: a switch track, a checked segment, the
+         chosen row of a picker, a glyph, a section header. One, because two made the switch visibly
+         change colour between light and dark.
+
+         Its lightness is not a preference, it is the only window that exists. To be a fill or a glyph
+         at 3:1 it has to be darker than L=0.254 (else it vanishes on a white card) and lighter than
+         L=0.143 (else it vanishes on a dark one). L=0.193 is the middle of that window: 3.75:1 on the
+         light card, 3.78:1 on the dark one. @color/brand sits at L=0.333, above the window, which is
+         why it measured 2.4:1 on white.
+
+         Same hue as @color/brand, saturation eased to 0.65 — at this lightness the full saturation
+         reads as fire engine rather than coral.
+
+         What it cannot be is small text at 4.5:1 in BOTH schemes: that would need it darker than
+         L=0.172 on white and lighter than L=0.204 on black, and those windows do not overlap. As a
+         section header it lands at 4.11:1 light and 4.30:1 dark — short of AA, and still twice what
+         the bright coral managed on white. -->
+    <color name="brand_accent">#FFD6493C</color>
+    <!-- Ink on that accent. Near-black wins the arithmetic on a mid-toned fill: 4.88:1, where white is
+         4.31:1 and fails small text. -->
+    <color name="brand_accent_on">@color/black</color>
 
     <!-- M3 primary container (switch track when on, tonal surfaces): the brand at container tone.
          One value for both day and night — a deep coral reads on white and on the dark settings list alike.

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -93,6 +93,9 @@
          keyed to how bright the ground is, but they were not: a picker row and an OffsetPanel pill sit
          on the same dark panel — @color/pill_off_fill is barely a fill — and took #40 and #20. -->
     <color name="ripple_chrome">#40FFFFFF</color>
+    <!-- The wash inside @color/focus_halo. Translucent, because it is drawn over the thumb it
+         rings and the thumb has to stay readable through it. -->
+    <color name="focus_halo_wash">#66FFFFFF</color>
 
     <!-- Segment highlights (see CustomDefaultTimeBar): a *_fill band across the segment plus a crisp
          boundary hairline in the lighter *_edge colour. Three-colour timeline system — coral =

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -54,6 +54,9 @@
          @color/ui_controls_background further down. What used to be four names was two pairs 2/255 and
          1/255 apart — close enough that nothing could have been choosing between them on purpose. -->
     <color name="chrome_surface">#F0141414</color>
+    <!-- The panels are Material detached side sheets: a card over a dimmed picture, so the tone is
+         the chrome one at full opacity. Nothing shows through a sheet that has its own scrim. -->
+    <color name="sheet_surface">#FF141414</color>
     <color name="badge_scrim">#CC000000</color>
     <color name="placeholder_card">#FF333333</color>
     <color name="thumb_box">#FF2A2A2A</color>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -12,6 +12,19 @@
 
     <dimen name="marker_width">3dp</dimen>
 
+    <!-- The D-pad focus ring, everywhere one is drawn: the three button styles in themes.xml, the
+         picker row, the slider thumb and the skip pill. One number, because it used to be five
+         literal 2dp's reached by three different paths, and they did not agree — Utils.dpToPx
+         truncates, so the row's "2dp" arrived 50% thinner than the buttons' identical 2dp.
+
+         A television gets a wider one (values-television, values-notouch). Everything else in the
+         player's geometry grows with UiMetrics.dpS, which this cannot: a style in XML has no way to
+         reach it. Contrast is not thickness — at three metres a hairline is lost where a line reads
+         at once, and 2dp on a 720p set is three pixels. Outlined buttons are the exception: their
+         stroke is also their resting border, so they stay thin at rest and thicken to this on focus
+         (see Utils.focusRing). -->
+    <dimen name="focus_ring_width">2dp</dimen>
+
     <dimen name="level_bar_width">6dp</dimen>
     <dimen name="level_bar_height">160dp</dimen>
     <dimen name="level_bar_margin">28dp</dimen>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -191,6 +191,13 @@
     <string name="time_ends_at_inline">until %1$s</string>
     <string name="time_live">● LIVE</string>
     <string name="playlist">Playlist</string>
+    <plurals name="playlist_items">
+        <item quantity="one">%d file</item>
+        <item quantity="other">%d files</item>
+    </plurals>
+    <string name="playlist_playing">Playing</string>
+    <string name="playlist_view_grid">Grid view</string>
+    <string name="playlist_view_list">List view</string>
     <string name="pref_map_dv7">Dolby Vision profile 7 fallback</string>
     <string name="pref_map_dv7_on">Play Dolby Vision profile 7 content on HDR displays</string>
     <string name="pref_map_dv7_off">Play UHD Blu-ray content containing Dolby Vision as is</string>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -12,6 +12,14 @@
         <item name="colorPrimary">@color/brand</item>
         <item name="colorPrimaryContainer">@color/brand_container</item>
         <item name="colorOnPrimary">@color/brand_on</item>
+        <!-- One answer to "this one is chosen", for every control that has to say it: the checked
+             segment of a toggle group, the current row of a picker, the track of a switch. Material
+             would give a checked segment colorSecondaryContainer, which this app leaves neutral, so the
+             three said it three different ways — and the coral container the rows used measured 1.59:1
+             against a dark card, a selection you had to look for. Pointed at the accent pair, all three
+             read the same and clear 3:1 either way round. -->
+        <item name="colorSecondaryContainer">@color/brand</item>
+        <item name="colorOnSecondaryContainer">@color/brand_on</item>
         <!-- colorAccent is NOT derived from colorPrimary: Theme.Material3.Dark inherits it through
              Theme.MaterialComponents, where Base.V14.Theme.MaterialComponents sets it to
              ?attr/colorSecondary — a role this app leaves at the M3 default on purpose. Drop this line
@@ -47,6 +55,14 @@
         <item name="colorPrimary">@color/brand</item>
         <item name="colorPrimaryContainer">@color/brand_container</item>
         <item name="colorOnPrimary">@color/brand_on</item>
+        <!-- One answer to "this one is chosen", for every control that has to say it: the checked
+             segment of a toggle group, the current row of a picker, the track of a switch. Material
+             would give a checked segment colorSecondaryContainer, which this app leaves neutral, so the
+             three said it three different ways — and the coral container the rows used measured 1.59:1
+             against a dark card, a selection you had to look for. Pointed at the accent pair, all three
+             read the same and clear 3:1 either way round. -->
+        <item name="colorSecondaryContainer">@color/brand</item>
+        <item name="colorOnSecondaryContainer">@color/brand_on</item>
         <item name="colorAccent">@color/brand</item>
         <item name="android:colorControlActivated">@color/brand</item>
     </style>
@@ -63,11 +79,21 @@
              primary colour, which with a coral primary is a red band across the top of the screen.
              SettingsActivity sets the icon appearance to match. -->
         <item name="android:statusBarColor">?attr/colorSurface</item>
-        <item name="colorPrimary">@color/brand</item>
+        <!-- The one DayNight screen in the app, so the accent is the pair that follows the mode: the
+             bright coral is unreadable as a section header on a white card, at 2.6:1. -->
+        <item name="colorPrimary">@color/brand_accent</item>
         <item name="colorPrimaryContainer">@color/brand_container</item>
-        <item name="colorOnPrimary">@color/brand_on</item>
-        <item name="colorAccent">@color/brand</item>
-        <item name="android:colorControlActivated">@color/brand</item>
+        <item name="colorOnPrimary">@color/brand_accent_on</item>
+        <!-- One answer to "this one is chosen", for every control that has to say it: the checked
+             segment of a toggle group, the current row of a picker, the track of a switch. Material
+             would give a checked segment colorSecondaryContainer, which this app leaves neutral, so the
+             three said it three different ways — and the coral container the rows used measured 1.59:1
+             against a dark card, a selection you had to look for. Pointed at the accent pair, all three
+             read the same and clear 3:1 either way round. -->
+        <item name="colorSecondaryContainer">@color/brand_accent</item>
+        <item name="colorOnSecondaryContainer">@color/brand_accent_on</item>
+        <item name="colorAccent">@color/brand_accent</item>
+        <item name="android:colorControlActivated">@color/brand_accent</item>
     </style>
 
     <!-- Split like Theme.Player and Theme.Error, so values-television and values-notouch can give the
@@ -118,13 +144,23 @@
     <style name="BaseTheme.Dialogs.Light" parent="Theme.Material3.Light.NoActionBar">
         <item name="alertDialogTheme">@style/ThemeOverlay.JustPlus.AlertDialog</item>
         <item name="materialAlertDialogTheme">@style/ThemeOverlay.JustPlus.AlertDialog</item>
-        <item name="colorPrimary">@color/brand</item>
+        <!-- Not @color/brand: this theme is light whatever the system is doing, and the bright coral
+             cannot be read on it. See @color/brand_on_light. -->
+        <item name="colorPrimary">@color/brand_on_light</item>
         <item name="colorPrimaryContainer">@color/brand_container</item>
-        <item name="colorOnPrimary">@color/brand_on</item>
+        <item name="colorOnPrimary">@color/white</item>
+        <!-- One answer to "this one is chosen", for every control that has to say it: the checked
+             segment of a toggle group, the current row of a picker, the track of a switch. Material
+             would give a checked segment colorSecondaryContainer, which this app leaves neutral, so the
+             three said it three different ways — and the coral container the rows used measured 1.59:1
+             against a dark card, a selection you had to look for. Pointed at the accent pair, all three
+             read the same and clear 3:1 either way round. -->
+        <item name="colorSecondaryContainer">@color/brand_on_light</item>
+        <item name="colorOnSecondaryContainer">@color/white</item>
         <!-- The player's panels are built against these themes now, so they need the accent the
              window themes carry: Material 3 derives colorAccent from colorSecondary, not from
              colorPrimary, and would hand every AppCompat widget in here a baseline mauve. -->
-        <item name="colorAccent">@color/brand</item>
+        <item name="colorAccent">@color/brand_on_light</item>
     </style>
 
     <!-- Split like Theme.Player, so values-television and values-notouch can give a panel the
@@ -138,6 +174,14 @@
         <item name="colorPrimary">@color/brand</item>
         <item name="colorPrimaryContainer">@color/brand_container</item>
         <item name="colorOnPrimary">@color/brand_on</item>
+        <!-- One answer to "this one is chosen", for every control that has to say it: the checked
+             segment of a toggle group, the current row of a picker, the track of a switch. Material
+             would give a checked segment colorSecondaryContainer, which this app leaves neutral, so the
+             three said it three different ways — and the coral container the rows used measured 1.59:1
+             against a dark card, a selection you had to look for. Pointed at the accent pair, all three
+             read the same and clear 3:1 either way round. -->
+        <item name="colorSecondaryContainer">@color/brand</item>
+        <item name="colorOnSecondaryContainer">@color/brand_on</item>
         <!-- The player's panels are built against these themes now, so they need the accent the
              window themes carry: Material 3 derives colorAccent from colorSecondary, not from
              colorPrimary, and would hand every AppCompat widget in here a baseline mauve. -->

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -75,6 +75,12 @@
     <style name="BaseTheme.Settings" parent="Theme.Material3.DayNight.NoActionBar">
         <item name="alertDialogTheme">@style/ThemeOverlay.JustPlus.AlertDialog</item>
         <item name="materialAlertDialogTheme">@style/ThemeOverlay.JustPlus.AlertDialog</item>
+        <!-- Material's own button attributes, pointed at the three styles below, so every button in
+             here — including the ones no code of ours constructs — wears the focus ring. -->
+        <item name="materialButtonStyle">@style/Widget.JustPlus.Button.Filled</item>
+        <item name="materialButtonOutlinedStyle">@style/Widget.JustPlus.Button.Outlined</item>
+        <item name="materialIconButtonStyle">@style/Widget.JustPlus.Button.Quiet.Icon</item>
+        <item name="borderlessButtonStyle">@style/Widget.JustPlus.Button.Quiet</item>
         <!-- One field with the list below it. Left unset, a Material theme paints the bar from the
              primary colour, which with a coral primary is a red band across the top of the screen.
              SettingsActivity sets the icon appearance to match. -->
@@ -119,6 +125,36 @@
         <item name="buttonBarNeutralButtonStyle">@style/Widget.JustPlus.Button.Dialog.Neutral</item>
     </style>
 
+    <!--
+        Three button styles, and one rule between them: a filled button is the action that moves things
+        forward, an outlined one is a choice among several, and a quiet one is everything else. It is the
+        same rule in a dialog and over video, which is what makes the Skip button legible as the top of a
+        hierarchy rather than an exception to it.
+
+        All three take the focus ring. Material draws D-pad focus as a state layer, which measured 2.51:1
+        on a television against the 3:1 a non-text indicator wants — and on a control carrying the accent
+        as a fill it washed the accent out too, leaving 2.21:1 for the label on it.
+    -->
+    <style name="Widget.JustPlus.Button.Quiet" parent="Widget.Material3.Button.TextButton">
+        <item name="strokeWidth">2dp</item>
+        <item name="strokeColor">@color/focus_ring</item>
+    </style>
+
+    <style name="Widget.JustPlus.Button.Quiet.Icon" parent="Widget.Material3.Button.IconButton">
+        <item name="strokeWidth">2dp</item>
+        <item name="strokeColor">@color/focus_ring</item>
+    </style>
+
+    <style name="Widget.JustPlus.Button.Outlined" parent="Widget.Material3.Button.OutlinedButton">
+        <item name="strokeWidth">2dp</item>
+        <item name="strokeColor">@color/focus_ring_outlined</item>
+    </style>
+
+    <style name="Widget.JustPlus.Button.Filled" parent="Widget.Material3.Button">
+        <item name="strokeWidth">2dp</item>
+        <item name="strokeColor">@color/focus_ring</item>
+    </style>
+
     <style name="Widget.JustPlus.Button.Dialog.Dismissive" parent="Widget.Material3.Button.TextButton.Dialog">
         <item name="android:textColor">@color/dialog_button_dismissive</item>
     </style>
@@ -144,6 +180,12 @@
     <style name="BaseTheme.Dialogs.Light" parent="Theme.Material3.Light.NoActionBar">
         <item name="alertDialogTheme">@style/ThemeOverlay.JustPlus.AlertDialog</item>
         <item name="materialAlertDialogTheme">@style/ThemeOverlay.JustPlus.AlertDialog</item>
+        <!-- Material's own button attributes, pointed at the three styles below, so every button in
+             here — including the ones no code of ours constructs — wears the focus ring. -->
+        <item name="materialButtonStyle">@style/Widget.JustPlus.Button.Filled</item>
+        <item name="materialButtonOutlinedStyle">@style/Widget.JustPlus.Button.Outlined</item>
+        <item name="materialIconButtonStyle">@style/Widget.JustPlus.Button.Quiet.Icon</item>
+        <item name="borderlessButtonStyle">@style/Widget.JustPlus.Button.Quiet</item>
         <!-- Not @color/brand: this theme is light whatever the system is doing, and the bright coral
              cannot be read on it. @color/brand_accent is the one value that works on both. -->
         <item name="colorPrimary">@color/brand_accent</item>
@@ -171,6 +213,12 @@
     <style name="BaseTheme.Dialogs.Dark" parent="Theme.Material3.Dark.NoActionBar">
         <item name="alertDialogTheme">@style/ThemeOverlay.JustPlus.AlertDialog</item>
         <item name="materialAlertDialogTheme">@style/ThemeOverlay.JustPlus.AlertDialog</item>
+        <!-- Material's own button attributes, pointed at the three styles below, so every button in
+             here — including the ones no code of ours constructs — wears the focus ring. -->
+        <item name="materialButtonStyle">@style/Widget.JustPlus.Button.Filled</item>
+        <item name="materialButtonOutlinedStyle">@style/Widget.JustPlus.Button.Outlined</item>
+        <item name="materialIconButtonStyle">@style/Widget.JustPlus.Button.Quiet.Icon</item>
+        <item name="borderlessButtonStyle">@style/Widget.JustPlus.Button.Quiet</item>
         <!-- The same accent the light panel uses, so a switch does not change colour with the theme.
              @color/brand stays what it always was: the chrome over video, which is never light. -->
         <item name="colorPrimary">@color/brand_accent</item>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -145,8 +145,8 @@
         <item name="alertDialogTheme">@style/ThemeOverlay.JustPlus.AlertDialog</item>
         <item name="materialAlertDialogTheme">@style/ThemeOverlay.JustPlus.AlertDialog</item>
         <!-- Not @color/brand: this theme is light whatever the system is doing, and the bright coral
-             cannot be read on it. See @color/brand_on_light. -->
-        <item name="colorPrimary">@color/brand_on_light</item>
+             cannot be read on it. @color/brand_accent is the one value that works on both. -->
+        <item name="colorPrimary">@color/brand_accent</item>
         <item name="colorPrimaryContainer">@color/brand_container</item>
         <item name="colorOnPrimary">@color/white</item>
         <!-- One answer to "this one is chosen", for every control that has to say it: the checked
@@ -155,12 +155,12 @@
              three said it three different ways — and the coral container the rows used measured 1.59:1
              against a dark card, a selection you had to look for. Pointed at the accent pair, all three
              read the same and clear 3:1 either way round. -->
-        <item name="colorSecondaryContainer">@color/brand_on_light</item>
-        <item name="colorOnSecondaryContainer">@color/white</item>
+        <item name="colorSecondaryContainer">@color/brand_accent</item>
+        <item name="colorOnSecondaryContainer">@color/brand_accent_on</item>
         <!-- The player's panels are built against these themes now, so they need the accent the
              window themes carry: Material 3 derives colorAccent from colorSecondary, not from
              colorPrimary, and would hand every AppCompat widget in here a baseline mauve. -->
-        <item name="colorAccent">@color/brand_on_light</item>
+        <item name="colorAccent">@color/brand_accent</item>
     </style>
 
     <!-- Split like Theme.Player, so values-television and values-notouch can give a panel the
@@ -171,21 +171,23 @@
     <style name="BaseTheme.Dialogs.Dark" parent="Theme.Material3.Dark.NoActionBar">
         <item name="alertDialogTheme">@style/ThemeOverlay.JustPlus.AlertDialog</item>
         <item name="materialAlertDialogTheme">@style/ThemeOverlay.JustPlus.AlertDialog</item>
-        <item name="colorPrimary">@color/brand</item>
+        <!-- The same accent the light panel uses, so a switch does not change colour with the theme.
+             @color/brand stays what it always was: the chrome over video, which is never light. -->
+        <item name="colorPrimary">@color/brand_accent</item>
         <item name="colorPrimaryContainer">@color/brand_container</item>
-        <item name="colorOnPrimary">@color/brand_on</item>
+        <item name="colorOnPrimary">@color/white</item>
         <!-- One answer to "this one is chosen", for every control that has to say it: the checked
              segment of a toggle group, the current row of a picker, the track of a switch. Material
              would give a checked segment colorSecondaryContainer, which this app leaves neutral, so the
              three said it three different ways — and the coral container the rows used measured 1.59:1
              against a dark card, a selection you had to look for. Pointed at the accent pair, all three
              read the same and clear 3:1 either way round. -->
-        <item name="colorSecondaryContainer">@color/brand</item>
-        <item name="colorOnSecondaryContainer">@color/brand_on</item>
+        <item name="colorSecondaryContainer">@color/brand_accent</item>
+        <item name="colorOnSecondaryContainer">@color/brand_accent_on</item>
         <!-- The player's panels are built against these themes now, so they need the accent the
              window themes carry: Material 3 derives colorAccent from colorSecondary, not from
              colorPrimary, and would hand every AppCompat widget in here a baseline mauve. -->
-        <item name="colorAccent">@color/brand</item>
+        <item name="colorAccent">@color/brand_accent</item>
     </style>
 
     <!-- Split like Theme.Player, so values-television and values-notouch can give a panel the

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -136,22 +136,27 @@
         as a fill it washed the accent out too, leaving 2.21:1 for the label on it.
     -->
     <style name="Widget.JustPlus.Button.Quiet" parent="Widget.Material3.Button.TextButton">
-        <item name="strokeWidth">2dp</item>
+        <item name="strokeWidth">@dimen/focus_ring_width</item>
         <item name="strokeColor">@color/focus_ring</item>
     </style>
 
     <style name="Widget.JustPlus.Button.Quiet.Icon" parent="Widget.Material3.Button.IconButton">
-        <item name="strokeWidth">2dp</item>
+        <item name="strokeWidth">@dimen/focus_ring_width</item>
         <item name="strokeColor">@color/focus_ring</item>
     </style>
 
+    <!-- The one style whose stroke is not only the ring: it is also the border that makes the button
+         outlined. So it keeps the thin border at rest and Utils.focusRing widens it to the ring's own
+         width while it holds focus, which is the second half of the signal. A grey border that only
+         changes colour is a weak event — measured 2.76:1 between the same pixels focused and not,
+         where a ring appearing on a picker row reads 16.30:1. -->
     <style name="Widget.JustPlus.Button.Outlined" parent="Widget.Material3.Button.OutlinedButton">
         <item name="strokeWidth">2dp</item>
         <item name="strokeColor">@color/focus_ring_outlined</item>
     </style>
 
     <style name="Widget.JustPlus.Button.Filled" parent="Widget.Material3.Button">
-        <item name="strokeWidth">2dp</item>
+        <item name="strokeWidth">@dimen/focus_ring_width</item>
         <item name="strokeColor">@color/focus_ring</item>
     </style>
 

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -115,20 +115,38 @@
          appearance choice on its own. Two explicit themes rather than one DayNight theme over an
          overridden configuration: createConfigurationContext returns a context with no activity
          token, and a dialog built against one cannot add its window at all. -->
-    <style name="Theme.Dialogs.Light" parent="Theme.Material3.Light.NoActionBar">
+    <style name="BaseTheme.Dialogs.Light" parent="Theme.Material3.Light.NoActionBar">
         <item name="alertDialogTheme">@style/ThemeOverlay.JustPlus.AlertDialog</item>
         <item name="materialAlertDialogTheme">@style/ThemeOverlay.JustPlus.AlertDialog</item>
         <item name="colorPrimary">@color/brand</item>
         <item name="colorPrimaryContainer">@color/brand_container</item>
         <item name="colorOnPrimary">@color/brand_on</item>
+        <!-- The player's panels are built against these themes now, so they need the accent the
+             window themes carry: Material 3 derives colorAccent from colorSecondary, not from
+             colorPrimary, and would hand every AppCompat widget in here a baseline mauve. -->
+        <item name="colorAccent">@color/brand</item>
     </style>
 
-    <style name="Theme.Dialogs.Dark" parent="Theme.Material3.Dark.NoActionBar">
+    <!-- Split like Theme.Player, so values-television and values-notouch can give a panel the
+         white focus wash a remote needs without redefining everything above. -->
+    <style name="Theme.Dialogs.Light" parent="BaseTheme.Dialogs.Light">
+    </style>
+
+    <style name="BaseTheme.Dialogs.Dark" parent="Theme.Material3.Dark.NoActionBar">
         <item name="alertDialogTheme">@style/ThemeOverlay.JustPlus.AlertDialog</item>
         <item name="materialAlertDialogTheme">@style/ThemeOverlay.JustPlus.AlertDialog</item>
         <item name="colorPrimary">@color/brand</item>
         <item name="colorPrimaryContainer">@color/brand_container</item>
         <item name="colorOnPrimary">@color/brand_on</item>
+        <!-- The player's panels are built against these themes now, so they need the accent the
+             window themes carry: Material 3 derives colorAccent from colorSecondary, not from
+             colorPrimary, and would hand every AppCompat widget in here a baseline mauve. -->
+        <item name="colorAccent">@color/brand</item>
+    </style>
+
+    <!-- Split like Theme.Player, so values-television and values-notouch can give a panel the
+         white focus wash a remote needs without redefining everything above. -->
+    <style name="Theme.Dialogs.Dark" parent="BaseTheme.Dialogs.Dark">
     </style>
 
     <style name="ExoStyledControls.Button.Center.Secondary" parent="ExoStyledControls.Button.Center">

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -12,6 +12,13 @@
         <item name="colorPrimary">@color/brand</item>
         <item name="colorPrimaryContainer">@color/brand_container</item>
         <item name="colorOnPrimary">@color/brand_on</item>
+        <!-- colorAccent is NOT derived from colorPrimary: Theme.Material3.Dark inherits it through
+             Theme.MaterialComponents, where Base.V14.Theme.MaterialComponents sets it to
+             ?attr/colorSecondary — a role this app leaves at the M3 default on purpose. Drop this line
+             and every AppCompat widget that reads the accent goes baseline mauve. AppCompat's own
+             colorControlActivated maps to ?attr/colorAccent (Base.V7.Theme.AppCompat), so setting that
+             as well is redundant; the framework's android:colorControlActivated is not, since it maps
+             from android:colorAccent, which nothing here sets. -->
         <item name="colorAccent">@color/brand</item>
         <item name="android:colorControlActivated">@color/brand</item>
     </style>
@@ -60,7 +67,6 @@
         <item name="colorPrimaryContainer">@color/brand_container</item>
         <item name="colorOnPrimary">@color/brand_on</item>
         <item name="colorAccent">@color/brand</item>
-        <item name="colorControlActivated">@color/brand</item>
         <item name="android:colorControlActivated">@color/brand</item>
     </style>
 


### PR DESCRIPTION
Puts the player's own chrome on Material 3 and settles the three things it kept getting wrong: what a focused control looks like, what a panel is, and what a row of a list actually says.

## D-pad focus

One ring, one meaning. Five places drew it and all five said 2dp by three routes that disagreed — `Utils.dpToPx` truncates, so a picker row's "2dp" arrived at 1.5dp where a button's identical 2dp arrived at 2.25dp — and none of them grew with the device class while the geometry beside them scales 1.30 on a television. One dimen now, wider under `values-television` and `values-notouch`.

- An outlined button's stroke is also its border, so it keeps the thin one at rest and widens to the ring on focus. A grey edge merely turning white measured 2.76:1 between the same pixels, against 16.30:1 for a ring appearing on a row that had none.
- Focus no longer dims what it lands on: Material's state layer on a checked segment is the dark ink that reads against the accent, so focusing the chosen pill darkened its coral (#D6493C → #C04236) and took the ring down with it. The controls that wear the ring wear Material's ripple with the focus layer removed.
- The signal follows the surface. Every indicator was hardcoded white, and two of the three screens that use one go light with the appearance choice: a white ring on a light card measured **1.15:1**, and a focused settings row **1.09:1** against its neighbours. They take the surface's own ink now — 14.85:1 on a light card, and on a dark one a near-white that reads as the white it replaces.

## Panels

Every panel opened from a player button is one shape, one size and one place, decided by the window and never by which button opened it.

- Compact width (a phone held upright) docks to the bottom edge: the edge's own width capped at Material's 640dp, square corners against the edge, 28dp on top, and the navigation bar's inset carried inside the sheet so its surface reaches the screen.
- Anything wider docks to the end edge with 16dp corners: a window held sideways keeps the height a bottom sheet would have taken, the strip of picture beside the panel is worth having, and a remote's focus travels along one side instead of across the bottom.
- That removed a `Panel` enum, a parameter at five call sites and two of three width tokens. The duration keypad now measures itself against the same width the window uses.

## Playlist

Rows lead with the frame the sender sent, 16:9, with the file's number in a label over it; where nothing was sent the frame says so with a glyph. Two arrangements — a row per file, and a rail of frames that scrolls sideways, offered only in landscape, since a rail needs width and gives up height. The choice is remembered.

The panel shows only what the player already knows, so the duration and resolution chips went: a chip that appears on one row in twenty reads as a fault. What is playing is said by the number it already has, in the accent with the accent's own ink (4.88:1, where the word "Playing" in white on that coral was 4.31:1 and illegible at three metres), and by the weight of the name. Nothing is painted under the row — the neutral step tried first measured 1.29:1 dark, 1.16:1 light and nothing at all under AMOLED.

Fixed on the way: the panel never scrolled to the item playing on any touch device, because the only scroll-to-current was a focus request and rows are not focusable in touch mode. A playlist of two hundred files opened at the first one.

## Menus and track rows

The overflow panel drew a card per group inside a sheet — a container inside a container whose tones are 1.23:1 apart, with three different left edges. It is a list on the sheet now, with a hairline where a boundary has no name, the icon 16dp in and its label at 56dp. The leading icons take the ink a leading icon is given: eight coral glyphs in a column is not a signature, and the same coral says "chosen" on the row that is.

A track row was one line in the header's shape, so a file whose tracks declare neither a name nor a language produced four rows reading `[AAC 2.0 298k]`, three identical to the eye. The name is on the first line now — the container's label, else the language, else the track's number — and the codec, channels and bitrate on the second, which is the shape the quality panel already used.

## Verified

On the `tv_720p` television emulator and a phone emulator in both orientations and both appearances, and installed on a phone for each step. Contrast figures above are measured off screenshots of the built app, not computed from tokens.

## Open, deliberately

- The subtitle offset panel now arrives from the bottom on a phone held upright like every other panel, which means it covers the subtitle line it retimes while open. It used to be the one exception; removing exceptions was the point. Restoring it is one condition in `Utils.pickerWindow` if that trade is judged the wrong way round.
- The playlist panel still builds every row up front and fires a thumbnail request per row. On long playlists (200+) that is worth a `RecyclerView`, but the cost has not been measured yet and there are cheaper rungs first — loading artwork only for visible rows, or building the first fifty and appending on scroll.
