### PR TITLE
Park the bottom bar by how tall it actually is

### DIFF
--- a/app/src/main/java/com/brouken/player/BottomBarLayout.java
+++ b/app/src/main/java/com/brouken/player/BottomBarLayout.java
@@ -1,0 +1,42 @@
+package com.brouken.player;
+
+import android.content.Context;
+import android.util.AttributeSet;
+import android.widget.FrameLayout;
+
+/**
+ * The bottom control bar, with one thing added: it travels as far as it is tall.
+ *
+ * <p>Media3 parks the bar off screen by translating it down by {@code exo_styled_bottom_bar_height} —
+ * a resource value read once and baked into PlayerControlViewLayoutManager's animators, so it never
+ * learns that the bar has since been resized. The bar is grown by the bottom inset (the navigation bar,
+ * or synthesized TV overscan) so its scrim keeps reaching the screen edge, which leaves it taller than
+ * that constant by exactly the inset: the park stopped short by the same amount and left the top of the
+ * bar — the top of the button row with it — sitting over the picture while only the seek bar was up.
+ *
+ * <p>Scaling every translation by how much taller the bar is restores the two ends the animators mean:
+ * flush at rest, fully parked when hidden, and no seam in between.
+ */
+public class BottomBarLayout extends FrameLayout {
+
+    private float travelScale = 1f;
+    private float travel;
+
+    public BottomBarLayout(Context context, AttributeSet attrs) {
+        super(context, attrs);
+    }
+
+    /** Bar height as laid out, over the {@code exo_styled_bottom_bar_height} Media3 parks it by. */
+    void setTravelScale(float scale) {
+        if (scale != travelScale) {
+            travelScale = scale;
+            super.setTranslationY(travel * scale);
+        }
+    }
+
+    @Override
+    public void setTranslationY(float translationY) {
+        travel = translationY;
+        super.setTranslationY(translationY * travelScale);
+    }
+}

--- a/app/src/main/java/com/brouken/player/PlayerActivity.java
+++ b/app/src/main/java/com/brouken/player/PlayerActivity.java
@@ -1982,10 +1982,15 @@ public class PlayerActivity extends Activity {
                 // pulls every child up off the screen edge, the two scrims included (the full-screen dim and
                 // the bar's own gradient), and what shows through underneath is a bright strip of raw video.
                 // On TV that inset is pure overscan, so the strip appeared with nothing drawn over it at all.
-                final FrameLayout exoBottomBar = findViewById(R.id.exo_bottom_bar);
+                final BottomBarLayout exoBottomBar = findViewById(R.id.exo_bottom_bar);
+                final int barHeight = getResources().getDimensionPixelSize(R.dimen.exo_styled_bottom_bar_height);
                 final ViewGroup.LayoutParams params = exoBottomBar.getLayoutParams();
-                params.height = getResources().getDimensionPixelSize(R.dimen.exo_styled_bottom_bar_height) + bottomBarPaddingBottom;
+                params.height = barHeight + bottomBarPaddingBottom;
                 exoBottomBar.setLayoutParams(params);
+                // Media3 parks the bar by that unchanged resource height, so tell it how much taller the bar
+                // now is -- without this the park stops the inset short and the button row's top stays over
+                // the picture for as long as the seek bar is up on its own.
+                exoBottomBar.setTravelScale((float) params.height / barHeight);
 
                 if (Build.VERSION.SDK_INT >= 35) {
                     findViewById(R.id.exo_left).getLayoutParams().width = windowInsets.getInsets(WindowInsets.Type.navigationBars()).left;

--- a/app/src/main/res/layout/exo_player_control_view.xml
+++ b/app/src/main/res/layout/exo_player_control_view.xml
@@ -10,7 +10,7 @@
       android:layoutDirection="ltr">
   </FrameLayout>
 
-  <FrameLayout android:id="@+id/exo_bottom_bar"
+  <com.brouken.player.BottomBarLayout android:id="@+id/exo_bottom_bar"
       android:layout_width="match_parent"
       android:layout_height="@dimen/exo_styled_bottom_bar_height"
       android:layout_marginTop="@dimen/exo_styled_bottom_bar_margin_top"
@@ -86,7 +86,7 @@
 
     </HorizontalScrollView>
 
-  </FrameLayout>
+  </com.brouken.player.BottomBarLayout>
 
   <com.brouken.player.CustomDefaultTimeBar android:id="@+id/exo_progress"
       android:layout_width="match_parent"


### PR DESCRIPTION
﻿## The bug

On Android TV, while only the seek bar is up after the controls fade, the top of the bottom bar's button block shows below it, over the picture, in the bottom-right corner (#176).

## Cause

`PlayerControlViewLayoutManager` parks `exo_bottom_bar` by translating it down by two constants read out of resources once, in its constructor, and baked into all five show/hide `AnimatorSet`s:

| stop | translation |
|---|---|
| controls up | `0` |
| seek bar alone | `exo_styled_bottom_bar_height - exo_styled_progress_bar_height` = 58dp |
| all hidden | `exo_styled_bottom_bar_height` = 60dp |

The bar's height is set to `exo_styled_bottom_bar_height + systemWindowInsetBottom + overscanV` so its scrim keeps reaching the screen edge. It is therefore taller than the distance it is parked by, by exactly the inset -- and exactly that much of it, its top edge and the top of the button row with it, stays on screen. Only in the seek-bar-alone state: at full hide the layout manager sets the whole `PlayerControlView` to `GONE`, which is why the leftover disappears together with the bar.

#173 did not create this geometry -- the API 35+ branch already grew the bar the same way. What hid the overshoot on API 34 and below was that the inset was taken as padding on `PlayerControlView`, and `clipToPadding` cut off everything below the padding box: the same clip that cut off the two scrims, which is the strip #173 fixed. One clip was hiding both, so removing it inherited the other.

So the split in the report reads as an Android version split, but the discriminator is TV vs phone: on a phone in fullscreen `systemWindowInsetBottom` is 0, the bar never grows, nothing overshoots. On a TV running Android 15+ the artefact was already there before 1.4.3.

## Fix

`BottomBarLayout` scales every translation by how much taller the bar is than the resource Media3 parks it by. A scale rather than a flat offset, so both ends the animators mean stay exact -- flush at rest, fully parked when hidden -- and the slide between them has no seam.

## Verification

TV emulator, 1280x720, density 213 (16dp = 21px), same clip and same frame both times.

Seek bar alone, column at x=1150:

- before -- dark chrome from `y=699` down to `y=719`: 21px of button panel under the line at `y=694..696`;
- after -- `y=694..696` only, the line itself, nothing below it.

Controls up, unchanged: the bottom columns at x=300 / 640 / 1000 read the same before and after, and the gradient still runs monotonically to row 719 (x=1000: `700:38 710:29 715:26 719:24`).

Closes #176
