### PR TITLE
Let a TV remote's EXIT key leave the player

### DIFF
--- a/app/src/main/java/com/brouken/player/PlayerActivity.java
+++ b/app/src/main/java/com/brouken/player/PlayerActivity.java
@@ -3265,6 +3265,17 @@ public class PlayerActivity extends Activity {
                 // Handled in onBackPressed(), the one path every API level shares. The case still has to
                 // exist so Back does not fall into default: below, which would show the controller.
                 break;
+            case KeyEvent.KEYCODE_ESCAPE:
+                // A TV remote's EXIT key commonly arrives as ESCAPE. Left unhandled it falls into default:
+                // below, which consumes it to raise the controller — so the ESCAPE→BACK fallback the
+                // framework would otherwise synthesise never happens, and the key cannot leave the player
+                // in the one state it still could: with the controls up, where default: lets it through.
+                // Route it to the same exit path as Back instead. Consuming it here is what keeps that
+                // fallback from firing a second Back on top. Dialogs are unaffected — they own the window,
+                // so this never runs while one is up and EXIT keeps closing them.
+                if (event.getRepeatCount() == 0)
+                    onBackPressed();
+                return true;
             case KeyEvent.KEYCODE_UNKNOWN:
                 return super.onKeyDown(keyCode, event);
             default:


### PR DESCRIPTION
A viewer on an Android 7 TV box (Formuler 4K S Turbo Pro, Openbox remote) reports that EXIT stopped leaving the player after `v0.1.7`. They installed every version down from 1.4.x to find where it still worked.

### What is happening

Their EXIT key is not `KEYCODE_BACK`. Three observations pin that down: the "Press back again to exit" hint never appears, EXIT instead "opens the same thing as OK" — the signature of the `default:` arm of `onKeyDown`, which consumes any unknown keycode to raise the controller — and the playlist window *does* close with EXIT.

The key is almost certainly `KEYCODE_ESCAPE`, handled nowhere in the app, and it reaches Back only through the framework's unhandled-key fallback (`ESCAPE → BACK` in the key character map), which is generated only when the app leaves the key unconsumed. Hence the one invariant that explains every observation: **EXIT acts as Back exactly where the app does not consume it.**

| observation | consumed by the app? | what the viewer sees |
|---|---|---|
| playlist dialog open | no — the dialog owns the window, the activity's key handlers are out of the path | dialog closes |
| `v0.1.7`, paused, controls up | no — `default:` lets it through when `controllerVisibleFully` | player exits |
| controls down, any version | yes — `default:` → `showController()` | panel opens, nothing else |
| current, paused, controls up | no, but the resulting Back hits the "hide the controls" step | panel closes, no way out |

The last row is the regression. #78 moved Back handling into `onBackPressed` and added the TV ladder, so the fallback Back is now absorbed by `if (controllerVisible) { hideController(); }`. The two states feed each other and the exit confirmation is never reached.

### The change

One `case` in `onKeyDown`: route `KEYCODE_ESCAPE` to `onBackPressed()` and consume it, so no second Back is synthesised on top. `getRepeatCount() == 0` keeps a held key from walking the ladder.

Nothing about the Back ladder changes — plain Back behaves exactly as before, on TV and elsewhere. `dispatchKeyEvent` is untouched: its TV branch already hands keys to `onKeyDown` with the controls down, and `super.dispatchKeyEvent` gets there with them up. (Intercepting the key *in* `dispatchKeyEvent` is what #91 warns against: it breaks key tracking and leaves Back dead below Android 13.)

### Checked on the `tv_720p` emulator

- ESCAPE with the controls down → hint, second press exits to the launcher.
- ESCAPE held (`--longpress`) → hint once, the ladder does not cascade.
- With **Single-press Back** enabled, one ESCAPE with the controls down exits; with the controls up the first press closes them first, identical to Back.
- Plain Back unchanged: one press hides the controls when they are up, two presses exit when they are down.
- Subtitles dialog open → ESCAPE closes only the dialog, playback continues; a probe confirmed `onBackPressed` is not reached at all, even with single-press Back on, which would otherwise have exited instantly.