### PR TITLE
Give the transfer figures a line of their own above the seek bar

### DIFF
--- a/app/src/main/java/com/brouken/player/PlayerActivity.java
+++ b/app/src/main/java/com/brouken/player/PlayerActivity.java
@@ -588,6 +588,7 @@ public class PlayerActivity extends Activity {
     private static final int ENDS_AT_COLOR = 0xB3FFFFFF;
     private TextView roomPill;
     private TextView statsView;
+    private TextView transferView;
     private OutlineTextClock overlayClock;
     private OutlineTextClock headerClock;
     private ImageButton buttonOpen;
@@ -1120,6 +1121,7 @@ public class PlayerActivity extends Activity {
             // The stats panel needs the same once-a-second tick over the same lifetime (controls visible),
             // so it rides this one rather than starting a second timer.
             updateStats();
+            updateTransfer();
             if (controllerVisible) {
                 playerView.postDelayed(this, 1000);
             }
@@ -1865,6 +1867,35 @@ public class PlayerActivity extends Activity {
         roomPill.setVisibility(View.GONE);
         coordinatorLayout.addView(roomPill);
 
+        // The transfer figures — buffer, network, bitrate — as one line on the room pill's slot, under a
+        // switch of their own: a viewer who wants to watch the buffer all evening does not want the whole
+        // stats panel over the picture for it. It takes the pill's exact geometry (set with the insets, so
+        // it follows the seek bar on every device) and yields to whichever pill wants that row — the room
+        // on this side, Skip on the other, which a full-width line does reach under in portrait.
+        // Monospace, like the panel, so the digits stand still.
+        transferView = new TextView(this);
+        transferView.setTextColor(0xB3FFFFFF);
+        transferView.setTypeface(Typeface.MONOSPACE);
+        transferView.setTextSize(TypedValue.COMPLEX_UNIT_SP, ui.textInfo());
+        // One row where it fits — landscape and TV — and three where it does not, which is a phone held
+        // upright (updateTransfer gives each figure its own row there) and any screen where the Skip
+        // pill has taken the end of the row. Ellipsising instead cost the bitrate, which is losing the
+        // point of the line. The fields carry non-breaking spaces, so a break the layout has to make
+        // falls between them rather than through a number.
+        transferView.setMaxLines(3);
+        transferView.setEllipsize(TextUtils.TruncateAt.END);
+        final GradientDrawable transferBackground = new GradientDrawable();
+        transferBackground.setColor(0x99000000);
+        transferBackground.setCornerRadius(ui.pillCorner());
+        transferView.setBackground(transferBackground);
+        transferView.setPadding(Utils.dpToPx(10), Utils.dpToPx(5), Utils.dpToPx(10), Utils.dpToPx(5));
+        final CoordinatorLayout.LayoutParams transferLp = new CoordinatorLayout.LayoutParams(
+                ViewGroup.LayoutParams.WRAP_CONTENT, ViewGroup.LayoutParams.WRAP_CONTENT);
+        transferLp.gravity = Gravity.BOTTOM | Gravity.START;
+        transferView.setLayoutParams(transferLp);
+        transferView.setVisibility(View.GONE);
+        coordinatorLayout.addView(transferView);
+
         // The room itself reads in the pill above; this floats only for the one thing that pill cannot say
         // in time — that the pause was the room's doing and not the viewer's, which has to show while the
         // controls are down. It goes under the centre disc, on the loading rate's geometry, because that is
@@ -2048,6 +2079,19 @@ public class PlayerActivity extends Activity {
                             + ui.dpS(24);
                     pillLp.leftMargin = insetH + ui.gridH();
                     roomPill.setLayoutParams(pillLp);
+                }
+
+                // The transfer line is the room pill's stand-in on the same slot, so it takes the pill's
+                // offsets verbatim; a right margin too, so a long line stops at the grid instead of the edge.
+                if (transferView != null) {
+                    final CoordinatorLayout.LayoutParams transferParams =
+                            (CoordinatorLayout.LayoutParams) transferView.getLayoutParams();
+                    transferParams.bottomMargin = windowInsets.getSystemWindowInsetBottom() + overscanV
+                            + getResources().getDimensionPixelSize(R.dimen.exo_styled_progress_margin_bottom)
+                            + ui.dpS(24);
+                    transferParams.leftMargin = insetH + ui.gridH();
+                    transferParams.rightMargin = insetH + ui.gridH();
+                    transferView.setLayoutParams(transferParams);
                 }
 
                 // Mirror of the Skip pill on the other edge: the stats panel floats on the same coordinator,
@@ -4230,7 +4274,10 @@ public class PlayerActivity extends Activity {
         buttonSkip.setFocusable(actionable);
         final boolean appearing = buttonSkip.getVisibility() != View.VISIBLE;
         if (appearing) {
+            // After the layout, not before it: what the transfer line has to give up is the pill's
+            // width, and a pill that has never been shown has none to read yet.
             buttonSkip.setVisibility(View.VISIBLE);
+            buttonSkip.post(this::updateTransfer);
         }
         if (isTvBox && actionable && claimFocus && (appearing || stateChanged)) {
             buttonSkip.requestFocus();
@@ -4308,6 +4355,7 @@ public class PlayerActivity extends Activity {
                 playerView.requestFocus();
             }
             buttonSkip.setVisibility(View.GONE);
+            updateTransfer(); // the whole row is the line's again
         }
     }
 
@@ -5237,6 +5285,9 @@ public class PlayerActivity extends Activity {
         if (statsView != null) {
             statsView.setVisibility(View.GONE);
         }
+        if (transferView != null) {
+            transferView.setVisibility(View.GONE);
+        }
     }
 
     /**
@@ -5244,11 +5295,8 @@ public class PlayerActivity extends Activity {
      * the same time, and repeating "1080p H264" there would be noise. What is left is the figures that
      * move and the decoder names the coarse codec label hides.
      *
-     * <p>Splitting the transfer figures (buffer, network, bitrate) out of here onto a line of their own,
-     * under a second switch, was tried and put back: everything they say is already on this panel, and
-     * the bottom bar has no band wide enough for them — the time is short, the button cluster is not, so
-     * a centred line is capped at twice the narrower side and loses the bitrate to an ellipsis on a TV.
-     * Worth revisiting only if the controls are laid out differently.
+     * <p>The transfer figures (buffer, network, bitrate) are listed here only while the transfer line is
+     * off: with it on they have their own place above the seek bar, and nothing is said twice.
      */
     private void updateStats() {
         if (statsView == null) {
@@ -5258,53 +5306,129 @@ public class PlayerActivity extends Activity {
             fadeChrome(statsView, false);
             return;
         }
-        final StringBuilder text = new StringBuilder();
-        // Ahead of the playhead, against the load control's target — the "how much slack is there"
-        // reading. On a local file this is always full, which is itself the answer.
-        final long bufferedMs = player.getTotalBufferedDuration();
-        text.append(getString(R.string.stats_buffer, bufferedMs / 1000,
-                (int) Math.min(100, bufferedMs * 100 / bufferCeilingMs())));
-        if (bandwidthBitrate > 0) {
-            text.append('\n').append(getString(R.string.stats_network,
-                    getString(R.string.quality_bitrate, bandwidthBitrate / 1_000_000f)));
-        }
+        final List<String> lines = new ArrayList<>();
         final Format video = player.getVideoFormat();
+        if (!mPrefs.showTransfer) {
+            lines.add(bufferText());
+            addIfAny(lines, networkText());
+        }
         if (video != null) {
-            text.append('\n').append(video.width).append('×').append(video.height);
+            lines.add(video.width + "×" + video.height);
             // Its own line rather than a third field: the panel has to stay narrower than the gap to the
             // centred transport buttons, and every line here is kept short enough to never wrap.
-            if (video.bitrate != Format.NO_VALUE) {
-                text.append('\n').append(getString(R.string.stats_stream,
-                        getString(R.string.quality_bitrate, video.bitrate / 1_000_000f)));
-            } else {
-                // Matroska and AVI carry no bitrate to read, so the whole file over its duration is all
-                // there is. Labelled apart from Stream: it counts audio and subtitles in too.
-                final float overall = overallBitrate();
-                if (overall > 0) {
-                    text.append('\n').append(getString(R.string.stats_overall,
-                            getString(R.string.quality_bitrate, overall)));
-                }
+            if (!mPrefs.showTransfer) {
+                addIfAny(lines, bitrateText(video));
             }
         }
         // The mime says "hevc"; only the decoder name says whether that went to the vendor's hardware
         // codec or to a software one, which is the whole question behind most "it stutters" reports.
         // One per line: the two of them on one line was the panel's widest content by a wide margin.
-        if (videoDecoderName != null) {
-            text.append('\n').append(videoDecoderName);
-        }
-        if (audioDecoderName != null) {
-            text.append('\n').append(audioDecoderName);
-        }
-        final String dolbyVision = dolbyVisionStatus();
-        if (dolbyVision != null) {
-            text.append('\n').append(dolbyVision);
-        }
+        addIfAny(lines, videoDecoderName);
+        addIfAny(lines, audioDecoderName);
+        addIfAny(lines, dolbyVisionStatus());
         final DecoderCounters counters = player.getVideoDecoderCounters();
         if (counters != null) {
-            text.append('\n').append(getString(R.string.stats_dropped, counters.droppedBufferCount));
+            lines.add(getString(R.string.stats_dropped, counters.droppedBufferCount));
         }
-        statsView.setText(text);
+        statsView.setText(TextUtils.join("\n", lines));
         fadeChrome(statsView, true);
+    }
+
+    /**
+     * The transfer line: buffer, network and bitrate on the row above the seek bar. Its own switch,
+     * because "watch the buffer" and "a panel over the picture" are different asks.
+     *
+     * <p>It shares that row with the two pills, and answers them differently because they stand in
+     * different places. The room pill holds this very slot, so the line gives it up and comes back when
+     * the room's badge goes. Skip is at the far end, and it can stand there for a whole opening — long
+     * enough that hiding the figures for its sake was the wrong trade — so the line stops short of it
+     * instead, taking a second or third row for what no longer fits beside it.
+     */
+    private void updateTransfer() {
+        if (transferView == null) {
+            return;
+        }
+        if (!mPrefs.showTransfer || player == null || !controllerChromeVisible || inPip
+                || isVisible(roomPill)) {
+            fadeChrome(transferView, false);
+            return;
+        }
+        final List<String> fields = new ArrayList<>();
+        addField(fields, bufferText());
+        addField(fields, networkText());
+        final Format video = player.getVideoFormat();
+        if (video != null) {
+            addField(fields, bitrateText(video));
+        }
+        // Upright the three never fit across the screen, so they stop pretending to be one line and take
+        // a row each. The separators go with the row they were separating: what tells two figures apart
+        // there is the line break, and a dot at the end of every row is only clutter.
+        final boolean portrait =
+                getResources().getConfiguration().orientation == Configuration.ORIENTATION_PORTRAIT;
+        transferView.setText(TextUtils.join(portrait ? "\n" : " · ", fields));
+        // Stop short of the Skip pill rather than step aside for it: the pill stands for a whole opening
+        // or a whole set of credits, and the figures would be gone for all of it. The pill's own width is
+        // the only thing that has to be read, and it is read on the tick that is running anyway.
+        final CoordinatorLayout.LayoutParams lp =
+                (CoordinatorLayout.LayoutParams) transferView.getLayoutParams();
+        final int row = coordinatorLayout.getWidth() - lp.leftMargin - lp.rightMargin;
+        final int free = isVisible(buttonSkip) ? row - buttonSkip.getWidth() - ui.dpS(8) : row;
+        if (free > 0) {
+            transferView.setMaxWidth(free);
+        }
+        fadeChrome(transferView, true);
+    }
+
+    private static boolean isVisible(@Nullable View view) {
+        return view != null && view.getVisibility() == View.VISIBLE;
+    }
+
+    /**
+     * A field of the transfer line, with its own spaces made non-breaking: the line wraps where it has to
+     * on a narrow screen, and the only place it may break is between two fields.
+     */
+    private static void addField(List<String> fields, @Nullable String value) {
+        if (value != null) {
+            fields.add(value.replace(' ', '\u00A0'));
+        }
+    }
+
+    private static void addIfAny(List<String> list, @Nullable String value) {
+        if (value != null) {
+            list.add(value);
+        }
+    }
+
+    /**
+     * Ahead of the playhead, against the load control's target — the "how much slack is there" reading.
+     * On a local file this is always full, which is itself the answer.
+     */
+    private String bufferText() {
+        final long bufferedMs = player.getTotalBufferedDuration();
+        return getString(R.string.stats_buffer, bufferedMs / 1000,
+                (int) Math.min(100, bufferedMs * 100 / bufferCeilingMs()));
+    }
+
+    /** The measured network rate, or null before the first estimate lands. */
+    @Nullable
+    private String networkText() {
+        return bandwidthBitrate > 0
+                ? getString(R.string.stats_network, getString(R.string.quality_bitrate, bandwidthBitrate / 1_000_000f))
+                : null;
+    }
+
+    /**
+     * The track's own bitrate where the container states one. Matroska and AVI carry none to read, so the
+     * whole file over its duration is all there is — labelled apart from Stream: it counts audio and
+     * subtitles in too. Null when neither is known.
+     */
+    @Nullable
+    private String bitrateText(Format video) {
+        if (video.bitrate != Format.NO_VALUE) {
+            return getString(R.string.stats_stream, getString(R.string.quality_bitrate, video.bitrate / 1_000_000f));
+        }
+        final float overall = overallBitrate();
+        return overall > 0 ? getString(R.string.stats_overall, getString(R.string.quality_bitrate, overall)) : null;
     }
 
 
@@ -9552,6 +9676,8 @@ public class PlayerActivity extends Activity {
                 roomPill.setCompoundDrawableTintList(ColorStateList.valueOf(tint));
             }
             fadeChrome(roomPill, showPill);
+            // The transfer line holds the pill's slot: it steps aside the moment the pill comes up.
+            updateTransfer();
         }
 
         // The float says only what the header cannot say in time: this pause is the room's, not yours. Bounded

--- a/app/src/main/java/com/brouken/player/Prefs.java
+++ b/app/src/main/java/com/brouken/player/Prefs.java
@@ -109,6 +109,7 @@ class Prefs {
     private static final String PREF_KEY_SHOW_CLOCK = "showClock";
     private static final String PREF_KEY_TIME_REMAINING = "timeRemaining";
     private static final String PREF_KEY_SHOW_STATS = "showStats";
+    private static final String PREF_KEY_SHOW_TRANSFER = "showTransfer";
     private static final String PREF_KEY_SYSTEM_VOLUME = "systemVolume";
     private static final String PREF_KEY_TOGETHER_NICK = "togetherNick";
     private static final String PREF_KEY_TOGETHER_PASSWORD = "togetherPassword";
@@ -269,6 +270,8 @@ class Prefs {
     /** Bottom bar counts down what is left instead of showing the total duration. */
     public boolean timeRemaining = false;
     public boolean showStats = false;
+    /** Buffer, network and bitrate on one line above the seek bar, apart from the stats panel. */
+    public boolean showTransfer = false;
     public boolean systemVolume = true;
     /** How other people in a watch-together room see this device. Generated once, then editable. */
     public String togetherNick = "";
@@ -431,6 +434,7 @@ class Prefs {
         showClock = mSharedPreferences.getBoolean(PREF_KEY_SHOW_CLOCK, showClock);
         timeRemaining = mSharedPreferences.getBoolean(PREF_KEY_TIME_REMAINING, timeRemaining);
         showStats = mSharedPreferences.getBoolean(PREF_KEY_SHOW_STATS, showStats);
+        showTransfer = mSharedPreferences.getBoolean(PREF_KEY_SHOW_TRANSFER, showTransfer);
         // Forced on for TV boxes, where the remote routes volume to the panel or receiver over CEC and
         // only the system stream responds — the setting is hidden there too.
         systemVolume = Utils.isTvBox(mContext) || mSharedPreferences.getBoolean(PREF_KEY_SYSTEM_VOLUME, systemVolume);

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -211,6 +211,9 @@
     <string name="stats_report_message">Отправьте эти подробности воспроизведения, сообщая о проблеме с изображением или звуком.</string>
     <string name="pref_show_stats_on">Буфер, декодеры и пропущенные кадры показываются с элементами управления</string>
     <string name="pref_show_stats_off">Подробности воспроизведения скрыты</string>
+    <string name="pref_show_transfer">Строка передачи</string>
+    <string name="pref_show_transfer_on">Буфер, сеть и битрейт показываются одной строкой над полосой перемотки</string>
+    <string name="pref_show_transfer_off">Показатели передачи остаются на панели статистики</string>
     <string name="pref_keep_awake_on_pause">Не гасить экран на паузе</string>
     <string name="pref_keep_awake_on_pause_on">Заставка устройства не включается; изображение затемняется через минуту, а через два часа экран отдаётся системе</string>
     <string name="pref_keep_awake_on_pause_off">Пауза остаётся на усмотрение устройства, и его заставка включается как обычно</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -218,6 +218,9 @@
     <string name="stats_report_message">Надішліть ці подробиці відтворення, повідомляючи про проблему із зображенням чи звуком.</string>
     <string name="pref_show_stats_on">Буфер, декодери та пропущені кадри показуються з елементами керування</string>
     <string name="pref_show_stats_off">Подробиці відтворення приховані</string>
+    <string name="pref_show_transfer">Рядок передачі</string>
+    <string name="pref_show_transfer_on">Буфер, мережа та бітрейт показуються одним рядком над смугою перемотування</string>
+    <string name="pref_show_transfer_off">Показники передачі залишаються на панелі статистики</string>
     <string name="pref_keep_awake_on_pause">Не вимикати екран на паузі</string>
     <string name="pref_keep_awake_on_pause_on">Заставка пристрою не вмикається; зображення тьмяніє через хвилину, а через дві години екран віддається системі</string>
     <string name="pref_keep_awake_on_pause_off">Пауза лишається на розсуд пристрою, і його заставка вмикається як завжди</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -239,6 +239,9 @@
     <string name="stats_report_message">Send these playback details when reporting a problem with picture or sound.</string>
     <string name="pref_show_stats_on">Buffer, decoders and dropped frames are shown with the player controls</string>
     <string name="pref_show_stats_off">Playback details stay hidden</string>
+    <string name="pref_show_transfer">Transfer line</string>
+    <string name="pref_show_transfer_on">Buffer, network and bitrate are shown on one line above the seek bar</string>
+    <string name="pref_show_transfer_off">Transfer figures stay in the statistics panel</string>
     <string name="pref_keep_awake_on_pause">Keep the screen on while paused</string>
     <string name="pref_keep_awake_on_pause_on">The device screensaver stays away; the picture dims after a minute and the screen is released after two hours</string>
     <string name="pref_keep_awake_on_pause_off">A pause is left to the device, and its screensaver comes on as usual</string>

--- a/app/src/main/res/xml/root_preferences.xml
+++ b/app/src/main/res/xml/root_preferences.xml
@@ -314,6 +314,13 @@
             app:title="@string/stats_title" />
 
         <SwitchPreferenceCompat
+            app:key="showTransfer"
+            app:defaultValue="false"
+            app:summaryOn="@string/pref_show_transfer_on"
+            app:summaryOff="@string/pref_show_transfer_off"
+            app:title="@string/pref_show_transfer" />
+
+        <SwitchPreferenceCompat
             app:key="keepAwakeOnPause"
             app:defaultValue="true"
             app:summaryOn="@string/pref_keep_awake_on_pause_on"


### PR DESCRIPTION
Second attempt at the transfer line from #126 (c), anchored as #178 proposes.

- New switch `Transfer line` (`showTransfer`) next to `Statistics` in settings.
- `Buffer · Network · Stream/Average` on the row above the seek bar, left-aligned to the content grid. Its margins are set in the same inset pass as the seek bar and the two pills, so it cannot drift on a nav bar or TV overscan.
- It shares that row with the two pills and answers them differently, because they stand in different places. The room pill holds the line's own slot, so the line gives it up and returns when the badge goes. Skip is at the far end and can stand there for a whole opening, so the line gives up only the width the pill occupies, read from the pill itself on the tick that is already running.
- Held upright, a phone has no row wide enough for the three figures, so in portrait they take a row each and drop the separators — the break is what tells them apart. Landscape and TV keep the single row. Where Skip has taken the end of a single row, the wrap falls between fields, never through a number: the fields carry non-breaking spaces.
- With the line on, the stats panel drops buffer, network and bitrate — nothing is shown twice. With it off, the panel lists them exactly as before.
- Strings in en/uk/ru.

Verified on the TV emulator (1280×720, one row with separators) and on a phone emulator (1080×2400, portrait, Ukrainian): three rows without separators, no overlap with the Skip pill, and the panel trimmed with the line on and untouched with it off.

Closes #178