### PR TITLE
One button system: a contour on every control, and a corner that says what it is

### DIFF
--- a/app/src/main/java/com/brouken/player/DurationPanel.java
+++ b/app/src/main/java/com/brouken/player/DurationPanel.java
@@ -13,6 +13,7 @@ import android.view.Gravity;
 import android.view.KeyEvent;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.FrameLayout;
 import android.widget.LinearLayout;
 import android.widget.ScrollView;
 import android.widget.TextView;
@@ -254,12 +255,13 @@ final class DurationPanel {
         final MaterialButton backspace = Utils.iconButton(ctx, ui, R.drawable.ic_backspace_24dp,
                 R.string.sleep_timer_backspace, true);
         // Square, not the field's height: it is a circle now that it carries an edge, and a 48 × 72 one
-        // is an oval. Nudged down by half the difference so it still centres on the fields beside it,
-        // which is what the row's TOP gravity was giving it for free while it was as tall as they are.
-        final LinearLayout.LayoutParams backspaceLp =
-                new LinearLayout.LayoutParams(backspaceBox, backspaceBox);
-        backspaceLp.topMargin = (boxH - backspaceBox) / 2;
-        valueRow.addView(backspace, backspaceLp);
+        // is an oval. It takes a slot as tall as a field and centres in it, rather than being nudged
+        // down by half the difference — the row is as tall as a field plus the unit named under it, so
+        // arithmetic from the row's own top put the circle 22dp below the middle of the fields.
+        final FrameLayout backspaceSlot = new FrameLayout(ctx);
+        backspaceSlot.addView(backspace,
+                new FrameLayout.LayoutParams(backspaceBox, backspaceBox, Gravity.CENTER));
+        valueRow.addView(backspaceSlot, new LinearLayout.LayoutParams(backspaceBox, boxH));
 
         // Where the duration lands in wall-clock terms — the same phrasing the header uses for the end
         // of the video, since it answers the same question.

--- a/app/src/main/java/com/brouken/player/DurationPanel.java
+++ b/app/src/main/java/com/brouken/player/DurationPanel.java
@@ -92,14 +92,25 @@ final class DurationPanel {
         // backspace on the other, and neither wins by being asked first.
         final int colW = landscape ? (usableW - colGap) / 2 : usableW;
 
-        // Portrait has height to spare, so the rows simply take VLC's own size. Landscape has to divide
-        // what is left of the window: a phone held sideways is 411dp tall and the docked card gets 346
-        // of that once the margins and the bars are out, of which the padding, the title and the
-        // durations row spend 140. Hence the 205 — 64 of insets and margins the panel never sees plus
-        // those 140 — and hence the keypad standing beside the readout rather than under it.
-        final int rowHeight = ui.dp(landscape
-                ? Math.max(36, Math.min(52, (cfg.screenHeightDp - 205) / 4 - 8))
-                : 52);
+        // Sideways the keypad turns: four columns by three rows rather than three by four. Three rows
+        // of 48dp with their gaps are 160, which is exactly what the readout's column beside it needs
+        // for its own three controls — so the two columns match line for line, and every key is the
+        // size of every other control in the panel instead of the 36dp that were left over. The digits
+        // keep their 3x3 block and the fourth column takes what is not a digit; a keypad is read by the
+        // shape of that block, and the shape does not move.
+        //
+        // A short window sideways cannot hold both ways of naming a duration. Measured on a phone held
+        // sideways — 360dp tall, of which insets and margins take 88 and the card's own padding and
+        // title another 84 — the body is left 132dp, and the keypad alone wants 168 at its smallest
+        // legal row. The ready-made durations are the 56dp that unblock it, and they are the half the
+        // keypad can say in two presses; a length nobody thought to offer has no other way in at all.
+        // So they stand down on a window this short, and nowhere else: a television is 541dp tall and
+        // keeps both, as does any tablet.
+        final boolean presets = !landscape || cfg.screenHeightDp >= 420;
+        // Portrait has height to spare, so the rows simply take VLC's own size. Landscape divides what
+        // is left: 205 is 64dp of insets and margins the panel never sees plus the 140 the padding, the
+        // title and the durations row spend — less those 56 when the durations are not there.
+        final int rowHeight = landscape ? ui.dpS(48) : ui.dp(52);
 
         // Built against the appearance choice rather than the player's own dark theme — see
         // OffsetPanel for the same move and Utils.dialogContext for what it resolves.
@@ -144,7 +155,9 @@ final class DurationPanel {
                 ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT);
         durationsLp.topMargin = Utils.dpToPx(8);
         durations.setLayoutParams(durationsLp);
-        root.addView(durations);
+        if (presets) {
+            root.addView(durations);
+        }
 
         // What is armed is checked by the readout pass below, never here: check() fires the same
         // listener a press does, and a panel that armed the running timer again as it opened would
@@ -174,7 +187,8 @@ final class DurationPanel {
         readoutColumn.setOrientation(LinearLayout.VERTICAL);
         readoutColumn.setLayoutParams(new LinearLayout.LayoutParams(
                 landscape ? colW : ViewGroup.LayoutParams.MATCH_PARENT,
-                ViewGroup.LayoutParams.WRAP_CONTENT));
+                landscape ? ViewGroup.LayoutParams.MATCH_PARENT
+                        : ViewGroup.LayoutParams.WRAP_CONTENT));
         body.addView(readoutColumn);
 
         // A duration and "however long this file has left" are one choice — what stops the film — so
@@ -202,6 +216,13 @@ final class DurationPanel {
         // rather than an input: the keypad below fills them, and a tap on one picks nothing.
         final LinearLayout valueRow = new LinearLayout(ctx);
         valueRow.setOrientation(LinearLayout.HORIZONTAL);
+        // A horizontal LinearLayout lines its children up by the baseline of their text unless told not
+        // to, and that is what cut the fields off. The row is as tall as the colon and the backspace
+        // beside them; the fields, shifted down to put their baseline on the colon's, then ran 5dp past
+        // its bottom and were clipped there — square corners under rounded ones, and the digits' feet
+        // gone with them. They are all centred in boxes of the same height, so the baseline they would
+        // be aligned to is the one they already share.
+        valueRow.setBaselineAligned(false);
         // Top, so the colon and the backspace centre on the fields themselves rather than on the
         // fields plus the unit named under them. Centred as well where the row is wider than the two
         // fields, the spacer and the backspace it holds — packed from the start edge, the pair of
@@ -209,7 +230,9 @@ final class DurationPanel {
         valueRow.setGravity(landscape ? Gravity.TOP : (Gravity.TOP | Gravity.CENTER_HORIZONTAL));
         final LinearLayout.LayoutParams valueLp = new LinearLayout.LayoutParams(
                 ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT);
-        valueLp.topMargin = Utils.dpToPx(24); // the gap that separates the picked from the typed
+        // The gap that separates the picked from the typed. Sideways there is no height to spend on
+        // saying it twice — the column already sets the readout apart by standing it under a button.
+        valueLp.topMargin = Utils.dpToPx(landscape ? 8 : 24);
         valueRow.setLayoutParams(valueLp);
         readoutColumn.addView(valueRow);
 
@@ -233,7 +256,11 @@ final class DurationPanel {
         // And 72dp tall, except where the height is the scarce dimension: sideways the column has 206dp
         // for the end-of-file button, the readout, its wall-clock line and the actions, and at Material's
         // own size the actions came to rest below the bottom of the card.
-        final int boxH = ui.dpS(landscape ? 56 : 72);
+        // Material's 72dp field upright. Sideways it is exactly one row of the keypad standing beside
+        // it — the readout, the button above it and the actions below then draw the same three lines as
+        // the keys do, which is the whole point of putting them side by side. The digits are 40sp,
+        // whose cap height is about 28dp, so they sit in 48 without touching its edges.
+        final int boxH = landscape ? rowHeight : ui.dpS(72);
         final int fieldFill = MaterialColors.getColor(ctx, R.attr.colorSurfaceContainerHighest,
                 ContextCompat.getColor(ctx, R.color.sheet_surface));
 
@@ -285,7 +312,13 @@ final class DurationPanel {
         endsAt.setTextSize(TypedValue.COMPLEX_UNIT_SP, ui.textEndsAt());
         endsAt.setGravity(centred ? Gravity.CENTER_HORIZONTAL : Gravity.START);
         endsAt.setPadding(0, Utils.dpToPx(4), 0, 0);
-        readoutColumn.addView(endsAt);
+        // Portrait only. Sideways this is the one line in the column that is derived rather than
+        // pressed — the readout right above it already says how long is left — and it is what put the
+        // actions past the bottom of the card on both short windows: 11dp on a phone, 12 on a
+        // television, where every control is a third larger again.
+        if (!landscape) {
+            readoutColumn.addView(endsAt);
+        }
 
         // Right-aligned at the foot, as Material ends a sheet: the way out of a running timer, then the
         // one action a typed length needs.
@@ -371,13 +404,16 @@ final class DurationPanel {
         final LinearLayout.LayoutParams keypadLp = new LinearLayout.LayoutParams(
                 landscape ? colW : ViewGroup.LayoutParams.MATCH_PARENT,
                 ViewGroup.LayoutParams.WRAP_CONTENT);
-        keypadLp.topMargin = Utils.dpToPx(8);
+        // Sideways this column stands beside the readout rather than under it, so the gap belongs to the
+        // rows inside it — with both, the keypad started 8dp below the button it sits next to.
+        keypadLp.topMargin = landscape ? 0 : Utils.dpToPx(8);
         if (landscape) {
             keypadLp.setMarginStart(colGap);
         }
         keypad.setLayoutParams(keypadLp);
+        final int cols = landscape ? 4 : 3;
         for (int row = 0; row < 3; row++) {
-            final LinearLayout line = keyRow(ctx, rowHeight);
+            final LinearLayout line = keyRow(ctx, rowHeight, cols);
             for (int col = 0; col < 3; col++) {
                 final int digit = row * 3 + col + 1;
                 final View key = keyButton(ctx, ui, String.valueOf(digit),
@@ -385,20 +421,37 @@ final class DurationPanel {
                 digitKeys[digit] = key;
                 line.addView(key);
             }
+            if (landscape) {
+                // The fourth column, top to bottom: the two minute values worth a shortcut, then the
+                // zero — where a calculator keeps it, and the only one of the three that is a digit.
+                if (row == 0) {
+                    line.addView(keyButton(ctx, ui, ":00", () -> appendMinutes(typed, 0, render)));
+                } else if (row == 1) {
+                    line.addView(keyButton(ctx, ui, ":30", () -> appendMinutes(typed, 30, render)));
+                } else {
+                    digitKeys[0] = keyButton(ctx, ui, "0", () -> appendDigit(typed, 0, render));
+                    line.addView(digitKeys[0]);
+                }
+            }
             keypad.addView(line);
         }
-        // Last row as VLC has it: the two minute values worth a shortcut, either side of the zero.
-        final LinearLayout lastRow = keyRow(ctx, rowHeight);
-        lastRow.addView(keyButton(ctx, ui, ":00", () -> appendMinutes(typed, 0, render)));
-        digitKeys[0] = keyButton(ctx, ui, "0", () -> appendDigit(typed, 0, render));
-        lastRow.addView(digitKeys[0]);
-        lastRow.addView(keyButton(ctx, ui, ":30", () -> appendMinutes(typed, 30, render)));
-        keypad.addView(lastRow);
+        if (!landscape) {
+            // Last row as VLC has it: the two minute values worth a shortcut, either side of the zero.
+            final LinearLayout lastRow = keyRow(ctx, rowHeight, cols);
+            lastRow.addView(keyButton(ctx, ui, ":00", () -> appendMinutes(typed, 0, render)));
+            digitKeys[0] = keyButton(ctx, ui, "0", () -> appendDigit(typed, 0, render));
+            lastRow.addView(digitKeys[0]);
+            lastRow.addView(keyButton(ctx, ui, ":30", () -> appendMinutes(typed, 30, render)));
+            keypad.addView(lastRow);
+        }
         body.addView(keypad);
 
         // The foot of its own column either way: under the readout when the keypad is beside it, under
-        // everything when the keypad is below it.
+        // everything when the keypad is below it. Sideways the column is as tall as the keypad standing
+        // next to it, so a spring above the actions puts them on the keypad's own last line — two
+        // columns that end together read as one block, and two that end 11dp apart read as a mistake.
         if (landscape) {
+            readoutColumn.addView(new View(ctx), new LinearLayout.LayoutParams(1, 0, 1f));
             readoutColumn.addView(actions);
         } else {
             root.addView(actions);
@@ -481,11 +534,18 @@ final class DurationPanel {
         box.setTextSize(TypedValue.COMPLEX_UNIT_SP, ui.textValue());
         box.setFontFeatureSettings("tnum"); // fixed-width digits: the readout stops twitching as it fills
         box.setGravity(Gravity.CENTER);
+        // Without this a 40sp digit carries about 5dp of font padding it never draws in, which is what
+        // made the readout 53dp tall inside a 48dp box sideways — and a column 5dp taller than the
+        // keypad beside it takes those 5 out of the actions at its foot. The glyphs stay centred.
+        box.setIncludeFontPadding(false);
         box.setMinHeight(height); // a minimum, not a height: the digits follow the system font scale
         final GradientDrawable container = new GradientDrawable();
         container.setCornerRadius(ui.pillCorner()); // 8dp, Material's small corner, as its field wears
         container.setColor(fill);
         box.setBackground(container);
+        // A minimum and not a fixed height: forced to exactly the row's height the box came out shorter
+        // than the digits it holds and cut their feet off. Without the font padding the 40sp numerals
+        // measure just under a 48dp row, so the minimum is what decides the box and nothing is clipped.
         box.setLayoutParams(new LinearLayout.LayoutParams(width, ViewGroup.LayoutParams.WRAP_CONTENT));
         return box;
     }
@@ -533,10 +593,10 @@ final class DurationPanel {
         return button;
     }
 
-    private static LinearLayout keyRow(final Context ctx, final int rowHeight) {
+    private static LinearLayout keyRow(final Context ctx, final int rowHeight, final int cols) {
         final LinearLayout line = new LinearLayout(ctx);
         line.setOrientation(LinearLayout.HORIZONTAL);
-        line.setWeightSum(3f);
+        line.setWeightSum(cols);
         final LinearLayout.LayoutParams lp = new LinearLayout.LayoutParams(
                 ViewGroup.LayoutParams.MATCH_PARENT, rowHeight);
         lp.topMargin = Utils.dpToPx(8);

--- a/app/src/main/java/com/brouken/player/DurationPanel.java
+++ b/app/src/main/java/com/brouken/player/DurationPanel.java
@@ -214,17 +214,22 @@ final class DurationPanel {
         readoutColumn.addView(valueRow);
 
         final int backspaceBox = ui.dp(48);
+        // Material's floor between two touch targets, and the reason it is needed here rather than
+        // assumed: the button used to be a bare glyph, so nothing of it reached the field. A circle with
+        // an edge does, and at no gap at all it read as attached to the minutes.
+        final int backspaceGap = ui.dp(8);
         final int colonW = ui.dp(20);
         // Portrait has the room to hang the backspace off the end and still centre the fields, which is
         // what the leading spacer buys; half a landscape panel does not, so there the pair sits from the
         // start edge and the backspace follows it.
         final boolean centred = !landscape;
         if (centred) {
-            valueRow.addView(new View(ctx), new LinearLayout.LayoutParams(backspaceBox, 1));
+            valueRow.addView(new View(ctx),
+                    new LinearLayout.LayoutParams(backspaceBox + backspaceGap, 1));
         }
         // Material's field is 96dp wide; narrower only when the column cannot seat two of them.
         final int boxW = Math.min(ui.dpS(96),
-                (colW - colonW - backspaceBox - (centred ? backspaceBox : 0)) / 2);
+                (colW - colonW - (backspaceBox + backspaceGap) * (centred ? 2 : 1)) / 2);
         // And 72dp tall, except where the height is the scarce dimension: sideways the column has 206dp
         // for the end-of-file button, the readout, its wall-clock line and the actions, and at Material's
         // own size the actions came to rest below the bottom of the card.
@@ -259,9 +264,19 @@ final class DurationPanel {
         // down by half the difference — the row is as tall as a field plus the unit named under it, so
         // arithmetic from the row's own top put the circle 22dp below the middle of the fields.
         final FrameLayout backspaceSlot = new FrameLayout(ctx);
+        // Optically, not geometrically: the glyph's box is centred but its mass is not — the left end
+        // is an arrow point and the right a full-height rectangle, which puts its ink centroid 1.10dp
+        // right of the middle. Padding is asymmetric by that much, since MaterialButton lays the icon
+        // against paddingStart; the circle it sits in does not move.
+        final int nudge = ui.dp(1);
+        backspace.setPadding(backspace.getPaddingLeft() - nudge, backspace.getPaddingTop(),
+                backspace.getPaddingRight() + nudge, backspace.getPaddingBottom());
         backspaceSlot.addView(backspace,
                 new FrameLayout.LayoutParams(backspaceBox, backspaceBox, Gravity.CENTER));
-        valueRow.addView(backspaceSlot, new LinearLayout.LayoutParams(backspaceBox, boxH));
+        final LinearLayout.LayoutParams slotLp =
+                new LinearLayout.LayoutParams(backspaceBox, boxH);
+        slotLp.setMarginStart(backspaceGap);
+        valueRow.addView(backspaceSlot, slotLp);
 
         // Where the duration lands in wall-clock terms — the same phrasing the header uses for the end
         // of the video, since it answers the same question.

--- a/app/src/main/java/com/brouken/player/DurationPanel.java
+++ b/app/src/main/java/com/brouken/player/DurationPanel.java
@@ -3,7 +3,6 @@ package com.brouken.player;
 import android.app.Activity;
 import android.app.Dialog;
 import android.content.Context;
-import android.content.res.ColorStateList;
 import android.content.res.Configuration;
 import android.graphics.Color;
 import android.graphics.Typeface;
@@ -14,8 +13,6 @@ import android.view.Gravity;
 import android.view.KeyEvent;
 import android.view.View;
 import android.view.ViewGroup;
-import android.widget.ImageButton;
-import android.widget.ImageView;
 import android.widget.LinearLayout;
 import android.widget.ScrollView;
 import android.widget.TextView;
@@ -250,18 +247,19 @@ final class DurationPanel {
         valueRow.addView(landscape ? minutes
                 : unitColumn(ctx, ui, minutes, activity.getString(R.string.duration_minutes), dim));
 
-        final ImageButton backspace = new ImageButton(ctx, null, 0,
-                R.style.ExoStyledControls_Button_Bottom);
-        backspace.setImageResource(R.drawable.ic_backspace_24dp);
-        backspace.setContentDescription(activity.getString(R.string.sleep_timer_backspace));
-        // The style behind it draws for the chrome over video, which is never light: white on a light
-        // panel is a glyph that is not there. Tinted like the unit labels beside it instead.
-        backspace.setImageTintList(ColorStateList.valueOf(dim));
-        // And it scales fitXY, which is fine for the square buttons of the control row but not here: the
-        // button is as tall as the field it belongs to, so the 24dp glyph came out 24 × 48 and read as a
-        // narrow sliver. Drawn at its own size, centred in whatever the button measures.
-        backspace.setScaleType(ImageView.ScaleType.CENTER_INSIDE);
-        valueRow.addView(backspace, new LinearLayout.LayoutParams(backspaceBox, boxH));
+        // A Material icon button with an edge, like the ± of the other panels: it stands beside the
+        // fields rather than inside a bar, so nothing else says where it begins. It replaced a Media3
+        // ExoStyledControls button, which drew for the chrome over video — white on a light panel is a
+        // glyph that is not there — and scaled fitXY, which stretched the 24dp glyph to 24 × 48.
+        final MaterialButton backspace = Utils.iconButton(ctx, ui, R.drawable.ic_backspace_24dp,
+                R.string.sleep_timer_backspace, true);
+        // Square, not the field's height: it is a circle now that it carries an edge, and a 48 × 72 one
+        // is an oval. Nudged down by half the difference so it still centres on the fields beside it,
+        // which is what the row's TOP gravity was giving it for free while it was as tall as they are.
+        final LinearLayout.LayoutParams backspaceLp =
+                new LinearLayout.LayoutParams(backspaceBox, backspaceBox);
+        backspaceLp.topMargin = (boxH - backspaceBox) / 2;
+        valueRow.addView(backspace, backspaceLp);
 
         // Where the duration lands in wall-clock terms — the same phrasing the header uses for the end
         // of the video, since it answers the same question.
@@ -282,12 +280,12 @@ final class DurationPanel {
         actionsLp.topMargin = Utils.dpToPx(landscape ? 8 : 16);
         actions.setLayoutParams(actionsLp);
 
-        final MaterialButton off = action(ctx, ui, ctx.getString(R.string.sleep_timer_off));
+        final MaterialButton off = action(ctx, ui, ctx.getString(R.string.sleep_timer_off), false);
         off.setOnClickListener(v -> {
             listener.onDurationPicked(0);
             dialog.dismiss();
         });
-        final MaterialButton start = action(ctx, ui, ctx.getString(R.string.sleep_timer_start));
+        final MaterialButton start = action(ctx, ui, ctx.getString(R.string.sleep_timer_start), true);
         final LinearLayout.LayoutParams startLp = new LinearLayout.LayoutParams(
                 ViewGroup.LayoutParams.WRAP_CONTENT, ViewGroup.LayoutParams.WRAP_CONTENT);
         startLp.setMarginStart(Utils.dpToPx(8));
@@ -492,10 +490,17 @@ final class DurationPanel {
         return column;
     }
 
-    /** One of the two actions at the foot — outlined, as every button this app's panels carry is. */
-    private static MaterialButton action(final Context ctx, final UiMetrics ui, final String label) {
-        final MaterialButton button = new MaterialButton(ctx, null,
-                com.google.android.material.R.attr.materialButtonOutlinedStyle);
+    /**
+     * One of the two actions at the foot.
+     *
+     * @param filled the one action that arms the timer; everything else on a surface is outlined, and a
+     *               panel is allowed exactly one filled control — the thing it exists to do
+     */
+    private static MaterialButton action(final Context ctx, final UiMetrics ui, final String label,
+                                         final boolean filled) {
+        final MaterialButton button = new MaterialButton(ctx, null, filled
+                ? com.google.android.material.R.attr.materialButtonStyle
+                : com.google.android.material.R.attr.materialButtonOutlinedStyle);
         button.setText(label);
         button.setTextSize(TypedValue.COMPLEX_UNIT_SP, ui.textAction());
         button.setMaxLines(1);
@@ -504,6 +509,9 @@ final class DurationPanel {
         button.setInsetTop(0);
         button.setInsetBottom(0);
         button.setMinHeight(ui.dpS(48));
+        if (!filled) {
+            Utils.quietInk(button);
+        }
         Utils.focusRing(button);
         return button;
     }
@@ -534,7 +542,7 @@ final class DurationPanel {
         // them in pixels instead is what once squeezed this keypad down to its middle column.
         key.setLayoutParams(new LinearLayout.LayoutParams(
                 0, ViewGroup.LayoutParams.MATCH_PARENT, 1f));
-        key.setBackground(Utils.pickerRow(ctx, Color.TRANSPARENT));
+        key.setBackground(Utils.pickerRow(ctx, Color.TRANSPARENT, true));
         key.setOnClickListener(v -> onTap.run());
         return key;
     }

--- a/app/src/main/java/com/brouken/player/OffsetPanel.java
+++ b/app/src/main/java/com/brouken/player/OffsetPanel.java
@@ -410,8 +410,8 @@ Utils.pickerWindow(activity, ui, dialog, scroller);
         // which is where it belongs. Slider has no key-increment setter, hence the key listener.
         final int keyStep = Math.max(2, (int) Math.round(maxSec / 90 / stepSec));
 
-        final MaterialButton minus = iconButton(ctx, R.drawable.ic_remove_24dp, "-");
-        final MaterialButton plus = iconButton(ctx, R.drawable.ic_add_24dp, "+");
+        final MaterialButton minus = iconButton(ctx, ui, R.drawable.ic_remove_24dp, "-");
+        final MaterialButton plus = iconButton(ctx, ui, R.drawable.ic_add_24dp, "+");
 
         final LinearLayout row = new LinearLayout(ctx);
         row.setOrientation(LinearLayout.HORIZONTAL);
@@ -498,23 +498,11 @@ Utils.pickerWindow(activity, ui, dialog, scroller);
     }
 
     /** A ± button: Material's icon button, as legible on a light panel as on a dark one. */
-    private static MaterialButton iconButton(final Context ctx, final int icon,
+    private static MaterialButton iconButton(final Context ctx, final UiMetrics ui, final int icon,
                                              final String description) {
-        final MaterialButton button = new MaterialButton(ctx, null,
-                com.google.android.material.R.attr.materialIconButtonOutlinedStyle);
-        button.setIconResource(icon);
+        final MaterialButton button = Utils.iconButton(ctx, ui, icon, description, true);
         button.setIconTint(ColorStateList.valueOf(
                 MaterialColors.getColor(ctx, R.attr.colorOnSurface, Color.WHITE)));
-        button.setContentDescription(description);
-        button.setInsetTop(0);
-        button.setInsetBottom(0);
-        // Material's icon button is a 20dp glyph in 10dp of padding — a 40dp box, and with the insets
-        // taken off, 40dp tall. The platform's floor for anything a finger has to hit is 48.
-        button.setMinWidth(Utils.dpToPx(48));
-        button.setMinHeight(Utils.dpToPx(48));
-        button.setMinimumWidth(Utils.dpToPx(48));
-        button.setMinimumHeight(Utils.dpToPx(48));
-        Utils.focusRing(button);
         return button;
     }
 

--- a/app/src/main/java/com/brouken/player/OffsetPanel.java
+++ b/app/src/main/java/com/brouken/player/OffsetPanel.java
@@ -19,7 +19,6 @@ import android.widget.TextView;
 import androidx.annotation.NonNull;
 import androidx.core.content.ContextCompat;
 import androidx.core.view.ViewCompat;
-import androidx.core.widget.TextViewCompat;
 
 import com.google.android.material.color.MaterialColors;
 import com.google.android.material.button.MaterialButton;
@@ -226,6 +225,7 @@ final class OffsetPanel {
         reset.setInsetTop(0);
         reset.setInsetBottom(0);
         reset.setMinHeight(ui.dpS(48)); // a target this small is missed as often as it is hit
+        Utils.quietInk(reset);
         Utils.focusRing(reset);
         final LinearLayout.LayoutParams resetLp = new LinearLayout.LayoutParams(
                 ViewGroup.LayoutParams.WRAP_CONTENT, ViewGroup.LayoutParams.WRAP_CONTENT);
@@ -288,22 +288,7 @@ Utils.pickerWindow(activity, ui, dialog, scroller);
 
         final MaterialButton[] pills = new MaterialButton[choice.values.length];
         for (int i = 0; i < choice.values.length; i++) {
-            final MaterialButton pill = new MaterialButton(ctx, null,
-                    com.google.android.material.R.attr.materialButtonOutlinedStyle);
-            pill.setId(View.generateViewId()); // the group tracks its buttons by id
-            pill.setText(choice.labels[i]);
-            pill.setMaxLines(1);
-            pill.setInsetTop(0);
-            pill.setInsetBottom(0);
-            pill.setMinHeight(ui.dpS(48)); // the platform's floor for anything a finger has to hit
-            Utils.focusRing(pill);
-            pill.setPadding(ui.dpS(4), pill.getPaddingTop(), ui.dpS(4), pill.getPaddingBottom());
-            // Shrunk rather than wrapped or clipped: the widest label already fills its share of the
-            // row at the ordinary size, so a longer language or a system font a notch up used to break
-            // one word across two lines and leave the row ragged.
-            TextViewCompat.setAutoSizeTextTypeUniformWithConfiguration(
-                    pill, (int) ui.textAction() - 4, (int) ui.textAction(), 1,
-                    TypedValue.COMPLEX_UNIT_SP);
+            final MaterialButton pill = Utils.pickerSegment(ctx, ui, choice.labels[i]);
             // Equal shares of the row rather than each button's own width: four words of different
             // lengths read as a set this way, and the widest of them decides nothing. The group is a
             // LinearLayout, so weights work and it joins the segments into one control itself.
@@ -516,7 +501,7 @@ Utils.pickerWindow(activity, ui, dialog, scroller);
     private static MaterialButton iconButton(final Context ctx, final int icon,
                                              final String description) {
         final MaterialButton button = new MaterialButton(ctx, null,
-                com.google.android.material.R.attr.materialIconButtonStyle);
+                com.google.android.material.R.attr.materialIconButtonOutlinedStyle);
         button.setIconResource(icon);
         button.setIconTint(ColorStateList.valueOf(
                 MaterialColors.getColor(ctx, R.attr.colorOnSurface, Color.WHITE)));
@@ -529,6 +514,7 @@ Utils.pickerWindow(activity, ui, dialog, scroller);
         button.setMinHeight(Utils.dpToPx(48));
         button.setMinimumWidth(Utils.dpToPx(48));
         button.setMinimumHeight(Utils.dpToPx(48));
+        Utils.focusRing(button);
         return button;
     }
 

--- a/app/src/main/java/com/brouken/player/PlayerActivity.java
+++ b/app/src/main/java/com/brouken/player/PlayerActivity.java
@@ -1558,7 +1558,12 @@ public class PlayerActivity extends Activity {
         buttonAudio.setOnClickListener(view -> showAudioDialog());
 
         buttonMore = new ImageButton(this, null, 0, R.style.ExoStyledControls_Button_Bottom);
-        buttonMore.setImageResource(R.drawable.ic_settings_24dp);
+        // The overflow glyph, not a gear. A gear here meant three things at once: press it for this
+        // panel, hold it for the settings screen, and find a row called Settings inside the panel it
+        // opens — all behind the one symbol every other Android app spends on settings alone. The gear
+        // is now only that row, and the long press is what it always was: a shortcut nobody reads off a
+        // glyph anyway.
+        buttonMore.setImageResource(R.drawable.ic_more_vert_24dp);
         buttonMore.setId(View.generateViewId());
         buttonMore.setContentDescription(getString(R.string.button_more));
         buttonMore.setOnClickListener(view -> showMoreMenu());

--- a/app/src/main/java/com/brouken/player/PlayerActivity.java
+++ b/app/src/main/java/com/brouken/player/PlayerActivity.java
@@ -9786,8 +9786,8 @@ public class PlayerActivity extends Activity {
      */
     private void showMoreMenu() {
         final List<MenuItem> items = new ArrayList<>();
-        // Unnamed: the rules below already divide the three bands, and a caption over the first of them
-        // said what the rows under it say for themselves.
+        // The bands are divided by the rules below rather than by captions: a caption over the first of
+        // them said what the rows under it say for themselves.
         if (player != null) {
             items.add(new MenuItem(R.drawable.ic_speed_24dp, getString(R.string.speed_row),
                     // Quiet at 1x, like every other row here: a summary reports what has been changed,
@@ -9840,9 +9840,12 @@ public class PlayerActivity extends Activity {
         items.add(new MenuItem(R.drawable.ic_folder_open_24dp, getString(R.string.empty_state_open), null, false, () -> openFile(mPrefs.mediaUri)));
         items.add(new MenuItem(R.drawable.ic_link_24dp, getString(R.string.empty_state_link), null, false, emptyState::askForLink));
         items.add(new MenuItem(R.drawable.ic_settings_24dp, getString(R.string.pref_title), null, false, this::openSettings));
-        // No title: every group in here already names itself, and "More" only repeated the button
-        // that opened the panel.
-        showSideMenu(null, items);
+        // Titled after the button that opens it. The title was dropped once, when every panel drew a
+        // header line only if it had something to put on it and "More" would have bought a line to
+        // repeat a word. Every panel carries a close button now, so the line is drawn either way — and
+        // an empty one reads as a mistake rather than as restraint. Not "Settings", which the panel's
+        // own last row already means: one word, two destinations, is what the title said before that.
+        showSideMenu(getString(R.string.button_more), items);
     }
 
     // --- Watch together -------------------------------------------------------------------------

--- a/app/src/main/java/com/brouken/player/PlayerActivity.java
+++ b/app/src/main/java/com/brouken/player/PlayerActivity.java
@@ -6105,8 +6105,11 @@ public class PlayerActivity extends Activity {
             modeButton.setInsetTop(0);
             modeButton.setInsetBottom(0);
             modeButton.setIconSize(ui.dpS(24));
-            modeButton.setMinWidth(ui.clusterBox());
-            modeButton.setMinHeight(ui.clusterBox());
+            // 48, not the 40dp cluster box: this one sits in a header row beside the close button, which
+            // is 48, and it is the platform's floor for anything a finger has to hit. The cluster box is
+            // for the glyphs packed into the chrome's pill over video, where the row is the target.
+            modeButton.setMinWidth(ui.dpS(48));
+            modeButton.setMinHeight(ui.dpS(48));
             Utils.focusRing(modeButton);
             // The panel is built from scratch every time it opens, so switching is opening it again — and
             // showPlaylistDialog dismisses the one on screen itself before it builds the next.
@@ -8616,9 +8619,11 @@ public class PlayerActivity extends Activity {
 
         // One action, at the end of its own line: the way back is the arrow in the header, and a panel
         // that answers with numbers still needs something to press when they are right.
+        // Filled: it is the only action this panel has and the whole reason to open it, and a panel is
+        // allowed exactly one such control.
         final com.google.android.material.button.MaterialButton ok =
                 new com.google.android.material.button.MaterialButton(ctx, null,
-                        com.google.android.material.R.attr.materialButtonOutlinedStyle);
+                        com.google.android.material.R.attr.materialButtonStyle);
         ok.setText(android.R.string.ok);
         ok.setTextSize(TypedValue.COMPLEX_UNIT_SP, ui.textAction());
         ok.setInsetTop(0);

--- a/app/src/main/java/com/brouken/player/SpeedPanel.java
+++ b/app/src/main/java/com/brouken/player/SpeedPanel.java
@@ -278,9 +278,7 @@ final class SpeedPanel {
 
     private static MaterialButton iconButton(final Context ctx, final UiMetrics ui, final int icon,
                                              final String description) {
-        final MaterialButton button = new MaterialButton(ctx, null,
-                com.google.android.material.R.attr.materialIconButtonOutlinedStyle);
-        button.setIconResource(icon);
+        final MaterialButton button = Utils.iconButton(ctx, ui, icon, description, true);
         // Two states, not one colour: these are the only ± in the app that can be disabled — at a
         // quarter speed and at four times it — and a flat ColorStateList had them shine at the ends of
         // the range exactly as brightly as in the middle of it. 97/255 is Material's 38% for disabled
@@ -289,16 +287,6 @@ final class SpeedPanel {
         button.setIconTint(new ColorStateList(
                 new int[][]{{-android.R.attr.state_enabled}, {}},
                 new int[]{MaterialColors.compositeARGBWithAlpha(ink, 97), ink}));
-        button.setContentDescription(description);
-        button.setInsetTop(0);
-        button.setInsetBottom(0);
-        // Material's icon button is a 20dp glyph in 10dp of padding — a 40dp box, and with the insets
-        // taken off, 40dp tall. The platform's floor for anything a finger has to hit is 48.
-        button.setMinWidth(ui.dpS(48));
-        button.setMinHeight(ui.dpS(48));
-        button.setMinimumWidth(ui.dpS(48));
-        button.setMinimumHeight(ui.dpS(48));
-        Utils.focusRing(button);
         return button;
     }
 }

--- a/app/src/main/java/com/brouken/player/SpeedPanel.java
+++ b/app/src/main/java/com/brouken/player/SpeedPanel.java
@@ -153,6 +153,7 @@ final class SpeedPanel {
         reset.setInsetTop(0);
         reset.setInsetBottom(0);
         reset.setMinHeight(ui.dpS(48));
+        Utils.quietInk(reset);
         Utils.focusRing(reset);
         final LinearLayout.LayoutParams resetLp = new LinearLayout.LayoutParams(
                 ViewGroup.LayoutParams.WRAP_CONTENT, ViewGroup.LayoutParams.WRAP_CONTENT);
@@ -278,7 +279,7 @@ final class SpeedPanel {
     private static MaterialButton iconButton(final Context ctx, final UiMetrics ui, final int icon,
                                              final String description) {
         final MaterialButton button = new MaterialButton(ctx, null,
-                com.google.android.material.R.attr.materialIconButtonStyle);
+                com.google.android.material.R.attr.materialIconButtonOutlinedStyle);
         button.setIconResource(icon);
         // Two states, not one colour: these are the only ± in the app that can be disabled — at a
         // quarter speed and at four times it — and a flat ColorStateList had them shine at the ends of
@@ -297,6 +298,7 @@ final class SpeedPanel {
         button.setMinHeight(ui.dpS(48));
         button.setMinimumWidth(ui.dpS(48));
         button.setMinimumHeight(ui.dpS(48));
+        Utils.focusRing(button);
         return button;
     }
 }

--- a/app/src/main/java/com/brouken/player/Utils.java
+++ b/app/src/main/java/com/brouken/player/Utils.java
@@ -24,6 +24,7 @@ import android.graphics.drawable.ColorDrawable;
 import android.graphics.drawable.Drawable;
 import android.graphics.drawable.GradientDrawable;
 import android.graphics.drawable.RippleDrawable;
+import android.graphics.drawable.StateListDrawable;
 import android.graphics.Color;
 import android.media.AudioManager;
 import android.media.MediaExtractor;
@@ -43,6 +44,7 @@ import android.view.KeyEvent;
 import android.os.SystemClock;
 import android.util.Log;
 import android.util.Rational;
+import android.util.StateSet;
 import android.view.Display;
 import android.view.LayoutInflater;
 import android.util.TypedValue;
@@ -707,12 +709,42 @@ class Utils {
      * @param fill the row's own colour, or {@link Color#TRANSPARENT} for a row that is not the current one
      */
     public static Drawable pickerRow(final Context ctx, final int fill) {
+        return pickerRow(ctx, fill, false);
+    }
+
+    /**
+     * The same tile, optionally with an edge at rest.
+     *
+     * <p>A row inside a list does not want one — the card it sits in is its frame, and twenty rows each
+     * boxed is a grid, not a list. A key on a keypad has no such frame: without an edge it is a digit
+     * printed on the panel, and twelve of them read as a table of numbers rather than as twelve things
+     * to press. So the key keeps a hairline in the surface's outline colour, and the focus ring is that
+     * same edge widened — the signal is a change of shape, which the eye catches without being aimed
+     * at it, rather than an edge appearing out of nothing.
+     *
+     * @param outlined true to draw the resting hairline
+     */
+    public static Drawable pickerRow(final Context ctx, final int fill, final boolean outlined) {
         final int corner = dpToPx(8);
         final GradientDrawable content = new GradientDrawable();
         content.setCornerRadius(corner);
         content.setColor(fill);
         content.setStroke(ctx.getResources().getDimensionPixelSize(R.dimen.focus_ring_width),
                 ContextCompat.getColorStateList(ctx, R.color.focus_ring));
+        Drawable layer = content;
+        if (outlined) {
+            // Two widths, so two drawables: a GradientDrawable's stroke width is not state-dependent,
+            // and a hairline that only changes colour is the weakest focus event this app has —
+            // measured 2.76:1 where a ring appearing reads 16.30:1.
+            final GradientDrawable rest = new GradientDrawable();
+            rest.setCornerRadius(corner);
+            rest.setColor(fill);
+            rest.setStroke(dpToPx(1), ContextCompat.getColorStateList(ctx, R.color.focus_ring_outlined));
+            final StateListDrawable states = new StateListDrawable();
+            states.addState(new int[]{android.R.attr.state_focused}, content);
+            states.addState(StateSet.WILD_CARD, rest);
+            layer = states;
+        }
         final GradientDrawable mask = new GradientDrawable();
         mask.setCornerRadius(corner);
         mask.setColor(Color.WHITE);
@@ -724,7 +756,7 @@ class Utils {
         return new RippleDrawable(new ColorStateList(
                 new int[][]{{android.R.attr.state_focused, -android.R.attr.state_pressed}, {}},
                 new int[]{Color.TRANSPARENT, press}),
-                content, mask);
+                layer, mask);
     }
 
     /**
@@ -747,11 +779,25 @@ class Utils {
     }
 
     /** A 48dp glyph on nothing, in the colour a panel gives its quieter text. */
-    private static com.google.android.material.button.MaterialButton iconButton(
+    static com.google.android.material.button.MaterialButton iconButton(
             final Context ctx, final UiMetrics ui, final int icon, final int description) {
+        return iconButton(ctx, ui, icon, description, false);
+    }
+
+    /**
+     * The same glyph, with or without an edge of its own.
+     *
+     * @param outlined true for a control that stands alone — a ± beside a number, a backspace — and so
+     *                 has to say where it begins; false for one of a row inside a header or a bar,
+     *                 which is already a frame and does not want a second one drawn inside it
+     */
+    static com.google.android.material.button.MaterialButton iconButton(
+            final Context ctx, final UiMetrics ui, final int icon, final int description,
+            final boolean outlined) {
         final com.google.android.material.button.MaterialButton button =
-                new com.google.android.material.button.MaterialButton(ctx, null,
-                        com.google.android.material.R.attr.materialIconButtonStyle);
+                new com.google.android.material.button.MaterialButton(ctx, null, outlined
+                        ? com.google.android.material.R.attr.materialIconButtonOutlinedStyle
+                        : com.google.android.material.R.attr.materialIconButtonStyle);
         button.setIconResource(icon);
         button.setIconSize(ui.dpS(24));
         button.setIconTint(ColorStateList.valueOf(MaterialColors.getColor(ctx,
@@ -859,16 +905,21 @@ class Utils {
     }
 
     /**
-     * One segment of a picker's toggle group: outlined, at least 48dp tall, lettering that shrinks
-     * rather than wraps, and the app's focus ring. Shared by the panels that offer a row of ready-made
-     * answers — the sleep timer's durations and the speed panel's rates — so the two say "pick one of
-     * these" in one shape.
+     * One segment of a picker's toggle group: outlined, 8dp at the corners, at least 48dp tall,
+     * lettering that shrinks rather than wraps, and the app's focus ring. Shared by every panel that
+     * offers a row of ready-made answers — the sleep timer's durations, the speed panel's rates, the
+     * skip panel's modes — so they all say "pick one of these" in one shape.
      */
     public static com.google.android.material.button.MaterialButton pickerSegment(
-            final Context ctx, final UiMetrics ui, final String label) {
+            final Context ctx, final UiMetrics ui, final CharSequence label) {
         final com.google.android.material.button.MaterialButton button =
                 new com.google.android.material.button.MaterialButton(ctx, null,
                         com.google.android.material.R.attr.materialButtonOutlinedStyle);
+        // A style is not a theme overlay — passing R.style.Widget_JustPlus_Button_Segment to the
+        // constructor would be ignored — so the one thing that style adds arrives here instead, read
+        // from the same resource the XML segments use.
+        button.setShapeAppearanceModel(ShapeAppearanceModel
+                .builder(ctx, R.style.ShapeAppearance_JustPlus_Segment, 0).build());
         button.setId(View.generateViewId()); // a toggle group tracks its buttons by id
         button.setText(label);
         button.setMaxLines(1);
@@ -905,6 +956,20 @@ class Utils {
             end--;
         }
         return number.substring(0, end);
+    }
+
+    /**
+     * The ink an outlined action letters in: the surface's quieter one, never the accent.
+     *
+     * <p>Material gives an outlined button {@code colorPrimary}, which is the rule this repository
+     * already overrode for a dialog's Cancel — the accent marks the one action that moves things
+     * forward, and a second control wearing it makes the two look like equal choices. It reads the same
+     * on a panel: Off beside a filled Start, Reset under a coral readout. A segment is left alone, since
+     * its own selector already answers checked and unchecked.
+     */
+    static void quietInk(final MaterialButton button) {
+        button.setTextColor(ContextCompat.getColorStateList(button.getContext(),
+                R.color.dialog_button_dismissive));
     }
 
     /**

--- a/app/src/main/java/com/brouken/player/Utils.java
+++ b/app/src/main/java/com/brouken/player/Utils.java
@@ -781,34 +781,52 @@ class Utils {
     /** A 48dp glyph on nothing, in the colour a panel gives its quieter text. */
     static com.google.android.material.button.MaterialButton iconButton(
             final Context ctx, final UiMetrics ui, final int icon, final int description) {
-        return iconButton(ctx, ui, icon, description, false);
+        return iconButton(ctx, ui, icon, ctx.getString(description), false);
+    }
+
+    static com.google.android.material.button.MaterialButton iconButton(
+            final Context ctx, final UiMetrics ui, final int icon, final int description,
+            final boolean outlined) {
+        return iconButton(ctx, ui, icon, ctx.getString(description), outlined);
     }
 
     /**
      * The same glyph, with or without an edge of its own.
+     *
+     * <p>The box is padding plus glyph, never a minimum width around a smaller one. MaterialButton lays
+     * its icon against {@code paddingStart} and does not move it when the view is stretched by
+     * {@code minWidth}, so a 24dp glyph in a 40dp button widened to 48 sits 4dp left of the middle —
+     * measured on the ± of the offset panel, and 2dp on the panels' close button, which had been that
+     * way unseen for as long as those buttons drew no background. Padding is symmetric, so the glyph is
+     * centred by construction whatever the box is.
      *
      * @param outlined true for a control that stands alone — a ± beside a number, a backspace — and so
      *                 has to say where it begins; false for one of a row inside a header or a bar,
      *                 which is already a frame and does not want a second one drawn inside it
      */
     static com.google.android.material.button.MaterialButton iconButton(
-            final Context ctx, final UiMetrics ui, final int icon, final int description,
+            final Context ctx, final UiMetrics ui, final int icon, final CharSequence description,
             final boolean outlined) {
         final com.google.android.material.button.MaterialButton button =
                 new com.google.android.material.button.MaterialButton(ctx, null, outlined
                         ? com.google.android.material.R.attr.materialIconButtonOutlinedStyle
                         : com.google.android.material.R.attr.materialIconButtonStyle);
+        final int glyph = ui.dpS(24);
+        final int box = ui.dpS(48); // the platform's floor for anything a finger has to hit
         button.setIconResource(icon);
-        button.setIconSize(ui.dpS(24));
+        button.setIconSize(glyph);
         button.setIconTint(ColorStateList.valueOf(MaterialColors.getColor(ctx,
                 R.attr.colorOnSurfaceVariant, ContextCompat.getColor(ctx, R.color.ink_secondary))));
-        button.setContentDescription(ctx.getString(description));
+        button.setContentDescription(description);
         button.setInsetTop(0);
         button.setInsetBottom(0);
-        button.setMinWidth(ui.dpS(48));
-        button.setMinHeight(ui.dpS(48));
-        button.setMinimumWidth(ui.dpS(48));
-        button.setMinimumHeight(ui.dpS(48));
+        final int pad = (box - glyph) / 2;
+        button.setPadding(pad, pad, pad, pad);
+        // Kept as a floor, not as the thing that makes the box: see the note above.
+        button.setMinWidth(box);
+        button.setMinHeight(box);
+        button.setMinimumWidth(box);
+        button.setMinimumHeight(box);
         focusRing(button);
         return button;
     }

--- a/app/src/main/java/com/brouken/player/update/UpdateUi.java
+++ b/app/src/main/java/com/brouken/player/update/UpdateUi.java
@@ -86,7 +86,7 @@ public final class UpdateUi {
 
         if (onSkip != null) {
             final MaterialButton skip = new MaterialButton(dialogContext, null,
-                    androidx.appcompat.R.attr.borderlessButtonStyle);
+                    com.google.android.material.R.attr.materialButtonOutlinedStyle);
             skip.setText(R.string.update_skip);
             // Not the brand: this dialog letters its confirming action in the accent and everything else
             // in the quieter ink, and skipping a version is not what anybody came here to do.
@@ -102,8 +102,9 @@ public final class UpdateUi {
             });
             final LinearLayout.LayoutParams skipLp = new LinearLayout.LayoutParams(
                     LinearLayout.LayoutParams.WRAP_CONTENT, LinearLayout.LayoutParams.WRAP_CONTENT);
-            // Lettering flush with the message above it: a text button carries 12dp of its own padding.
-            skipLp.setMargins(padH - dp(dialogContext, 12), dp(dialogContext, 8), padH, 0);
+            // Aligned with the message above it. An outlined button pads 24dp a side, but the border is
+            // where the control now starts, so the margin is the dialog's own — no negative inset.
+            skipLp.setMargins(padH, dp(dialogContext, 8), padH, 0);
             content.addView(skip, skipLp);
         }
         dialog.show();

--- a/app/src/main/res/drawable/ic_more_vert_24dp.xml
+++ b/app/src/main/res/drawable/ic_more_vert_24dp.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Material Symbols "more_vert": the overflow glyph, for the button at the end of the bottom bar.
+     It used to be drawn as a gear, which is what this app's settings screen is — and that button opens
+     a panel whose own last row is Settings, so one glyph stood for three things. -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:tint="#FFFFFF"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M12,8c1.1,0 2,-0.9 2,-2s-0.9,-2 -2,-2s-2,0.9 -2,2S10.9,8 12,8zM12,10c-1.1,0 -2,0.9 -2,2s0.9,2 2,2s2,-0.9 2,-2S13.1,10 12,10zM12,16c-1.1,0 -2,0.9 -2,2s0.9,2 2,2s2,-0.9 2,-2S13.1,16 12,16z" />
+</vector>

--- a/app/src/main/res/layout-w600dp/preference_theme_mode.xml
+++ b/app/src/main/res/layout-w600dp/preference_theme_mode.xml
@@ -23,7 +23,7 @@
 
     <com.google.android.material.button.MaterialButton
         android:id="@+id/theme_mode_dark"
-        style="?attr/materialButtonOutlinedStyle"
+        style="@style/Widget.JustPlus.Button.Segment"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:minWidth="132dp"
@@ -33,7 +33,7 @@
 
     <com.google.android.material.button.MaterialButton
         android:id="@+id/theme_mode_light"
-        style="?attr/materialButtonOutlinedStyle"
+        style="@style/Widget.JustPlus.Button.Segment"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:minWidth="132dp"
@@ -43,7 +43,7 @@
 
     <com.google.android.material.button.MaterialButton
         android:id="@+id/theme_mode_system"
-        style="?attr/materialButtonOutlinedStyle"
+        style="@style/Widget.JustPlus.Button.Segment"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:minWidth="132dp"

--- a/app/src/main/res/layout/preference_theme_mode.xml
+++ b/app/src/main/res/layout/preference_theme_mode.xml
@@ -15,7 +15,7 @@
 
     <com.google.android.material.button.MaterialButton
         android:id="@+id/theme_mode_dark"
-        style="?attr/materialButtonOutlinedStyle"
+        style="@style/Widget.JustPlus.Button.Segment"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_weight="1"
@@ -25,7 +25,7 @@
 
     <com.google.android.material.button.MaterialButton
         android:id="@+id/theme_mode_light"
-        style="?attr/materialButtonOutlinedStyle"
+        style="@style/Widget.JustPlus.Button.Segment"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_weight="1"
@@ -35,7 +35,7 @@
 
     <com.google.android.material.button.MaterialButton
         android:id="@+id/theme_mode_system"
-        style="?attr/materialButtonOutlinedStyle"
+        style="@style/Widget.JustPlus.Button.Segment"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_weight="1"

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -96,6 +96,7 @@
         <item name="materialButtonStyle">@style/Widget.JustPlus.Button.Filled</item>
         <item name="materialButtonOutlinedStyle">@style/Widget.JustPlus.Button.Outlined</item>
         <item name="materialIconButtonStyle">@style/Widget.JustPlus.Button.Quiet.Icon</item>
+        <item name="materialIconButtonOutlinedStyle">@style/Widget.JustPlus.Button.Icon.Outlined</item>
         <item name="borderlessButtonStyle">@style/Widget.JustPlus.Button.Quiet</item>
         <!-- One field with the list below it. Left unset, a Material theme paints the bar from the
              primary colour, which with a coral primary is a red band across the top of the screen.
@@ -135,10 +136,11 @@
          at it - it applies the second itself, and whatever that names wins over the theme underneath. -->
     <style name="ThemeOverlay.JustPlus.AlertDialog" parent="ThemeOverlay.Material3.MaterialAlertDialog">
         <item name="android:windowBackground">@drawable/bg_dialog_material3</item>
-        <!-- Only the confirming action is coral. The ripple is left as it was: on a television the
-             focus wash of these buttons comes from it. -->
-        <item name="buttonBarNegativeButtonStyle">@style/Widget.JustPlus.Button.Dialog.Dismissive</item>
-        <item name="buttonBarNeutralButtonStyle">@style/Widget.JustPlus.Button.Dialog.Neutral</item>
+        <!-- Every action carries a contour: the confirming one is filled, the rest are outlined. The
+             ripple is left as it was: on a television the focus wash of these buttons comes from it. -->
+        <item name="buttonBarPositiveButtonStyle">@style/Widget.JustPlus.Button.Dialog.Filled</item>
+        <item name="buttonBarNegativeButtonStyle">@style/Widget.JustPlus.Button.Dialog.Outlined</item>
+        <item name="buttonBarNeutralButtonStyle">@style/Widget.JustPlus.Button.Dialog.Outlined.Flush</item>
     </style>
 
     <!--
@@ -156,9 +158,26 @@
         <item name="strokeColor">@color/focus_ring</item>
     </style>
 
+    <!--
+        Material insets an icon button 4dp at each side and none at top or bottom, so a 48dp box draws
+        its background 40 wide by 48 tall. Nothing showed while that background was a transparent
+        ripple; the moment one of these carries an edge — the focus ring on a television, the outline of
+        the style below — the "circle" is an upright oval. Both insets go, and the shape is the box.
+    -->
     <style name="Widget.JustPlus.Button.Quiet.Icon" parent="Widget.Material3.Button.IconButton">
+        <item name="android:insetLeft">0dp</item>
+        <item name="android:insetRight">0dp</item>
         <item name="strokeWidth">@dimen/focus_ring_width</item>
         <item name="strokeColor">@color/focus_ring</item>
+    </style>
+
+    <!-- A glyph that is a button in its own right — a ± beside a number, the backspace of a keypad —
+         rather than one of a row inside a bar, where the bar is the frame. It keeps its edge at rest,
+         like every other standalone action, and Utils.focusRing widens that edge on a remote. -->
+    <style name="Widget.JustPlus.Button.Icon.Outlined" parent="Widget.Material3.Button.IconButton.Outlined">
+        <item name="android:insetLeft">0dp</item>
+        <item name="android:insetRight">0dp</item>
+        <item name="strokeColor">@color/focus_ring_outlined</item>
     </style>
 
     <!-- The one style whose stroke is not only the ring: it is also the border that makes the button
@@ -167,8 +186,30 @@
          changes colour is a weak event — measured 2.76:1 between the same pixels focused and not,
          where a ring appearing on a picker row reads 16.30:1. -->
     <style name="Widget.JustPlus.Button.Outlined" parent="Widget.Material3.Button.OutlinedButton">
-        <item name="strokeWidth">2dp</item>
+        <!-- Material's own outline width (m3_comp_outlined_button_outline_width). It used to be 2dp,
+             from before the outline was a resting border on many controls rather than a focus signal on
+             a few: at 2dp a row of segments reads as a grid of boxes instead of one control. -->
+        <item name="strokeWidth">1dp</item>
         <item name="strokeColor">@color/focus_ring_outlined</item>
+    </style>
+
+    <!--
+        A segment of a toggle group. Material draws segmented buttons fully round, which is where its
+        common buttons are; here the shape says what a control IS. A pill is a verb — press it and
+        something happens — and a segment is a value the viewer picks out of a set, so it takes the
+        8dp of a chip, the shape this app already gives every other value: a picker row, a keypad key,
+        a status badge, the readout of a number.
+
+        Only the outer corners survive: MaterialButtonToggleGroup flattens the inner ones itself, so the
+        row still reads as one control rather than five.
+    -->
+    <style name="ShapeAppearance.JustPlus.Segment" parent="">
+        <item name="cornerFamily">rounded</item>
+        <item name="cornerSize">8dp</item>
+    </style>
+
+    <style name="Widget.JustPlus.Button.Segment" parent="Widget.JustPlus.Button.Outlined">
+        <item name="shapeAppearance">@style/ShapeAppearance.JustPlus.Segment</item>
     </style>
 
     <style name="Widget.JustPlus.Button.Filled" parent="Widget.Material3.Button">
@@ -176,13 +217,46 @@
         <item name="strokeColor">@color/focus_ring</item>
     </style>
 
-    <style name="Widget.JustPlus.Button.Dialog.Dismissive" parent="Widget.Material3.Button.TextButton.Dialog">
+    <!--
+        A dialog's actions, both of them with an edge. Material 3 letters them as text buttons, which
+        leaves a panel whose only pressable things are two words floating in it — nothing says where the
+        button ends, and on a phone the pair reads as a caption. The appearance is the one the three
+        styles above already define; what is restated here is the dialog bar's own geometry, which
+        Widget.Material3.Button.TextButton.Dialog would have carried: minWidth 64dp
+        (m3_btn_dialog_btn_min_width), 8dp between buttons (m3_btn_dialog_btn_spacing), and one line
+        that ellipsizes rather than wraps. The values are written out because neither dimen is in
+        Material's public.txt.
+
+        The pair costs 48dp more than the text buttons did — a filled or outlined button pads 24dp a
+        side where a text one pads 12 — so a bar that was close to stacking will stack sooner. That is
+        AppCompat's ButtonBarLayout doing what it exists for, and the update dialog was already cut to
+        two actions for it.
+    -->
+    <style name="Widget.JustPlus.Button.Dialog.Filled" parent="Widget.JustPlus.Button.Filled">
+        <item name="android:minWidth">64dp</item>
+        <item name="android:layout_marginStart">8dp</item>
+        <item name="android:layout_marginLeft">8dp</item>
+        <item name="android:lines">1</item>
+        <item name="android:ellipsize">end</item>
+        <item name="android:singleLine">true</item>
+    </style>
+
+    <!-- Only the confirming action is coral: an outlined button letters itself in colorPrimary by
+         default, which would put the brand on Cancel as well and make the two look like equal choices. -->
+    <style name="Widget.JustPlus.Button.Dialog.Outlined" parent="Widget.JustPlus.Button.Outlined">
         <item name="android:textColor">@color/dialog_button_dismissive</item>
+        <item name="android:minWidth">64dp</item>
+        <item name="android:layout_marginStart">8dp</item>
+        <item name="android:layout_marginLeft">8dp</item>
+        <item name="android:lines">1</item>
+        <item name="android:ellipsize">end</item>
+        <item name="android:singleLine">true</item>
     </style>
 
     <!-- The third action sits at the far edge, so it keeps Material's flush geometry. -->
-    <style name="Widget.JustPlus.Button.Dialog.Neutral" parent="Widget.Material3.Button.TextButton.Dialog.Flush">
-        <item name="android:textColor">@color/dialog_button_dismissive</item>
+    <style name="Widget.JustPlus.Button.Dialog.Outlined.Flush">
+        <item name="android:layout_marginStart">0dp</item>
+        <item name="android:layout_marginLeft">0dp</item>
     </style>
 
     <!-- AMOLED: the M3 dark scheme with its greys taken out, for a panel that costs nothing to leave
@@ -206,12 +280,16 @@
         <item name="materialButtonStyle">@style/Widget.JustPlus.Button.Filled</item>
         <item name="materialButtonOutlinedStyle">@style/Widget.JustPlus.Button.Outlined</item>
         <item name="materialIconButtonStyle">@style/Widget.JustPlus.Button.Quiet.Icon</item>
+        <item name="materialIconButtonOutlinedStyle">@style/Widget.JustPlus.Button.Icon.Outlined</item>
         <item name="borderlessButtonStyle">@style/Widget.JustPlus.Button.Quiet</item>
         <!-- Not @color/brand: this theme is light whatever the system is doing, and the bright coral
              cannot be read on it. @color/brand_accent is the one value that works on both. -->
         <item name="colorPrimary">@color/brand_accent</item>
         <item name="colorPrimaryContainer">@color/brand_container</item>
-        <item name="colorOnPrimary">@color/white</item>
+        <!-- Black, as Theme.Settings already has it: this is the ink on a filled accent, and on
+             #D6493C white measures 4.31:1 where black measures 4.88:1. A dialog's confirming action is
+             14sp, which is small text, so the difference is the AA line. -->
+        <item name="colorOnPrimary">@color/brand_accent_on</item>
         <!-- One answer to "this one is chosen", for every control that has to say it: the checked
              segment of a toggle group, the current row of a picker, the track of a switch. Material
              would give a checked segment colorSecondaryContainer, which this app leaves neutral, so the
@@ -239,12 +317,16 @@
         <item name="materialButtonStyle">@style/Widget.JustPlus.Button.Filled</item>
         <item name="materialButtonOutlinedStyle">@style/Widget.JustPlus.Button.Outlined</item>
         <item name="materialIconButtonStyle">@style/Widget.JustPlus.Button.Quiet.Icon</item>
+        <item name="materialIconButtonOutlinedStyle">@style/Widget.JustPlus.Button.Icon.Outlined</item>
         <item name="borderlessButtonStyle">@style/Widget.JustPlus.Button.Quiet</item>
         <!-- The same accent the light panel uses, so a switch does not change colour with the theme.
              @color/brand stays what it always was: the chrome over video, which is never light. -->
         <item name="colorPrimary">@color/brand_accent</item>
         <item name="colorPrimaryContainer">@color/brand_container</item>
-        <item name="colorOnPrimary">@color/white</item>
+        <!-- Black, as Theme.Settings already has it: this is the ink on a filled accent, and on
+             #D6493C white measures 4.31:1 where black measures 4.88:1. A dialog's confirming action is
+             14sp, which is small text, so the difference is the AA line. -->
+        <item name="colorOnPrimary">@color/brand_accent_on</item>
         <!-- One answer to "this one is chosen", for every control that has to say it: the checked
              segment of a toggle group, the current row of a picker, the track of a switch. Material
              would give a checked segment colorSecondaryContainer, which this app leaves neutral, so the


### PR DESCRIPTION
No button in this app had to say where it ended. Material 3 letters a dialog's
actions as text buttons, the panels' ± were glyphs on nothing, twelve keypad keys
were digits printed on a surface — and the owner's report was simply that buttons
without an outline are not buttons. This is the answer, applied to every surface
that already wears Material 3: the dialogs, the settings screen and the player's
panels.

## Two rules

**Verb / Value.** A control that *does* something — OK, Cancel, Reset, Start,
Skip, a ± stepper, a close — is a **pill**, Material's `Full` corner, a circle
when it is icon-only. A control that *is* something the viewer picks or reads — a
segment, a list row, a keypad key, a status badge, a boxed readout — is a **tile**:
8dp, or 12dp for a card 72dp or taller.

**One Frame.** Every control sits inside exactly one visible frame: its own, or a
bar that holds only controls (a panel header, the settings toolbar, the chrome's
plate). A text button with nothing around it is neither, and is now banned.

Emphasis is a separate axis with a hard budget: **one** filled-accent control per
surface — the action that moves things forward — tonal accent for the value that
is chosen, outlined for everything else, and a plate for anything drawn over
video. `Utils.quietInk` letters the standalone outlined actions in
`colorOnSurfaceVariant`, so the accent means one thing.

## What changed

**Dialogs.** The confirming action is filled, the rest outlined; both styles
restate the dialog bar's own geometry, which they no longer inherit.
`colorOnPrimary` in the two dialog themes goes to black, as `Theme.Settings`
already had it — on `#D6493C` white measures 4.31:1 against black's 4.88, and a
14sp label is small text.

**Segments.** 8dp outer corners instead of Material's `Full`, and the outline
goes from 2dp to Material's own 1dp. Chosen against a side-by-side of the real
build: round gives a mid-row checked segment square corners inside a rounded
track, so the control carries two corner languages at once and which one you see
depends on which value is set. `OffsetPanel` was building its segments by hand,
line for line what `Utils.pickerSegment` does, and now calls it.

**Panels.** The one action that arms a sleep timer or answers a season and
episode is filled. The ± steppers and the keypad's backspace are outlined icon
buttons; the twelve keypad keys keep a hairline at rest. The playlist's view
toggle reaches 48dp, the floor its neighbouring close button already had.

**The overflow button** at the end of the bottom bar was a gear — one symbol for
three things: press it for the More panel, hold it for the settings screen, and
find a row called Settings inside the panel it opens. It is Material's own
overflow glyph now, and that panel is titled with the string its button already
uses rather than opening with a bare close button on an empty line.

**The sleep timer sideways** did not fit its card at all, and is rebuilt for it:
the keypad turns four columns by three rows so every key reaches 48dp and the two
columns draw the same three lines, the ready-made durations stand down on a
window too short for both (a television keeps them), and the readout's fields
stop being clipped by their own row.

## What the screenshots said that the arithmetic did not

- Material insets an icon button 4dp at each side and none at top or bottom, so
  every 48dp "circle" in the app was a 40 x 48 oval — invisible until one of them
  carried an edge, and true of the panels' close button for as long as it has
  existed.
- An outlined `MaterialButton` letters itself in `colorPrimary`, which put the
  accent on Off beside a filled Start.
- A horizontal `LinearLayout` aligns its children by the baseline of their text
  unless told not to, which was cutting the lower corners off the timer's fields.
- The playlist's three 6dp radii are not frames but chips nested inside an 8dp
  frame, where a smaller radius is what Material asks for. Left alone.

## Measured

Phone emulator forced to 1080x2412 at 480dpi — the owner's own viewport — light
appearance, Ukrainian, plus a television emulator at 1920x1080 at 320dpi.

| | |
|---|---|
| Two dialog actions | 213dp of the 247 the dialog leaves; three still stack, as before |
| Glyph centring, ± and close | -4.17dp and -2.17dp off centre before, -0.17dp after |
| Backspace | 22.3dp below the fields before, 0.0dp after, with Material's 8dp between it and the minutes |
| Segments | 61.7 x 48dp, five across a 355dp column |
| Sleep timer sideways | button and first key row 48 and 48 (62 and 62 on the television), actions and last key row flush at the foot, nothing clipped |

All four debug variants build. There are no tests in this repository; every check
here is a screenshot with the pixels measured, and the branch has been installed
on the owner's phone at each step.

## Not verified

The dark appearance, a tablet, and a system font scale above 1.0. On the
television the panels were seen but D-pad focus was not walked through them.

## Left open

Whether a glyph inside a bar should keep its exemption from the One Frame rule,
whether a dialog's dismissive action would be better tonal than outlined, and the
two placement questions — panels docked at the end edge top-aligned rather than
centred, and what the subtitle-offset panel should do about covering the line it
retimes. None of them are in this branch.