### PR TITLE
The panel becomes a docked sheet, and subtitles are chosen against a picture

### DIFF
--- a/app/src/main/java/com/brouken/player/PlayerActivity.java
+++ b/app/src/main/java/com/brouken/player/PlayerActivity.java
@@ -85,7 +85,6 @@ import android.widget.ImageView;
 import android.widget.LinearLayout;
 import android.widget.ProgressBar;
 import android.widget.TextView;
-import android.widget.Toast;
 import android.window.OnBackInvokedDispatcher;
 
 import androidx.annotation.NonNull;
@@ -157,7 +156,6 @@ import androidx.media3.extractor.ts.DefaultTsPayloadReaderFactory;
 import androidx.media3.extractor.ts.TsExtractor;
 import androidx.media3.session.MediaSession;
 import androidx.media3.ui.AspectRatioFrameLayout;
-import androidx.media3.ui.CaptionStyleCompat;
 import androidx.media3.ui.DefaultTimeBar;
 import androidx.media3.ui.PlayerControlView;
 import androidx.media3.ui.PlayerView;
@@ -726,13 +724,11 @@ public class PlayerActivity extends Activity {
     private TextView transferView;
     private OutlineTextClock overlayClock;
     private OutlineTextClock headerClock;
-    private ImageButton buttonOpen;
     private ImageButton buttonPlaylist;
     private ImageButton buttonQuality;
     private ImageButton buttonAudio;
     private ImageButton buttonMore;
     private ImageButton buttonUpdate;
-    private ImageButton buttonSkipOffset;
     private android.app.Dialog qualityDialog;
     private android.app.Dialog playlistDialog;
     private android.app.Dialog skipOffsetDialog;
@@ -1523,22 +1519,6 @@ public class PlayerActivity extends Activity {
             }
         });
 
-        buttonOpen = new ImageButton(this, null, 0, R.style.ExoStyledControls_Button_Bottom);
-        buttonOpen.setImageResource(R.drawable.ic_folder_open_24dp);
-        buttonOpen.setId(View.generateViewId());
-        buttonOpen.setContentDescription(getString(R.string.button_open));
-
-        buttonOpen.setOnClickListener(view -> openFile(mPrefs.mediaUri));
-
-        buttonOpen.setOnLongClickListener(view -> {
-            if (!isTvBox && mPrefs.askScope) {
-                askForScope(true, false);
-            } else {
-                loadSubtitleFile(mPrefs.mediaUri);
-            }
-            return true;
-        });
-
         buttonPlaylist = new ImageButton(this, null, 0, R.style.ExoStyledControls_Button_Bottom);
         buttonPlaylist.setImageResource(R.drawable.ic_playlist_24dp);
         buttonPlaylist.setId(View.generateViewId());
@@ -1595,13 +1575,6 @@ public class PlayerActivity extends Activity {
                         player != null && player.isPlaying());
             }
         });
-
-        buttonSkipOffset = new ImageButton(this, null, 0, R.style.ExoStyledControls_Button_Bottom);
-        buttonSkipOffset.setImageResource(R.drawable.ic_skip_offset_24dp);
-        buttonSkipOffset.setId(View.generateViewId());
-        buttonSkipOffset.setContentDescription(getString(R.string.skip_session_title));
-        buttonSkipOffset.setVisibility(View.GONE);
-        buttonSkipOffset.setOnClickListener(view -> showSkipOffsetDialog());
 
         if (Utils.isPiPSupported(this)) {
             // TODO: Android 12 improvements:
@@ -3706,7 +3679,6 @@ public class PlayerActivity extends Activity {
         if (skipOffsetDialog != null && skipOffsetDialog.isShowing()) {
             skipOffsetDialog.dismiss();
         }
-        updateSkipOffsetButton();
         // Same for the subtitle offset: it was tuned against one file's timing and means nothing to the next.
         applySubtitleOffset(0);
         clearSubtitleTimeline();
@@ -3781,7 +3753,6 @@ public class PlayerActivity extends Activity {
         if (skipManager.hasSegments()) {
             skipSeenThisSession = true;
         }
-        updateSkipOffsetButton();
     }
 
     /**
@@ -3792,14 +3763,6 @@ public class PlayerActivity extends Activity {
     private boolean skipOffsetReachable() {
         return mPrefs != null && mPrefs.skipEnabled && skipManager != null
                 && (skipManager.hasSegments() || skipSeenThisSession);
-    }
-
-    /** The offset button is shown once any skip segment exists — now or earlier this session. */
-    private void updateSkipOffsetButton() {
-        if (buttonSkipOffset == null) {
-            return;
-        }
-        buttonSkipOffset.setVisibility(skipOffsetReachable() ? View.VISIBLE : View.GONE);
     }
 
     /** Apply a new session skip offset and re-derive the segments (moves timeline highlights live). */
@@ -6390,12 +6353,12 @@ public class PlayerActivity extends Activity {
     // panel docked to the end edge, with the current choice ticked and reachable by remote.
     private void showQualityDialog() {
         if (player == null) {
-            Toast.makeText(this, R.string.quality_unavailable, Toast.LENGTH_SHORT).show();
+            showNotice(getString(R.string.quality_unavailable), false);
             return;
         }
         final ArrayList<VideoQualityChoice> choices = buildQualityChoices();
         if (choices.size() < 2) {
-            Toast.makeText(this, R.string.quality_unavailable, Toast.LENGTH_SHORT).show();
+            showNotice(getString(R.string.quality_unavailable), false);
             return;
         }
         final int selected = selectedQualityIndex(choices);
@@ -6876,11 +6839,33 @@ public class PlayerActivity extends Activity {
         // below the last row.
         scrollView.setPadding(0, Utils.dpToPx(8), 0, 0);
 
+        final FrameLayout panel = new FrameLayout(ctx);
+        panel.addView(scrollView, new FrameLayout.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT));
+
+        // A list taller than its card is cut by the card's edge, and a row bisected with nothing to say so
+        // reads as a rendering fault rather than as "there is more". The platform's own fading edge cannot
+        // do it here — pickerWindow gives this card a background and clips it to its outline, and a fade is
+        // composited before that, so it never appears (measured: the last row's glyph arrives at full
+        // strength either way). A band of the card's own colour, over the list rather than inside it, does.
+        // 28dp, the length the grid's rail already fades by, and only while there is something below.
+        final View listFade = new View(ctx);
+        listFade.setBackground(new GradientDrawable(GradientDrawable.Orientation.TOP_BOTTOM,
+                new int[]{Color.TRANSPARENT, MaterialColors.getColor(ctx, R.attr.colorSurface,
+                        ContextCompat.getColor(ctx, R.color.sheet_surface))}));
+        listFade.setVisibility(View.GONE);
+        panel.addView(listFade, new FrameLayout.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT, ui.dpS(28), Gravity.BOTTOM));
+        final Runnable syncListFade = () -> listFade.setVisibility(
+                scrollView.canScrollVertically(1) ? View.VISIBLE : View.GONE);
+        scrollView.getViewTreeObserver().addOnScrollChangedListener(syncListFade::run);
+        scrollView.post(syncListFade);
+
         if (menuDialog != null) {
             menuDialog.dismiss();
         }
         menuDialog = new android.app.Dialog(this, android.R.style.Theme_Translucent_NoTitleBar);
-        Utils.pickerWindow(this, ui, menuDialog, scrollView);
+        Utils.pickerWindow(this, ui, menuDialog, panel);
         if (back != null) {
             Utils.panelBack(menuDialog, back);
         }
@@ -7734,7 +7719,7 @@ public class PlayerActivity extends Activity {
                     final String message = getString(R.string.subtitle_translate_failed,
                             displayLanguage(translateTo));
                     runOnUiThread(() ->
-                            Toast.makeText(this, message, Toast.LENGTH_SHORT).show());
+                            showNotice(message, false));
                 }
             }
             final Uri attach = show;
@@ -7776,8 +7761,8 @@ public class PlayerActivity extends Activity {
         // track it already had or by its own pass, the second by its own.
         if (secondary) {
             chooseSecondarySubtitle(file);
-            Toast.makeText(this, getString(R.string.subtitle_search_found_secondary,
-                    displayLanguage(language)), Toast.LENGTH_SHORT).show();
+            showNotice(getString(R.string.subtitle_search_found_secondary,
+                    displayLanguage(language)), false);
             return;
         }
         mPrefs.updateSubtitle(file);
@@ -7791,7 +7776,7 @@ public class PlayerActivity extends Activity {
             if (isMachineTranslated(file)) {
                 message = getString(R.string.subtitle_machine_translated, message);
             }
-            Toast.makeText(this, message, Toast.LENGTH_SHORT).show();
+            showNotice(message, false);
         }
     }
 
@@ -9508,7 +9493,7 @@ public class PlayerActivity extends Activity {
         // format in that same group, read as switched off. A DASH text AdaptationSet with two
         // Representations is the shape that does this.
         if (mediaGroup.length > 1) {
-            Toast.makeText(this, R.string.subtitle_secondary_unavailable, Toast.LENGTH_LONG).show();
+            showNotice(getString(R.string.subtitle_secondary_unavailable), true);
             return;
         }
         secondaryChoiceMedia = mPrefs.mediaUri;
@@ -9588,7 +9573,7 @@ public class PlayerActivity extends Activity {
             return;
         }
         setSecondaryTrack(null);
-        Toast.makeText(this, R.string.subtitle_secondary_unavailable, Toast.LENGTH_LONG).show();
+        showNotice(getString(R.string.subtitle_secondary_unavailable), true);
     }
 
     private void applySubtitle(TrackGroup group, int index) {
@@ -10073,7 +10058,8 @@ public class PlayerActivity extends Activity {
         final EditText password = Utils.textField(fields, getString(R.string.together_password));
         password.setText(mPrefs.togetherPassword);
 
-        final CheckBox listed = new CheckBox(dialogContext);
+        final com.google.android.material.checkbox.MaterialCheckBox listed =
+                new com.google.android.material.checkbox.MaterialCheckBox(dialogContext);
         listed.setText(R.string.together_public);
         listed.setChecked(mPrefs.togetherPublic);
 
@@ -10082,8 +10068,9 @@ public class PlayerActivity extends Activity {
         // coral, and a red field on top of it reads as alarm rather than as the one thing left to fill in.
         final TextView note = new TextView(dialogContext);
         note.setText(R.string.together_public_needs_password);
-        note.setTextSize(TypedValue.COMPLEX_UNIT_SP, 13);
-        note.setTextColor(ContextCompat.getColor(this, R.color.error_ink_muted));
+        note.setTextAppearance(com.google.android.material.R.style.TextAppearance_Material3_BodySmall);
+        note.setTextColor(MaterialColors.getColor(dialogContext, R.attr.colorOnSurfaceVariant,
+                ContextCompat.getColor(this, R.color.error_ink_muted)));
         note.setPadding(0, 0, 0, Utils.dpToPx(4));
         note.setVisibility(View.GONE);
 
@@ -13240,13 +13227,12 @@ public class PlayerActivity extends Activity {
         playerView.post(() -> {
             // Announced next to the switch it describes rather than before it, so a player torn down in
             // between (the user leaving) says nothing instead of promising a quality that never loads.
-            // A Toast rather than showSnack: on a TV box showSnack is a modal dialog, and an automatic
+            // showNotice rather than showSnack: on a TV box showSnack is a modal dialog, and an automatic
             // recovery must not stop to be acknowledged (same as recoverByDisablingTunneling).
             if (player == null) {
                 return;
             }
-            Toast.makeText(this, getString(R.string.notice_quality_lowered, label),
-                    Toast.LENGTH_LONG).show();
+            showNotice(getString(R.string.notice_quality_lowered, label), true);
             applyVideoQuality(VideoQualityChoice.source(label, url));
         });
         return true;
@@ -13338,7 +13324,7 @@ public class PlayerActivity extends Activity {
         }
         Utils.log("rebuild: tunneling off");
         mPrefs.disableTunneling();
-        Toast.makeText(this, R.string.notice_tunneling_disabled, Toast.LENGTH_LONG).show();
+        showNotice(getString(R.string.notice_tunneling_disabled), true);
         restorePlayState = true;
         // Keeps the Dolby Vision workaround across this rebuild: without it a device that needs both fixes
         // would lose the first one here, and the DV rung would be free to fire again.
@@ -13712,7 +13698,7 @@ public class PlayerActivity extends Activity {
     }
 
     private void loadSubtitleFile(Uri pickerInitialUri) {
-        Toast.makeText(PlayerActivity.this, R.string.open_subtitles, Toast.LENGTH_SHORT).show();
+        PlayerActivity.this.showNotice(getString(R.string.open_subtitles), false);
         final int targetSdkVersion = getApplicationContext().getApplicationInfo().targetSdkVersion;
         if ((isTvBox && Build.VERSION.SDK_INT >= 30 && targetSdkVersion >= 30 && mPrefs.fileAccess.equals("auto")) || mPrefs.fileAccess.equals("mediastore")) {
             Intent intent = new Intent(this, MediaStoreChooserActivity.class);
@@ -14568,6 +14554,25 @@ public class PlayerActivity extends Activity {
         });
     }
 
+    /**
+     * A passing notice — the snackbar this app already owns, never the platform's toast.
+     *
+     * <p>Actionless on purpose, which is what lets one helper serve both device classes: {@link #showSnack}
+     * substitutes a dialog on a television only because <em>its</em> Details button cannot be reached with a
+     * D-pad. A notice has nothing to reach, so the plate is right on a phone and on a set alike — and it is
+     * the same plate ({@code colorSurfaceInverse} = {@code chrome_surface}) the player draws over video, so
+     * a notice looks like this app rather than like the system.
+     */
+    void showNotice(final CharSequence text, final boolean longer) {
+        if (coordinatorLayout == null) {
+            return;
+        }
+        final Snackbar bar = Snackbar.make(coordinatorLayout, text,
+                longer ? Snackbar.LENGTH_LONG : Snackbar.LENGTH_SHORT);
+        bar.setAnchorView(R.id.exo_bottom_bar);
+        bar.show();
+    }
+
     void showSnack(final String textPrimary, final String textSecondary) {
         final Context dialogContext = Utils.dialogContext(this);
         // On TV the Snackbar action button is not reachable with the D-pad, so the "Details" affordance
@@ -14639,18 +14644,10 @@ public class PlayerActivity extends Activity {
         secondarySubtitlesScale =
                 SubtitleUtils.normalizeFontScale(mPrefs.subtitleSecondaryScale, isTvBox || isTablet);
         if (subtitleView != null) {
-            // A window behind the text is a captioning concept nobody asks for, so it stays off. The
-            // outline needs no knob either, it just has to contrast: black around every colour except
-            // black text, which only reads against a light outline.
-            final CaptionStyleCompat captionStyle = new CaptionStyleCompat(
-                    mPrefs.subtitleTextColor,
-                    mPrefs.subtitleBackgroundColor,
-                    Color.TRANSPARENT,
-                    mPrefs.subtitleEdgeType,
-                    mPrefs.subtitleTextColor == Color.BLACK ? Color.WHITE : Color.BLACK,
-                    Typeface.create(Typeface.DEFAULT,
-                            mPrefs.subtitleStyleBold ? Typeface.BOLD : Typeface.NORMAL));
-            subtitleView.setStyle(captionStyle);
+            // Built where the settings preview builds it, so the two cannot drift apart.
+            subtitleView.setStyle(SubtitleUtils.captionStyle(mPrefs.subtitleTextColor,
+                    mPrefs.subtitleBackgroundColor, mPrefs.subtitleEdgeType,
+                    mPrefs.subtitleStyleBold));
         }
         // Sets the sizes, the band the second line sits in, and the padding and margins with them.
         updateSubtitleLayout();

--- a/app/src/main/java/com/brouken/player/SettingsActivity.java
+++ b/app/src/main/java/com/brouken/player/SettingsActivity.java
@@ -4,6 +4,7 @@ import android.content.ClipData;
 import android.content.ClipboardManager;
 import android.content.Context;
 import android.content.Intent;
+import android.content.SharedPreferences;
 import android.content.res.ColorStateList;
 import android.content.res.Configuration;
 import android.content.res.Resources;
@@ -14,15 +15,13 @@ import android.graphics.Color;
 import android.graphics.Outline;
 import android.graphics.Paint;
 import android.graphics.Rect;
+import android.graphics.Typeface;
 import android.graphics.RectF;
 import android.graphics.drawable.ColorDrawable;
 import android.graphics.drawable.Drawable;
 import android.graphics.drawable.GradientDrawable;
 import android.graphics.drawable.RippleDrawable;
 import android.text.Layout;
-import android.text.SpannableStringBuilder;
-import android.text.Spanned;
-import android.text.style.ImageSpan;
 import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
@@ -32,6 +31,7 @@ import android.os.Parcelable;
 import android.text.StaticLayout;
 import android.text.TextUtils;
 import android.util.DisplayMetrics;
+import android.util.TypedValue;
 import android.view.Gravity;
 import android.view.KeyEvent;
 import android.view.LayoutInflater;
@@ -57,7 +57,9 @@ import androidx.core.view.WindowCompat;
 import androidx.core.view.WindowInsetsCompat;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.media3.common.MediaLibraryInfo;
+import androidx.media3.common.text.Cue;
 import androidx.media3.decoder.ffmpeg.FfmpegLibrary;
+import androidx.media3.ui.SubtitleView;
 import androidx.preference.ListPreference;
 import androidx.preference.Preference;
 import androidx.preference.PreferenceCategory;
@@ -588,8 +590,7 @@ public class SettingsActivity extends AppCompatActivity
             }
             if (translate != null) {
                 translate.setOnPreferenceChangeListener((preference, value) -> {
-                    enableTranslateBackends(searchMode == null
-                            || !Prefs.SEARCH_OFF.equals(searchMode.getValue()), (Boolean) value);
+                    enableTranslateBackends((Boolean) value);
                     // A translation cached under the previous choice would keep being served for
                     // everything watched recently, so the new choice would look like it did nothing.
                     SubtitleUtils.clearTranslatedCache(requireContext());
@@ -638,7 +639,7 @@ public class SettingsActivity extends AppCompatActivity
             }
 
             // Both subtitle lines, each with its own pair. The second line reuses the same two lists,
-            // so it gets the chips and the clash check for nothing.
+            // so it gets the clash check for nothing.
             bindColorPair("subtitleTextColor", "subtitleBackground");
             bindColorPair("subtitleSecondaryTextColor", "subtitleSecondaryBackground");
 
@@ -902,6 +903,7 @@ public class SettingsActivity extends AppCompatActivity
                     bindThemeMode(holder, getItem(position));
                     bindAccent(holder, getItem(position));
                     bindAbout(holder, getItem(position));
+                    bindSubtitlePreview(holder, getItem(position));
                 }
             };
         }
@@ -1309,7 +1311,9 @@ public class SettingsActivity extends AppCompatActivity
                 }
                 final int target = categoryNeighbour(list, from,
                         keyCode == KeyEvent.KEYCODE_DPAD_RIGHT);
-                if (target == RecyclerView.NO_POSITION) {
+                // Landing where the focus already is is not a jump, and swallowing the key for it
+                // leaves a remote pressing Left at nothing happening.
+                if (target == RecyclerView.NO_POSITION || target == from) {
                     return false;
                 }
                 openAtPosition(target, 3);
@@ -1340,7 +1344,10 @@ public class SettingsActivity extends AppCompatActivity
                     return i + 1;
                 }
             }
-            return RecyclerView.NO_POSITION;
+            // Nothing above and going up: the rows before the first header are a section too - the one
+            // that carries the screen's own subject and is left headerless on purpose. Without this,
+            // Left out of the first titled section reached nothing and the block was jump-proof.
+            return forward ? RecyclerView.NO_POSITION : 0;
         }
 
         /**
@@ -1348,6 +1355,13 @@ public class SettingsActivity extends AppCompatActivity
          * with the row itself focused. scrollToPreference alone scrolls the row barely into view — at
          * the bottom edge, inside a TV's overscan — and leaves a remote's focus on the first row, so
          * the first D-pad press yanks the list straight back to the top.
+         *
+         * <p>Scrolls to the row asked for and focuses the first row at or after it that can actually
+         * take focus, which is not always the same one: a header takes none, and neither does a
+         * picture or a row switched off. The subtitle previews are what made the two differ — each
+         * heads a section, so a section jump aimed straight at one and moved the list without moving
+         * the focus. The search stops at the next header, so a section with nothing live in it scrolls
+         * into view and leaves the focus where it was rather than throwing it into the section below.
          *
          * The holder can be missing on the first pre-draw, hence the few attempts. On a phone the
          * focus request is a no-op: a preference row is not focusable in touch mode.
@@ -1370,9 +1384,13 @@ public class SettingsActivity extends AppCompatActivity
                 return;
             }
             final LinearLayoutManager manager = (LinearLayoutManager) list.getLayoutManager();
+            final int focusAt = focusableFrom(list.getAdapter(), position);
             manager.scrollToPositionWithOffset(Math.max(0, position - 1), 0);
+            if (focusAt == RecyclerView.NO_POSITION) {
+                return;
+            }
             OneShotPreDrawListener.add(list, () -> {
-                final RecyclerView.ViewHolder holder = list.findViewHolderForAdapterPosition(position);
+                final RecyclerView.ViewHolder holder = list.findViewHolderForAdapterPosition(focusAt);
                 if (holder == null) {
                     openAtPosition(position, attemptsLeft - 1);
                     return;
@@ -1386,70 +1404,31 @@ public class SettingsActivity extends AppCompatActivity
         }
 
         /**
-         * Puts a chip of the actual colour in front of every label, in the list and in the summary —
-         * a colour is recognised, a colour name is recalled. Outlined, or white would be a blank gap
-         * on a light row and the transparent entry would show nothing at all.
+         * The first row at or after {@code start} that a remote can land on, within the section
+         * {@code start} falls in. A {@link PreferenceCategory} is a header and takes no focus; a row
+         * that is not selectable (the subtitle previews) or is switched off cannot take it either -
+         * {@code View.requestFocus} refuses a disabled view.
          */
-        private void showColorChips(final ListPreference preference) {
-            final CharSequence[] entries = preference.getEntries();
-            final CharSequence[] values = preference.getEntryValues();
-            final CharSequence[] chipped = new CharSequence[entries.length];
-            for (int i = 0; i < entries.length; i++) {
-                final GradientDrawable chip = new GradientDrawable();
-                chip.setShape(GradientDrawable.OVAL);
-                chip.setColor(Color.parseColor(values[i].toString()));
-                chip.setStroke(Math.max(1, Utils.dpToPx(1)), 0x80808080);
-                // The span replaces its one character with the chip's own width, so the space after it
-                // is the whole gap — no guessing how wide two blanks come out in the current font.
-                final SpannableStringBuilder label =
-                        new SpannableStringBuilder("   ").append(entries[i]);
-                label.setSpan(new ChipSpan(chip), 0, 1, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
-                chipped[i] = label;
+        private static int focusableFrom(final RecyclerView.Adapter<?> adapter, final int start) {
+            if (!(adapter instanceof PreferenceGroupAdapter)) {
+                return start;
             }
-            preference.setEntries(chipped);
-        }
-
-        /**
-         * Sits the chip on the optical middle of the text. ImageSpan's own alignments are baseline and
-         * line-bottom, both of which hang a round chip visibly low, and ALIGN_CENTER is API 29+.
-         */
-        private static class ChipSpan extends ImageSpan {
-            ChipSpan(final Drawable drawable) {
-                super(drawable);
-            }
-
-            @Override
-            public int getSize(@NonNull Paint paint, CharSequence text, int start, int end,
-                               @Nullable Paint.FontMetricsInt fontMetrics) {
-                resize(paint);
-                return super.getSize(paint, text, start, end, fontMetrics);
-            }
-
-            /**
-             * The chip is sized off the text beside it rather than a fixed dp, so it holds its
-             * proportion on a TV row (larger type than a phone's) and at any system font size.
-             */
-            private void resize(final Paint paint) {
-                final int size = Math.round(paint.getTextSize() * 0.7f);
-                final Drawable chip = getDrawable();
-                if (chip.getBounds().height() != size) {
-                    chip.setBounds(0, 0, size, size);
+            final PreferenceGroupAdapter rows = (PreferenceGroupAdapter) adapter;
+            for (int i = Math.max(0, start); i < rows.getItemCount(); i++) {
+                final Preference item = rows.getItem(i);
+                if (item instanceof PreferenceCategory) {
+                    // The one at start is the header of the section being entered; a later one is the
+                    // next section, and a jump does not carry on into it.
+                    if (i > start) {
+                        return RecyclerView.NO_POSITION;
+                    }
+                    continue;
+                }
+                if (item.isSelectable() && item.isEnabled()) {
+                    return i;
                 }
             }
-
-            @Override
-            public void draw(@NonNull Canvas canvas, CharSequence text, int start, int end, float x,
-                             int top, int y, int bottom, @NonNull Paint paint) {
-                resize(paint);
-                final Drawable chip = getDrawable();
-                final Paint.FontMetricsInt metrics = paint.getFontMetricsInt();
-                // y is the baseline; ascent is negative, so this lands mid-glyph rather than mid-line.
-                final float middle = y + (metrics.ascent + metrics.descent) / 2f;
-                canvas.save();
-                canvas.translate(x, middle - chip.getBounds().height() / 2f);
-                chip.draw(canvas);
-                canvas.restore();
-            }
+            return RecyclerView.NO_POSITION;
         }
 
         /** Where an edited language list is written back to. */
@@ -1486,15 +1465,158 @@ public class SettingsActivity extends AppCompatActivity
             });
         }
 
-        /** One text/background pair: colour chips on both lists, and neither allowed to match the other. */
+        /** The two preview rows, one on each screen that dresses a subtitle line. */
+        private static final String PREVIEW_KEY = "subtitlePreview";
+        private static final String SECONDARY_PREVIEW_KEY = "subtitleSecondaryPreview";
+        private static final String BOLD_KEY = "subtitleStyleBold";
+
+        /**
+         * The line the rows under it dress, drawn over a scene whose shore is pale where its water is
+         * dark, so the caption lands on both at once. A colour, a plate and an outline are judged against
+         * the picture they will sit on, which is the one thing a swatch beside a name cannot say - and
+         * what the swatches this replaced could not say either, since three of the six text colours are
+         * near-white and the transparent plate showed nothing at all.
+         *
+         * <p>Both lines are drawn the way the player draws them rather than imitated: the first through
+         * Media3 from the same {@link SubtitleUtils#captionStyle} the player builds, the second as a
+         * TextView on a plate, which is what {@link SecondarySubtitles} is. A preview built from its own
+         * copy of the rules is a preview of something else.
+         *
+         * <p>Sized as a screen in miniature: the row's height stands for the player's, so every fraction
+         * Media3 works in lands where it would, and the plate's corner and padding come down by the same
+         * ratio. The screen it stands for is the short side of the display - a film is watched sideways.
+         */
+        private void bindSubtitlePreview(final PreferenceViewHolder holder,
+                                         final Preference preference) {
+            if (preference == null) {
+                return;
+            }
+            final boolean hint = SECONDARY_PREVIEW_KEY.equals(preference.getKey());
+            if (!hint && !PREVIEW_KEY.equals(preference.getKey())) {
+                return;
+            }
+            // A disabled row dims its own title and summary; this one has neither, so the picture is what
+            // has to say the section is off - the look of a hint means nothing with no second line.
+            holder.itemView.setAlpha(preference.isEnabled() ? 1f : 0.38f);
+            final View lineView = holder.findViewById(R.id.subtitle_preview_line);
+            final TextView hintView = (TextView) holder.findViewById(R.id.subtitle_preview_hint);
+            if (!(lineView instanceof SubtitleView) || hintView == null) {
+                return;
+            }
+            final ListPreference scale =
+                    findPreference(hint ? "subtitleSecondaryScale" : "subtitleScale");
+            final ListPreference textColor =
+                    findPreference(hint ? "subtitleSecondaryTextColor" : "subtitleTextColor");
+            final ListPreference background =
+                    findPreference(hint ? "subtitleSecondaryBackground" : "subtitleBackground");
+            if (scale == null || textColor == null || background == null) {
+                return;
+            }
+            final Context context = holder.itemView.getContext();
+            final int height =
+                    context.getResources().getDimensionPixelSize(R.dimen.subtitle_preview_height);
+            final DisplayMetrics metrics = context.getResources().getDisplayMetrics();
+            final boolean small = Utils.isTvBox(context) || Utils.isTablet(context);
+            final float textFraction = SubtitleView.DEFAULT_TEXT_SIZE_FRACTION
+                    * SubtitleUtils.normalizeFontScale(Float.parseFloat(scale.getValue()), small);
+            final float gapFraction = SubtitleView.DEFAULT_BOTTOM_PADDING_FRACTION * 2f / 3f;
+            final int ink = Color.parseColor(textColor.getValue());
+            final int plate = Color.parseColor(background.getValue());
+            // Weight belongs to both lines and its row is on the first line's screen only, so from the
+            // second one it is read where it is stored rather than off a row that is not there.
+            final SwitchPreferenceCompat boldRow = findPreference(BOLD_KEY);
+            final boolean bold = boldRow != null ? boldRow.isChecked()
+                    : getPreferenceManager().getSharedPreferences().getBoolean(BOLD_KEY, false);
+            final String sample = getString(R.string.pref_subtitle_preview_sample);
+
+            final SubtitleView line = (SubtitleView) lineView;
+            line.setVisibility(hint ? View.GONE : View.VISIBLE);
+            hintView.setVisibility(hint ? View.VISIBLE : View.GONE);
+            if (!hint) {
+                final ListPreference edge = findPreference("subtitleEdge");
+                if (edge == null) {
+                    return;
+                }
+                line.setStyle(SubtitleUtils.captionStyle(ink, plate,
+                        Integer.parseInt(edge.getValue()), bold));
+                line.setFractionalTextSize(textFraction);
+                line.setBottomPaddingFraction(gapFraction);
+                line.setCues(Collections.singletonList(new Cue.Builder().setText(sample).build()));
+                return;
+            }
+            final float mini = height / (float) Math.min(metrics.widthPixels, metrics.heightPixels);
+            final int padH = Math.round(Utils.dpToPx(8) * mini);
+            final int padV = Math.round(Utils.dpToPx(4) * mini);
+            hintView.setText(sample);
+            hintView.setMaxLines(2);
+            hintView.setTextColor(ink);
+            hintView.setTypeface(Typeface.create(Typeface.DEFAULT,
+                    bold ? Typeface.BOLD : Typeface.NORMAL));
+            hintView.setTextSize(TypedValue.COMPLEX_UNIT_PX, textFraction * height);
+            hintView.setPadding(padH, padV, padH, padV);
+            if (plate == Color.TRANSPARENT) {
+                hintView.setBackground(null);
+            } else {
+                final GradientDrawable drawable = new GradientDrawable();
+                drawable.setCornerRadius(Utils.dpToPx(6) * mini);
+                drawable.setColor(plate);
+                hintView.setBackground(drawable);
+            }
+            final FrameLayout.LayoutParams params =
+                    (FrameLayout.LayoutParams) hintView.getLayoutParams();
+            params.bottomMargin = Math.round(gapFraction * height);
+            hintView.setLayoutParams(params);
+        }
+
+        /**
+         * A preview is drawn from what is stored, so anything that writes a subtitle setting redraws it
+         * - and a pick refused as a clash writes nothing, so it asks for nothing. One listener rather
+         * than one per row: seven rows feed the two previews, and two of them already carry a listener
+         * of their own.
+         */
+        private final SharedPreferences.OnSharedPreferenceChangeListener previewWatch =
+                (preferences, key) -> refreshPreviews();
+
+        private void refreshPreviews() {
+            final RecyclerView list = getListView();
+            final RecyclerView.Adapter<?> adapter = list == null ? null : list.getAdapter();
+            if (!(adapter instanceof PreferenceGroupAdapter)) {
+                return;
+            }
+            for (final String key : new String[]{PREVIEW_KEY, SECONDARY_PREVIEW_KEY}) {
+                final int position =
+                        ((PreferenceGroupAdapter) adapter).getPreferenceAdapterPosition(key);
+                if (position != RecyclerView.NO_POSITION) {
+                    adapter.notifyItemChanged(position);
+                }
+            }
+        }
+
+        @Override
+        public void onStart() {
+            super.onStart();
+            final SharedPreferences preferences = getPreferenceManager().getSharedPreferences();
+            if (preferences != null) {
+                preferences.registerOnSharedPreferenceChangeListener(previewWatch);
+            }
+        }
+
+        @Override
+        public void onStop() {
+            final SharedPreferences preferences = getPreferenceManager().getSharedPreferences();
+            if (preferences != null) {
+                preferences.unregisterOnSharedPreferenceChangeListener(previewWatch);
+            }
+            super.onStop();
+        }
+
+        /** One text/background pair: neither of the two allowed to be set to the colour of the other. */
         private void bindColorPair(final String textColorKey, final String backgroundKey) {
             final ListPreference textColor = findPreference(textColorKey);
             final ListPreference background = findPreference(backgroundKey);
             if (textColor == null || background == null) {
                 return;
             }
-            showColorChips(textColor);
-            showColorChips(background);
             // Text in the colour of its own box is invisible subtitles, and the two lists are far
             // enough apart that nobody would connect the cause. Refuse the pick instead.
             textColor.setOnPreferenceChangeListener((preference, value) ->
@@ -1514,10 +1636,14 @@ public class SettingsActivity extends AppCompatActivity
         }
 
         /** The chosen languages, in order, or a note that nothing is preferred. */
-        /** Everything the second line's screen holds besides the mode itself. */
+        /**
+         * Everything the second line's screen holds besides the mode itself - the whole look section,
+         * preview included, so the section greys out as one thing rather than as four rows under a
+         * picture that stayed bright.
+         */
         private static final String[] SECONDARY_DEPENDENTS = {
-                "languageSubtitleSecondary", "subtitleSecondaryScale", "subtitleSecondaryTextColor",
-                "subtitleSecondaryBackground",
+                "languageSubtitleSecondary", "subtitleSecondaryPreview", "subtitleSecondaryScale",
+                "subtitleSecondaryTextColor", "subtitleSecondaryBackground",
         };
 
         /**
@@ -1541,30 +1667,22 @@ public class SettingsActivity extends AppCompatActivity
             }
         }
 
-        /** Everything the search screen holds besides the mode itself. */
-        private static final String[] SEARCH_DEPENDENTS = {
-                "subtitleTranslateOn", "subtitleTranslateBackends", "subtitleSearchLanguage",
-                "subtitleSourceRest", "subtitleSourceStremio", "subtitleSourceShegu",
-                "subtitleSourceOpenSubtitles",
-        };
-
         /**
-         * Reflects the chosen mode: the row that leads here reports it, and with no search running the
-         * rows that configure one are greyed out rather than left live and inert. This is by hand
-         * because app:dependency watches a parent's enablement, not its value.
+         * Reflects the chosen mode on the row that leads here, and nothing else.
+         *
+         * <p>It used to grey out every other row on that screen while the mode was "never", on the
+         * reasoning that they configure a search that is not running. They do not: a search asked for
+         * from the player runs whatever the mode says - {@code offline = !subtitleSearch && !manual} in
+         * PlayerActivity - and it reads the sources, the translation and "ask for the language" exactly
+         * as an automatic one would. "Ask for the language" is manual-only, so it was the setting most
+         * plainly in force and most plainly greyed. A row that is dimmed while it still decides
+         * something is worse than no gate at all, so the gate is gone and the mode only reports itself.
          */
         private void applySearchMode(final ListPreference searchMode, final String mode,
                                      final SwitchPreferenceCompat translate) {
-            final boolean searching = !Prefs.SEARCH_OFF.equals(mode);
-            for (final String key : SEARCH_DEPENDENTS) {
-                final Preference dependent = findPreference(key);
-                if (dependent != null) {
-                    dependent.setEnabled(searching);
-                }
-            }
-            // The endpoint list answers to both: no search means no translation either, and the list is
-            // meaningless while translation itself is off.
-            enableTranslateBackends(searching, translate == null || translate.isChecked());
+            // The endpoint list is the one true gate on that screen: nothing to order if nothing is
+            // translated.
+            enableTranslateBackends(translate == null || translate.isChecked());
             // Null while the fragment is rooted at the search screen: the row lives one level up.
             final Preference screen = findPreference("subtitleSearchScreen");
             final int index = searchMode.findIndexOfValue(mode);
@@ -1574,13 +1692,13 @@ public class SettingsActivity extends AppCompatActivity
         }
 
         /**
-         * The endpoint list is live only while a search runs and translation is on. By hand rather than
-         * app:dependency, which answers to one parent and this answers to two.
+         * The endpoint list is live only while translation is on. By hand rather than app:dependency,
+         * which watches a parent's enablement rather than its checked state.
          */
-        private void enableTranslateBackends(final boolean searching, final boolean translating) {
+        private void enableTranslateBackends(final boolean translating) {
             final Preference backends = findPreference("subtitleTranslateBackends");
             if (backends != null) {
-                backends.setEnabled(searching && translating);
+                backends.setEnabled(translating);
             }
         }
 
@@ -1628,7 +1746,9 @@ public class SettingsActivity extends AppCompatActivity
      */
     private static final class GroupCards extends RecyclerView.ItemDecoration {
 
-        private static final int RADIUS = Utils.dpToPx(20);
+        // Corner.Medium, the step Material gives a card - and the step this app gives anything 72dp or
+        // taller. 20dp was a value nothing else here used: the dialog is 28, a value tile 8, a button a pill.
+        private static final int RADIUS = Utils.dpToPx(12);
 
         private final int headerGap = Utils.dpToPx(8);
         private final int hairlineInset = Utils.dpToPx(16);

--- a/app/src/main/java/com/brouken/player/SubtitleUtils.java
+++ b/app/src/main/java/com/brouken/player/SubtitleUtils.java
@@ -2,6 +2,8 @@ package com.brouken.player;
 
 import android.content.ContentResolver;
 import android.content.Context;
+import android.graphics.Color;
+import android.graphics.Typeface;
 import android.net.Uri;
 import android.text.Spannable;
 import android.text.SpannableString;
@@ -18,6 +20,7 @@ import androidx.media3.common.MediaItem;
 import androidx.media3.common.MimeTypes;
 import androidx.media3.common.text.Cue;
 import androidx.media3.common.text.CueGroup;
+import androidx.media3.ui.CaptionStyleCompat;
 
 import com.google.common.collect.ImmutableList;
 
@@ -417,6 +420,22 @@ class SubtitleUtils {
             subtitleConfigurationBuilder.setSelectionFlags(C.SELECTION_FLAG_DEFAULT);
         }
         return subtitleConfigurationBuilder.build();
+    }
+
+    /**
+     * The look of the first subtitle line, from the four settings that decide it. Here rather than in
+     * the player because the settings screen draws the same line as a preview, and a preview that is
+     * built from its own copy of these rules is a preview of something else.
+     *
+     * <p>A window behind the text is a captioning concept nobody asks for, so it stays off. The outline
+     * needs no knob either, it just has to contrast: black around every colour except black text, which
+     * only reads against a light outline.
+     */
+    static CaptionStyleCompat captionStyle(final int textColor, final int backgroundColor,
+                                           final int edgeType, final boolean bold) {
+        return new CaptionStyleCompat(textColor, backgroundColor, Color.TRANSPARENT, edgeType,
+                textColor == Color.BLACK ? Color.WHITE : Color.BLACK,
+                Typeface.create(Typeface.DEFAULT, bold ? Typeface.BOLD : Typeface.NORMAL));
     }
 
     public static float normalizeFontScale(float fontScale, boolean small) {

--- a/app/src/main/java/com/brouken/player/UiMetrics.java
+++ b/app/src/main/java/com/brouken/player/UiMetrics.java
@@ -107,8 +107,11 @@ final class UiMetrics {
     }
 
     // ---- TV overscan, synthesized as extra insets (0 on every non-TV class) ----
-    int overscanH() { return tv() ? dp(24) : 0; }
-    int overscanV() { return tv() ? dp(16) : 0; }
+    // The 5% every television keeps clear, as Android TV states it for the 960x540dp canvas: 48dp at the
+    // sides, 27dp top and bottom. At the old 24/16 the first interactive pixel sat 42dp from the side edge
+    // (24 + gridH 18) and 16dp from the bottom - inside the band a real set may not show.
+    int overscanH() { return tv() ? dp(48) : 0; }
+    int overscanV() { return tv() ? dp(27) : 0; }
     int pickerTopPadLand() { return Math.max(dp(16), overscanV()); }
 
     /**
@@ -116,8 +119,11 @@ final class UiMetrics {
      *
      * <p>One number, because a panel that changes size with the press that opened it reads as several
      * different panels. It follows the edge the panel is docked to, and that edge follows the window:
-     * a sheet docked to the bottom of a compact-width window is that edge's width, capped at the 640dp
-     * Material states for a sheet; a sheet at the end edge leaves a strip of the picture beside it —
+     * a sheet docked to the bottom of a compact-width window is that edge's width, capped at the 640dp of
+     * {@code material_bottom_sheet_max_width}; a sheet at the end edge leaves a strip of the picture beside
+     * it — the cap is the bottom sheet's number, not the side sheet's own 256dp, and it stays that way
+     * deliberately: the playlist's rail of 190dp cards needs 440dp to show a peeking third card, so
+     * narrowing to Material's side-sheet width would cost the rail the affordance that says it continues —
      * never more than 60% of a window held sideways, and never closer than 56dp to the far edge of one
      * held upright — capped at the same 640dp.
      */

--- a/app/src/main/java/com/brouken/player/UiMetrics.java
+++ b/app/src/main/java/com/brouken/player/UiMetrics.java
@@ -132,11 +132,16 @@ final class UiMetrics {
         if (windowW < 600) {
             return dp(Math.min(windowW - 8, 640));
         }
-        final int capPortrait = windowW - 56;
-        final int cap = cfg.orientation == Configuration.ORIENTATION_LANDSCAPE
-                ? Math.min(Math.round(windowW * 0.60f), capPortrait)
-                : capPortrait;
-        return dp(Math.min(640, cap));
+        // One number, and it is Google's twice over. Material gives a side sheet a 400dp maximum and ships
+        // 256dp in the library; Leanback's own television settings pane — full height, end edge — is
+        // lb_settings_pane_width, 360dp. So 360dp of usable width, plus the safe band on a television,
+        // because there the outermost 48dp is a strip a set may cut rather than somewhere to put a row.
+        // 360dp on a phone or tablet, 408dp on a television.
+        //
+        // What it has to hold is the speed panel's five segments, the widest thing in the family: they
+        // land at 65.6dp sideways and 60.8dp on a television, both over Material's own 48dp minimum touch
+        // target. The 440dp this replaces was a number of ours and nobody else's.
+        return Math.min(dp(360) + overscanH(), dp(windowW - 56));
     }
 
     // ---- typography (sp; keeps user font-scale). Columns: PHONE / sw600 / sw720 / TV ----

--- a/app/src/main/java/com/brouken/player/Utils.java
+++ b/app/src/main/java/com/brouken/player/Utils.java
@@ -54,6 +54,7 @@ import android.util.TypedValue;
 import android.view.MotionEvent;
 import android.view.View;
 import android.view.ViewGroup;
+import android.view.ViewTreeObserver;
 import android.view.Window;
 import android.view.WindowInsets;
 import android.view.WindowInsetsController;
@@ -76,6 +77,7 @@ import com.google.android.material.textfield.TextInputLayout;
 import androidx.core.content.ContextCompat;
 
 import com.google.android.material.button.MaterialButton;
+import com.google.android.material.animation.AnimationUtils;
 import com.google.android.material.color.MaterialColors;
 import com.google.android.material.shape.MaterialShapeDrawable;
 import com.google.android.material.shape.ShapeAppearanceModel;
@@ -574,7 +576,8 @@ class Utils {
         // And one width, which follows the edge rather than the content — see UiMetrics.panelWidthPx.
         final int screenWidth = activity.getResources().getDisplayMetrics().widthPixels;
         final int panelWidth = ui.panelWidthPx(cfg);
-        final int hMargin = Math.max(dpToPx(8), ui.overscanH());
+        // The only margin left anywhere: the top one under the bottom sheet, which keeps a long list from
+        // reaching the very top of the screen. A docked sheet has no others.
         final int vMargin = Math.max(dpToPx(8), ui.overscanV());
         // What actually blocks pixels while a panel is open, and nothing more. applyPickerBars hides the
         // status bar and shows the navigation bar, so reserving room for the status bar costs the card
@@ -602,13 +605,32 @@ class Utils {
             }
         }
 
+        // A panel is a DOCKED SHEET, not a floating card — the same component seen from two sides. Upright
+        // it docks to the bottom, full width, and grows up; sideways and on a television it docks to the
+        // end edge, a fixed width and the full height. Either way the two corners against the screen go
+        // square and only the leading edge is rounded, at the radius Material gives that shape: 28dp for
+        // the bottom sheet, 16dp for the side one.
+        //
+        // Why a fixed height sideways, when a card that wrapped its content seemed thriftier: the card had
+        // no silhouette. A two-row picker floated 172dp tall, a five-file playlist filled the window, and
+        // the playlist's own mode toggle moved the panel by 221dp on a television — one panel, four
+        // pictures, and which one appeared depended on how many files a folder held. A sheet has none of
+        // those variables. The price is an empty column under short content (a two-track list leaves 51 %
+        // of the field), paid deliberately: in a 440dp column that reads as a short list, where the same
+        // gap in the 575dp card it replaced read as a slab.
         final int corner = dpToPx(bottom ? 28 : 16);
+        final boolean rtl = cfg.getLayoutDirection() == View.LAYOUT_DIRECTION_RTL;
         final ShapeAppearanceModel.Builder shape = ShapeAppearanceModel.builder();
         if (bottom) {
             shape.setTopLeftCornerSize(corner).setTopRightCornerSize(corner)
                     .setBottomLeftCornerSize(0).setBottomRightCornerSize(0);
+        } else if (rtl) {
+            // END is the left edge, so that is the one that meets the screen.
+            shape.setTopLeftCornerSize(0).setBottomLeftCornerSize(0)
+                    .setTopRightCornerSize(corner).setBottomRightCornerSize(corner);
         } else {
-            shape.setAllCornerSizes(corner);
+            shape.setTopRightCornerSize(0).setBottomRightCornerSize(0)
+                    .setTopLeftCornerSize(corner).setBottomLeftCornerSize(corner);
         }
         final MaterialShapeDrawable card = new MaterialShapeDrawable(shape.build());
         // From the content's own theme, not the player's: the panels follow the appearance choice, so
@@ -629,20 +651,34 @@ class Utils {
         // bottom sheet does (paddingBottomSystemWindowInsets): the surface reaches the screen's edge and
         // the rows stop above the navigation bar. Held as a margin it left a strip of video between the
         // sheet and the edge, and a sheet with a gap under it is a card again.
-        host.setPadding(0, bottom ? Math.max(insetTop, dpToPx(56)) : insetTop, 0,
-                bottom ? 0 : insetBottom);
+        host.setPadding(0, bottom ? Math.max(insetTop, dpToPx(56)) : 0, 0, 0);
         if (bottom && insetBottom > 0) {
             content.setPadding(content.getPaddingLeft(), content.getPaddingTop(),
                     content.getPaddingRight(), content.getPaddingBottom() + insetBottom);
         }
+        if (!bottom) {
+            // The surface reaches the screen's edges; its content does not. That is Android TV's own rule
+            // — background art may cross the overscan band, anything interactive may not — and it is what
+            // lets the sheet dock instead of float. The blocked edges and the overscan therefore live as
+            // the sheet's padding rather than as its margin, added to whatever padding the panel already
+            // carries on its leading side.
+            content.setPadding(
+                    content.getPaddingLeft() + (rtl ? Math.max(insetEnd, ui.overscanH()) : 0),
+                    content.getPaddingTop() + Math.max(insetTop, ui.overscanV()),
+                    content.getPaddingRight() + (rtl ? 0 : Math.max(insetEnd, ui.overscanH())),
+                    content.getPaddingBottom() + Math.max(insetBottom, ui.overscanV()));
+        }
         final FrameLayout.LayoutParams lp = new FrameLayout.LayoutParams(
-                panelWidth, ViewGroup.LayoutParams.WRAP_CONTENT,
+                panelWidth,
+                bottom ? ViewGroup.LayoutParams.WRAP_CONTENT : ViewGroup.LayoutParams.MATCH_PARENT,
                 bottom ? Gravity.BOTTOM | Gravity.CENTER_HORIZONTAL
                         : Gravity.END | Gravity.TOP);
         if (bottom) {
+            // No side margins at all, and none at the bottom: a docked sheet is the width it is given
+            // and sits on the edge, above whatever the navigation bar left of it (that inset is the
+            // host's padding). A margin here is what made the shape read as a card glued to the bottom
+            // rather than as a sheet — detached at the sides, square where it met the screen.
             lp.setMargins(0, vMargin, 0, 0);
-        } else {
-            lp.setMargins(hMargin, vMargin, hMargin + insetEnd, vMargin);
         }
         host.addView(content, lp);
 
@@ -674,12 +710,34 @@ class Utils {
         if (window == null) {
             return;
         }
+        // The window IS the sheet: same width, same edge. That is what makes every press beyond it an
+        // outside press, which is how the panel closes without a scrim of its own.
         window.setLayout(
-                bottom ? screenWidth - dpToPx(8)
-                        : Math.min(screenWidth - dpToPx(8), panelWidth + 2 * hMargin + insetEnd),
+                bottom ? screenWidth - dpToPx(8) : Math.min(screenWidth, panelWidth),
                 ViewGroup.LayoutParams.MATCH_PARENT);
         window.setGravity(bottom ? Gravity.BOTTOM | Gravity.CENTER_HORIZONTAL : Gravity.END);
         window.setBackgroundDrawable(new ColorDrawable(Color.TRANSPARENT));
+        // A sheet slides in from the edge it is docked to. Every panel is a Theme_Translucent_NoTitleBar
+        // dialog, which fades in on the spot, and a shape that materialises in the middle of the screen
+        // reads as a rectangle that appeared rather than as a surface that was pulled in. Done on the view
+        // instead of through windowAnimationStyle so the scrim keeps its own fade underneath, and so the
+        // direction can follow the layout direction — END is the left edge in right-to-left.
+        content.getViewTreeObserver().addOnPreDrawListener(new ViewTreeObserver.OnPreDrawListener() {
+            @Override
+            public boolean onPreDraw() {
+                content.getViewTreeObserver().removeOnPreDrawListener(this);
+                if (bottom) {
+                    content.setTranslationY(content.getHeight());
+                    content.animate().translationY(0);
+                } else {
+                    content.setTranslationX(rtl ? -content.getWidth() : content.getWidth());
+                    content.animate().translationX(0);
+                }
+                content.animate().setDuration(220)
+                        .setInterpolator(AnimationUtils.LINEAR_OUT_SLOW_IN_INTERPOLATOR).start();
+                return true;
+            }
+        });
         // The picture behind a modal sheet steps back rather than competing with it.
         window.addFlags(WindowManager.LayoutParams.FLAG_DIM_BEHIND);
         window.setDimAmount(0.4f);

--- a/app/src/main/java/com/brouken/player/Utils.java
+++ b/app/src/main/java/com/brouken/player/Utils.java
@@ -62,7 +62,6 @@ import android.widget.EditText;
 import android.widget.FrameLayout;
 import android.widget.ImageButton;
 import android.widget.LinearLayout;
-import android.widget.Toast;
 
 import androidx.annotation.RequiresApi;
 import androidx.core.text.HtmlCompat;
@@ -301,7 +300,9 @@ class Utils {
         if (PlayerActivity.boostWarned || PlayerActivity.boostLevel <= 0)
             return;
         PlayerActivity.boostWarned = true;
-        Toast.makeText(context, R.string.volume_high_warning, Toast.LENGTH_SHORT).show();
+        if (context instanceof PlayerActivity) {
+            ((PlayerActivity) context).showNotice(context.getString(R.string.volume_high_warning), false);
+        }
     }
 
     /**
@@ -573,10 +574,6 @@ class Utils {
         // And one width, which follows the edge rather than the content — see UiMetrics.panelWidthPx.
         final int screenWidth = activity.getResources().getDisplayMetrics().widthPixels;
         final int panelWidth = ui.panelWidthPx(cfg);
-        // Material's own margin for a detached sheet is 16dp; 8dp here, because on a phone held sideways
-        // the panel is what the viewer came for and the strip of video beside it is not worth the room.
-        // A television wants its overscan instead — the card has an edge to lose, where the full-bleed
-        // fill before it had none.
         final int hMargin = Math.max(dpToPx(8), ui.overscanH());
         final int vMargin = Math.max(dpToPx(8), ui.overscanV());
         // What actually blocks pixels while a panel is open, and nothing more. applyPickerBars hides the
@@ -605,11 +602,6 @@ class Utils {
             }
         }
 
-        // Docked at the bottom means docked: the two corners against the edge go square, the way
-        // Material draws a bottom sheet, so the card reads as attached rather than as a card that
-        // happens to be low. And it takes the radius Material gives that shape — 28dp, its extra-large
-        // corner — where a sheet at the end edge takes the large one, 16dp. Two shapes, two numbers,
-        // both Material's own.
         final int corner = dpToPx(bottom ? 28 : 16);
         final ShapeAppearanceModel.Builder shape = ShapeAppearanceModel.builder();
         if (bottom) {
@@ -646,16 +638,10 @@ class Utils {
         final FrameLayout.LayoutParams lp = new FrameLayout.LayoutParams(
                 panelWidth, ViewGroup.LayoutParams.WRAP_CONTENT,
                 bottom ? Gravity.BOTTOM | Gravity.CENTER_HORIZONTAL
-                        : Gravity.END | Gravity.CENTER_VERTICAL);
+                        : Gravity.END | Gravity.TOP);
         if (bottom) {
-            // No side margins at all, and none at the bottom: a docked sheet is the width it is given
-            // and sits on the edge, above whatever the navigation bar left of it (that inset is the
-            // host's padding). A margin here is what made the shape read as a card glued to the bottom
-            // rather than as a sheet — detached at the sides, square where it met the screen.
             lp.setMargins(0, vMargin, 0, 0);
         } else {
-            // Horizontal gravity is END, where a margin is a bound and the blocked edge can simply be
-            // added.
             lp.setMargins(hMargin, vMargin, hMargin + insetEnd, vMargin);
         }
         host.addView(content, lp);
@@ -688,8 +674,6 @@ class Utils {
         if (window == null) {
             return;
         }
-        // The window carries the card plus its margins, so the card itself keeps the width the panel was
-        // designed at. Capped short of the screen so the window never becomes a fullscreen one.
         window.setLayout(
                 bottom ? screenWidth - dpToPx(8)
                         : Math.min(screenWidth - dpToPx(8), panelWidth + 2 * hMargin + insetEnd),

--- a/app/src/main/java/com/brouken/player/update/UpdateUi.java
+++ b/app/src/main/java/com/brouken/player/update/UpdateUi.java
@@ -12,10 +12,8 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.ImageView;
 import android.widget.LinearLayout;
-import android.widget.ProgressBar;
 import android.widget.ScrollView;
 import android.widget.TextView;
-import android.widget.Toast;
 
 import androidx.appcompat.app.AlertDialog;
 import androidx.core.content.ContextCompat;
@@ -303,7 +301,10 @@ public final class UpdateUi {
         if (activity.isFinishing()) {
             return;
         }
-        final ProgressBar bar = new ProgressBar(dialogContext, null, android.R.attr.progressBarStyleHorizontal);
+        // Material's own indicator rather than the platform bar: it takes colorPrimary, so the download
+        // wears the accent theme like everything else. It extends ProgressBar, so the calls below are the same.
+        final com.google.android.material.progressindicator.LinearProgressIndicator bar =
+                new com.google.android.material.progressindicator.LinearProgressIndicator(dialogContext);
         bar.setMax(100);
         bar.setIndeterminate(info.size <= 0);
 
@@ -347,7 +348,10 @@ public final class UpdateUi {
                     if (file != null) {
                         Updater.installApk(activity, file);
                     } else {
-                        Toast.makeText(activity, R.string.update_download_failed, Toast.LENGTH_LONG).show();
+                        com.google.android.material.snackbar.Snackbar.make(
+                                activity.findViewById(android.R.id.content),
+                                R.string.update_download_failed,
+                                com.google.android.material.snackbar.Snackbar.LENGTH_LONG).show();
                     }
                 }));
     }

--- a/app/src/main/res/drawable/bg_subtitle_preview.xml
+++ b/app/src/main/res/drawable/bg_subtitle_preview.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- The ground of the subtitle preview in settings. A ramp of grey was here first and answered the only
+     question a subtitle preview has - whether the colour, the plate and the outline hold on a dark scene
+     and on a bright one - but it read as a test card. This is the same answer as a picture: the caption
+     lands half on the dark water and half on the pale shore, so both grounds are under it at once.
+
+     Built to cost as little as a picture can. The sky and the sun are shapes, which are a shader and an
+     oval - no bitmap, no decode, nothing to hold. Only the land is a vector, only in the bottom 120dp,
+     and it is four straight-edged paths. The sun carries its own size and gravity so that it stays a
+     circle on a 360dp phone and on a 640dp card alike; nothing else in here minds being stretched.
+
+     Left out on purpose: clouds and the reflection in the water. Each cloud is a handful of curves in
+     the one layer that would then have to cover the whole row, which is the one expensive thing this
+     avoids. -->
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <item>
+        <shape android:shape="rectangle">
+            <gradient
+                android:angle="270"
+                android:endColor="#F8DFC7"
+                android:startColor="#F6C79E"
+                android:type="linear" />
+        </shape>
+    </item>
+
+    <item
+        android:width="44dp"
+        android:height="44dp"
+        android:gravity="top|center_horizontal"
+        android:top="26dp">
+        <shape android:shape="oval">
+            <solid android:color="#E0685A" />
+        </shape>
+    </item>
+
+    <item
+        android:drawable="@drawable/bg_subtitle_preview_hills"
+        android:top="60dp" />
+
+</layer-list>

--- a/app/src/main/res/drawable/bg_subtitle_preview_hills.xml
+++ b/app/src/main/res/drawable/bg_subtitle_preview_hills.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- The land of the subtitle preview: four straight-edged silhouettes, no curves, no gradients, no
+     groups. Gradients inside a vector need API 24 and this app runs from 23, and a straight-line path
+     is a fan of triangles for the rasteriser - which is what keeps this affordable on an old set.
+
+     Only the bottom 120dp of the row, because a vector renders into a cache the size of its bounds and
+     there is nothing to draw in the sky: the layer-list insets it, so the cache is two thirds of what a
+     full-height vector would hold.
+
+     The authored 320x120 is the phone's own 328x120dp to within 2%; a television stretches it sideways,
+     which flattens the peaks and does nothing worse - there is no circle in here to turn into an
+     ellipse, that is the sun's job and it lives in the layer-list at a fixed size.
+
+     The diagonal from 175,88 to 150,120 is not decoration. It is what puts dark water under the left of
+     the caption and pale shore under its right, so one glance says whether the colour and the outline
+     hold on both. It crosses the caption's own line at half the width, which is the only place that works
+     on both canvases: the caption spans about two thirds of a 360dp phone card and only a seventh of a
+     640dp one, so a boundary anywhere else misses the short line entirely. It was at 150,88 first and did
+     exactly that on a television. -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="320dp"
+    android:height="120dp"
+    android:viewportWidth="320"
+    android:viewportHeight="120">
+
+    <!-- Back to front. -->
+    <path
+        android:fillColor="#7FA6B2"
+        android:pathData="M130,88 L240,4 L320,66 L320,88 Z" />
+    <path
+        android:fillColor="#57767E"
+        android:pathData="M0,88 L100,14 L200,88 Z" />
+    <!-- The near ridge and the water are one shape because they are one colour: a path saved is a path
+         not tessellated. -->
+    <path
+        android:fillColor="#22344B"
+        android:pathData="M0,40 L48,88 L175,88 L150,120 L0,120 Z" />
+    <path
+        android:fillColor="#E9E3D6"
+        android:pathData="M175,88 L320,88 L320,120 L150,120 Z" />
+
+</vector>

--- a/app/src/main/res/layout/preference_subtitle_preview.xml
+++ b/app/src/main/res/layout/preference_subtitle_preview.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Row layout for the two subtitle previews: a miniature screen showing the line the settings under
+     it dress. Wired in SettingsActivity, which shows one of the two children - the first line is drawn
+     by Media3 from a CaptionStyleCompat, exactly as the player draws it, and the second line is a
+     TextView on a plate, exactly as SecondarySubtitles draws it. Neither is a picture of the other. -->
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="@dimen/subtitle_preview_height"
+    android:focusable="false"
+    android:importantForAccessibility="no">
+
+    <!-- A layer of its own rather than the row's background: GroupCards gives every row a ripple as
+         its background, so a ground set on the root is replaced the moment the row is bound. The scene
+         itself is three layers of shape and one small vector - see bg_subtitle_preview.xml. -->
+    <View
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:background="@drawable/bg_subtitle_preview" />
+
+    <androidx.media3.ui.SubtitleView
+        android:id="@+id/subtitle_preview_line"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent" />
+
+    <TextView
+        android:id="@+id/subtitle_preview_hint"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="bottom|center_horizontal"
+        android:visibility="gone" />
+
+</FrameLayout>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -238,6 +238,10 @@
     <string name="subtitle_secondary_unavailable">Эту дорожку нельзя показать как дополнительные субтитры</string>
     <string name="subtitle_secondary_peek_hint">Дополнительные субтитры появляются на паузе</string>
     <string name="pref_subtitle_secondary_header">Дополнительные субтитры</string>
+    <string name="pref_subtitle_section_display">Показ</string>
+    <string name="pref_subtitle_section_text">Текст</string>
+    <string name="pref_subtitle_section_backdrop">Фон и обводка</string>
+    <string name="pref_subtitle_section_translation">Перевод</string>
     <string name="pref_subtitle_secondary_mode">Когда показывать</string>
     <string name="pref_subtitle_secondary_mode_off">Никогда — дополнительных субтитров нет совсем</string>
     <string name="pref_subtitle_secondary_mode_always">Всегда — под основными субтитрами</string>
@@ -311,6 +315,7 @@
     <string name="pref_subtitle_header">Субтитры</string>
     <string name="pref_subtitle_appearance">Вид</string>
     <string name="pref_subtitle_appearance_summary">Размер, цвет, фон, обводка</string>
+    <string name="pref_subtitle_preview_sample">Так будут выглядеть субтитры</string>
     <string name="pref_subtitle_scale">Размер текста</string>
     <string name="pref_subtitle_scale_smallest">Очень мелкий</string>
     <string name="pref_subtitle_scale_small">Мелкий</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -248,6 +248,10 @@
     <string name="subtitle_secondary_unavailable">Цю дорожку не можна показати як додаткові субтитри</string>
     <string name="subtitle_secondary_peek_hint">Додаткові субтитри з’являються на паузі</string>
     <string name="pref_subtitle_secondary_header">Додаткові субтитри</string>
+    <string name="pref_subtitle_section_display">Показ</string>
+    <string name="pref_subtitle_section_text">Текст</string>
+    <string name="pref_subtitle_section_backdrop">Тло та обведення</string>
+    <string name="pref_subtitle_section_translation">Переклад</string>
     <string name="pref_subtitle_secondary_mode">Коли показувати</string>
     <string name="pref_subtitle_secondary_mode_off">Ніколи — додаткових субтитрів немає взагалі</string>
     <string name="pref_subtitle_secondary_mode_always">Завжди — під основними субтитрами</string>
@@ -311,6 +315,7 @@
     <string name="pref_subtitle_header">Субтитри</string>
     <string name="pref_subtitle_appearance">Вигляд</string>
     <string name="pref_subtitle_appearance_summary">Розмір, колір, тло, обведення</string>
+    <string name="pref_subtitle_preview_sample">Так виглядатимуть субтитри</string>
     <string name="pref_subtitle_scale">Розмір тексту</string>
     <string name="pref_subtitle_scale_smallest">Дуже малий</string>
     <string name="pref_subtitle_scale_small">Малий</string>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -26,4 +26,9 @@
     <dimen name="level_bar_width">6dp</dimen>
     <dimen name="level_bar_height">160dp</dimen>
     <dimen name="level_bar_margin">28dp</dimen>
+
+    <!-- The subtitle preview in settings: a screen in miniature, so a fraction of it reads as the same
+         fraction of a real one. A band rather than 16:9 - it is the bottom of a picture that matters,
+         and a card is at most 640dp wide while this has to stay a sensible height on a phone. -->
+    <dimen name="subtitle_preview_height">180dp</dimen>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -270,6 +270,12 @@
     <string name="subtitle_secondary_unavailable">This track cannot be shown as secondary subtitles</string>
     <string name="subtitle_secondary_peek_hint">Secondary subtitles appear when you pause</string>
     <string name="pref_subtitle_secondary_header">Secondary subtitles</string>
+    <!-- Section headers inside the subtitle screens. Each names a subject the screen holds
+         besides its own; none repeats the title above it. -->
+    <string name="pref_subtitle_section_display">Display</string>
+    <string name="pref_subtitle_section_text">Text</string>
+    <string name="pref_subtitle_section_backdrop">Background and outline</string>
+    <string name="pref_subtitle_section_translation">Translation</string>
     <string name="pref_subtitle_secondary_mode">When to show</string>
     <string name="pref_subtitle_secondary_mode_off">Never — no secondary subtitles at all</string>
     <string name="pref_subtitle_secondary_mode_always">Always — under the main subtitles</string>
@@ -333,6 +339,8 @@
     <string name="pref_subtitle_header">Subtitle</string>
     <string name="pref_subtitle_appearance">Appearance</string>
     <string name="pref_subtitle_appearance_summary">Size, colour, background, outline</string>
+    <!-- The line drawn in the settings preview: it says what it is, so nothing has to label it. -->
+    <string name="pref_subtitle_preview_sample">This is how subtitles will look</string>
     <string name="pref_subtitle_scale">Text size</string>
     <string name="pref_subtitle_scale_smallest">Very small</string>
     <string name="pref_subtitle_scale_small">Small</string>

--- a/app/src/main/res/xml/root_preferences.xml
+++ b/app/src/main/res/xml/root_preferences.xml
@@ -9,6 +9,10 @@
          or more moves behind a row of its own (Skip segments, Watch together, subtitle Appearance).
          Paying a tap to reveal three switches is worse than reading them.
 
+         Sections inside a screen, where a screen holds more than one subject: the screen's own subject
+         sits at the top with no header, and every other subject gets one. A header that repeats the
+         screen's title says nothing, and a tap to reach a second subject costs more than a header does.
+
          Only these top rows carry a glyph. It says "this leads somewhere"; inside a screen every row is
          a setting, and a column of icons there would say nothing. The glyphs are the player's own, drawn
          white for video, so SettingsFragment tints them to the surface accent. -->
@@ -220,70 +224,95 @@
             app:summary="@string/pref_subtitle_header_summary"
             app:title="@string/pref_subtitle_header">
 
+            <!-- Four doors, in the order the questions come: which subtitles are wanted, whether a second
+                 line runs under them, where a missing one is fetched from, and what all of it looks like.
+                 Each screen behind them keeps its own subject headerless at the top and gives a header to
+                 anything that is a different subject - see the rule at the top of this file. -->
+
             <!-- Ordered list of languages, edited in LanguagePriorityDialog; the summary lists them.
                  No defaultValue: unset means no preferred subtitle language at all. -->
             <Preference
                 app:key="languageSubtitle"
                 app:title="@string/pref_language_subtitle" />
 
-            <!-- Everything the second line has, behind one row. It was two halves on two screens — the
-                 language here, the look inside Appearance — which is one place too few to find any of it
-                 and one row too many for this category, which the rule at the top of this file caps at
-                 four. The summary names the mode, so "is there a second line at all" reads without a tap. -->
+            <!-- Everything the second line has, behind one row. It was two halves on two screens - the
+                 language here, the look inside the first line's Appearance - which is one place too few to
+                 find any of it. The summary names the mode, so "is there a second line at all" reads
+                 without a tap. -->
             <PreferenceScreen
                 app:key="subtitleSecondaryScreen"
                 app:title="@string/pref_subtitle_secondary_header">
 
-                <!-- Off takes the feature away rather than just the line: no row in the player's subtitle
-                     picker, nothing searched for it, no band under the first line. Always is what the second
-                     line did before it had a mode, and so the default: an absent value means no change for
-                     anyone already watching with two lines. -->
-                <ListPreference
-                    app:key="subtitleSecondaryMode"
-                    app:defaultValue="always"
-                    app:entries="@array/subtitle_secondary_mode_entries"
-                    app:entryValues="@array/subtitle_secondary_mode_values"
-                    app:title="@string/pref_subtitle_secondary_mode"
-                    app:useSimpleSummaryProvider="true" />
+                <!-- Whether the line runs at all, and what it says. Two questions that have nothing to do
+                     with how it is drawn, which is why they are a section of their own. -->
+                <PreferenceCategory app:title="@string/pref_subtitle_section_display">
 
-                <!-- The second line's own list, and the whole of "start with two subtitle lines": with a
-                     language in here the player looks for one and turns it on by itself. Separate from the
-                     first line's list because the two want opposite things — the language being learned on
-                     the first, the one already known on the second. A language in both lists belongs to the
-                     first line: the same words twice, once under the other, is not a hint. -->
-                <Preference
-                    app:key="languageSubtitleSecondary"
-                    app:title="@string/pref_language_subtitle_secondary" />
+                    <!-- Off takes the feature away rather than just the line: no row in the player's
+                         subtitle picker, nothing searched for it, no band under the first line. Always is
+                         what the second line did before it had a mode, and so the default: an absent value
+                         means no change for anyone already watching with two lines. -->
+                    <ListPreference
+                        app:key="subtitleSecondaryMode"
+                        app:defaultValue="always"
+                        app:entries="@array/subtitle_secondary_mode_entries"
+                        app:entryValues="@array/subtitle_secondary_mode_values"
+                        app:title="@string/pref_subtitle_secondary_mode"
+                        app:useSimpleSummaryProvider="true" />
 
-                <!-- Size, colour and plate of its own. Edge and weight stay inherited from the first line —
-                     nobody sets an outline for one line and not the other. The same three lists the main
-                     line uses, so the colour chips and the clash check in SettingsActivity cover these for
-                     free. The defaults are chosen so that nobody has to come here: the same size as the
-                     main subtitles, dimmed text on a translucent plate, which is what tells a hint apart from the
-                     line being read. -->
-                <ListPreference
-                    app:key="subtitleSecondaryScale"
-                    app:defaultValue="1.0"
-                    app:entries="@array/subtitle_scale_entries"
-                    app:entryValues="@array/subtitle_scale_values"
-                    app:title="@string/pref_subtitle_scale"
-                    app:useSimpleSummaryProvider="true" />
+                    <!-- The second line's own list, and the whole of "start with two subtitle lines": with
+                         a language in here the player looks for one and turns it on by itself. Separate
+                         from the first line's list because the two want opposite things - the language
+                         being learned on the first, the one already known on the second. A language in
+                         both lists belongs to the first line: the same words twice, once under the other,
+                         is not a hint. -->
+                    <Preference
+                        app:key="languageSubtitleSecondary"
+                        app:title="@string/pref_language_subtitle_secondary" />
 
-                <ListPreference
-                    app:key="subtitleSecondaryTextColor"
-                    app:defaultValue="#FFCCCCCC"
-                    app:entries="@array/subtitle_text_color_entries"
-                    app:entryValues="@array/subtitle_text_color_values"
-                    app:title="@string/pref_subtitle_text_color"
-                    app:useSimpleSummaryProvider="true" />
+                </PreferenceCategory>
 
-                <ListPreference
-                    app:key="subtitleSecondaryBackground"
-                    app:defaultValue="#80000000"
-                    app:entries="@array/subtitle_background_entries"
-                    app:entryValues="@array/subtitle_background_values"
-                    app:title="@string/pref_subtitle_background"
-                    app:useSimpleSummaryProvider="true" />
+                <!-- Size, colour and plate of its own. Edge and weight are not here and never will be:
+                     they stay inherited from the first line, because nobody sets an outline for one line
+                     and not the other. The same three lists the main line uses, so the clash check in
+                     SettingsActivity covers these for free. The defaults are chosen so that nobody has to
+                     come here at all: the same size as the main subtitles, dimmed text on a translucent
+                     plate, which is what tells a hint apart from the line being read.
+
+                     The whole section, preview included, greys out with the second line switched off. -->
+                <PreferenceCategory app:title="@string/pref_subtitle_appearance">
+
+                    <!-- The hint as the rows below it dress it, drawn by SettingsActivity. -->
+                    <Preference
+                        app:key="subtitleSecondaryPreview"
+                        app:layout="@layout/preference_subtitle_preview"
+                        app:persistent="false"
+                        app:selectable="false" />
+
+                    <ListPreference
+                        app:key="subtitleSecondaryScale"
+                        app:defaultValue="1.0"
+                        app:entries="@array/subtitle_scale_entries"
+                        app:entryValues="@array/subtitle_scale_values"
+                        app:title="@string/pref_subtitle_scale"
+                        app:useSimpleSummaryProvider="true" />
+
+                    <ListPreference
+                        app:key="subtitleSecondaryTextColor"
+                        app:defaultValue="#FFCCCCCC"
+                        app:entries="@array/subtitle_text_color_entries"
+                        app:entryValues="@array/subtitle_text_color_values"
+                        app:title="@string/pref_subtitle_text_color"
+                        app:useSimpleSummaryProvider="true" />
+
+                    <ListPreference
+                        app:key="subtitleSecondaryBackground"
+                        app:defaultValue="#80000000"
+                        app:entries="@array/subtitle_background_entries"
+                        app:entryValues="@array/subtitle_background_values"
+                        app:title="@string/pref_subtitle_background"
+                        app:useSimpleSummaryProvider="true" />
+
+                </PreferenceCategory>
 
             </PreferenceScreen>
 
@@ -295,6 +324,9 @@
                 app:key="subtitleSearchScreen"
                 app:title="@string/pref_subtitle_search_screen">
 
+                <!-- The search itself, which is what this screen is called after, so it carries no header
+                     of its own. What follows it does: a translation and a list of hosts are each their own
+                     subject. -->
                 <ListPreference
                     app:key="subtitleSearchMode"
                     app:defaultValue="off"
@@ -303,34 +335,42 @@
                     app:title="@string/pref_subtitle_search_when"
                     app:useSimpleSummaryProvider="true" />
 
-                <!-- Everything below configures a search. With none running they are live rows that do
-                     nothing, so SettingsActivity greys them out — app:dependency keys off a parent's
-                     enablement rather than off its value, so a ListPreference cannot drive it. -->
-                <!-- The summary names who the text is handed to: a machine translation is somebody else's
-                     service, and that belongs next to the switch that turns it on, not in a changelog. -->
-                <SwitchPreferenceCompat
-                    app:key="subtitleTranslateOn"
-                    app:defaultValue="true"
-                    android:summaryOn="@string/pref_subtitle_translate_on"
-                    android:summaryOff="@string/pref_subtitle_translate_off"
-                    app:title="@string/pref_subtitle_translate" />
-
-                <!-- Enabled endpoints in the order to try them, edited in LanguagePriorityDialog; the
-                     summary lists them. No defaultValue: SubtitleTranslate owns it. -->
-                <Preference
-                    app:key="subtitleTranslateBackends"
-                    app:title="@string/pref_subtitle_translate_backends" />
-
+                <!-- Manual searches only, and it stays live with the mode set to never: a search asked for
+                     from the player runs whatever the mode says (PlayerActivity: offline = !subtitleSearch
+                     && !manual). Everything on this screen was greyed out under that mode until
+                     2026-09-05, which said these settings do nothing while they were all still in force. -->
                 <SwitchPreferenceCompat
                     app:key="subtitleSearchLanguage"
                     app:defaultValue="false"
                     app:summary="@string/pref_subtitle_search_language_summary"
                     app:title="@string/pref_subtitle_search_language" />
 
+                <PreferenceCategory app:title="@string/pref_subtitle_section_translation">
+
+                    <!-- The summary names who the text is handed to: a machine translation is somebody
+                         else's service, and that belongs next to the switch that turns it on, not in a
+                         changelog. -->
+                    <SwitchPreferenceCompat
+                        app:key="subtitleTranslateOn"
+                        app:defaultValue="true"
+                        android:summaryOn="@string/pref_subtitle_translate_on"
+                        android:summaryOff="@string/pref_subtitle_translate_off"
+                        app:title="@string/pref_subtitle_translate" />
+
+                    <!-- Enabled endpoints in the order to try them, edited in LanguagePriorityDialog; the
+                         summary lists them. Greyed out with the switch above off, which is the one gate on
+                         this screen that is true: there is nothing to order if nothing is translated. No
+                         defaultValue: SubtitleTranslate owns it. -->
+                    <Preference
+                        app:key="subtitleTranslateBackends"
+                        app:title="@string/pref_subtitle_translate_backends" />
+
+                </PreferenceCategory>
+
                 <!-- Asked all at once and answered top to bottom, which is why OpenSubtitles.com stands
                      first: it is the only one that knows whether a file is machine-translated, so it is
                      the only one whose answer says anything about quality. Individually switchable so a
-                     single source can be exercised on its own when a result looks wrong — a testing
+                     single source can be exercised on its own when a result looks wrong - a testing
                      affordance, which is why it sits at the bottom of a sub-screen and not on the way to
                      anything. -->
                 <PreferenceCategory
@@ -365,52 +405,73 @@
 
             </PreferenceScreen>
 
-
             <PreferenceScreen
                 app:key="subtitleAppearance"
                 app:summary="@string/pref_subtitle_appearance_summary"
                 app:title="@string/pref_subtitle_appearance">
 
-                <ListPreference
-                    app:key="subtitleScale"
-                    app:defaultValue="1.0"
-                    app:entries="@array/subtitle_scale_entries"
-                    app:entryValues="@array/subtitle_scale_values"
-                    app:title="@string/pref_subtitle_scale"
-                    app:useSimpleSummaryProvider="true" />
+                <!-- What every row under it adds up to, drawn by SettingsActivity over a scene that is
+                     dark under one half of the line and pale under the other: a colour is judged against
+                     the picture it will sit on, not by a swatch beside its name. Above both sections and
+                     inside neither - it is the whole screen's answer, not one section's. -->
+                <Preference
+                    app:key="subtitlePreview"
+                    app:layout="@layout/preference_subtitle_preview"
+                    app:persistent="false"
+                    app:selectable="false" />
 
-                <!-- Entries get a colour chip in SettingsActivity, and the pair is checked there so the
-                     text cannot be set to the colour of its own background. -->
-                <ListPreference
-                    app:key="subtitleTextColor"
-                    app:defaultValue="#FFFFFFFF"
-                    app:entries="@array/subtitle_text_color_entries"
-                    app:entryValues="@array/subtitle_text_color_values"
-                    app:title="@string/pref_subtitle_text_color"
-                    app:useSimpleSummaryProvider="true" />
+                <!-- The glyphs: how big, what colour, how heavy. -->
+                <PreferenceCategory app:title="@string/pref_subtitle_section_text">
 
-                <ListPreference
-                    app:key="subtitleBackground"
-                    app:defaultValue="#00000000"
-                    app:entries="@array/subtitle_background_entries"
-                    app:entryValues="@array/subtitle_background_values"
-                    app:title="@string/pref_subtitle_background"
-                    app:useSimpleSummaryProvider="true" />
+                    <ListPreference
+                        app:key="subtitleScale"
+                        app:defaultValue="1.0"
+                        app:entries="@array/subtitle_scale_entries"
+                        app:entryValues="@array/subtitle_scale_values"
+                        app:title="@string/pref_subtitle_scale"
+                        app:useSimpleSummaryProvider="true" />
 
-                <ListPreference
-                    app:key="subtitleEdge"
-                    app:defaultValue="1"
-                    app:entries="@array/subtitle_edge_entries"
-                    app:entryValues="@array/subtitle_edge_values"
-                    app:title="@string/pref_subtitle_edge"
-                    app:useSimpleSummaryProvider="true" />
+                    <!-- The pair is checked in SettingsActivity so the text cannot be set to the colour of
+                         its own background - the other half of the pair is in the section below, which is
+                         exactly why the check is needed rather than left to the eye. -->
+                    <ListPreference
+                        app:key="subtitleTextColor"
+                        app:defaultValue="#FFFFFFFF"
+                        app:entries="@array/subtitle_text_color_entries"
+                        app:entryValues="@array/subtitle_text_color_values"
+                        app:title="@string/pref_subtitle_text_color"
+                        app:useSimpleSummaryProvider="true" />
 
-                <SwitchPreferenceCompat
-                    app:key="subtitleStyleBold"
-                    app:defaultValue="false"
-                    android:summaryOn="@string/pref_subtitle_style_bold_on"
-                    android:summaryOff="@string/pref_subtitle_style_bold_off"
-                    app:title="@string/pref_subtitle_style_bold" />
+                    <SwitchPreferenceCompat
+                        app:key="subtitleStyleBold"
+                        app:defaultValue="false"
+                        android:summaryOn="@string/pref_subtitle_style_bold_on"
+                        android:summaryOff="@string/pref_subtitle_style_bold_off"
+                        app:title="@string/pref_subtitle_style_bold" />
+
+                </PreferenceCategory>
+
+                <!-- What is behind the glyphs and what is around them. Both answer the same question -
+                     whether the line survives a bright frame - and neither is about the text itself. -->
+                <PreferenceCategory app:title="@string/pref_subtitle_section_backdrop">
+
+                    <ListPreference
+                        app:key="subtitleBackground"
+                        app:defaultValue="#00000000"
+                        app:entries="@array/subtitle_background_entries"
+                        app:entryValues="@array/subtitle_background_values"
+                        app:title="@string/pref_subtitle_background"
+                        app:useSimpleSummaryProvider="true" />
+
+                    <ListPreference
+                        app:key="subtitleEdge"
+                        app:defaultValue="1"
+                        app:entries="@array/subtitle_edge_entries"
+                        app:entryValues="@array/subtitle_edge_values"
+                        app:title="@string/pref_subtitle_edge"
+                        app:useSimpleSummaryProvider="true" />
+
+                </PreferenceCategory>
 
             </PreferenceScreen>
 


### PR DESCRIPTION
Three separate subjects, one per commit, so any of them can be reverted alone.

### Subtitles are chosen against a picture, not a list of words

The appearance screen asked for a size, a colour, a background and an outline and answered each with a word. It now opens on a 180dp preview band with a horizon in it and the sample line where a subtitle sits, redrawn on every change. The colour lists lose their `ImageSpan` chips with it — a swatch glued into a label had to be resized against the paint on every measure pass and still sat on the baseline. The subtitle screens also gain section headers (Display · Text · Background and outline · Translation), and two remote-control focus faults are fixed: the first focusable row was skipped when a screen opened at a header, and a search that found nothing walked focus off the end of the list.

### A message about the player belongs on the player, not over it

Twelve toasts become Snackbars anchored to the bottom bar. A toast lands wherever the system puts it — on a phone that is over the seek bar — cannot be dismissed, and looks like nothing else in the app.

Same pass over the rest: `LinearProgressIndicator` in the update sheet, `MaterialCheckBox` in the Watch Party dialog, and the settings group cards drop from a 20dp radius to 12dp — 20dp is the shape scale's extra-large, which belongs to a sheet.

Two dead buttons are removed rather than fixed (`buttonOpen`, `buttonSkipOffset`: built, wired, never shown), the side menu gets a real fade at its cut, and the television safe area is corrected to the 48/27dp Android TV states for a 960×540dp canvas — at the old 24/16 the first interactive pixel sat inside a band a real set may not show.

### A panel is a docked sheet, not a floating card

The picker had no silhouette. Sideways it wrapped its content, so a two-track list floated 172dp tall while a five-file playlist filled the window, and the playlist's grid toggle moved the panel by 221dp on a television — one panel, four pictures, decided by how many audio tracks a file happened to carry.

It docks now, on both orientations: bottom edge and full width under 600dp, end edge and full height above it, square where it meets the screen and rounded only on the leading edge. The surface reaches the screen's edges and its content stays in the safe field.

The width is Material's rather than ours. M3 gives a side sheet a 400dp maximum and the library ships 256dp; Leanback's own television settings pane is 360dp, full height, end edge. So **360dp of usable width plus the 48dp safe band on a television** — measured on the build at 359.6dp on a phone sideways and 408dp on a television. The speed panel's five segments, the widest thing in the family, land at 65.6dp and 60.8dp, both over Material's 48dp minimum touch target. The 440dp this replaces was ours alone and cost 80dp of picture in every landscape window.

It also slides 220ms from the edge it is docked to instead of fading in on the spot, mirrored under RTL, with no animation resources added.

**The price, paid deliberately:** a full-height sheet under a short list leaves an empty column — 304dp of 540 on a television for a two-track picker, measured. Nothing is padded to hide it. A translucent surface was built at 88% and 93%, put on the television emulator over a test pattern of pure primaries and measured (title contrast rose to 15.5:1; the picture leaking into the empty column fell to 11 levels per channel from 19) — and rejected on looking at it. The surface stays opaque.

### Checked

`assembleLatestUniversalDebug`, then run on the `tv_test` television emulator (960×540dp) and the `ddd_test` phone emulator in landscape, with a two-track file — the shortest list the app can produce. Widths measured off the pixels, not computed.

Still open, and untouched here: the playlist's grid mode. Cards are 247dp on a television and 190dp on a phone; two across needs 440–560dp of content and a 360dp sheet gives 312dp. It survives as a portrait-only mode or it goes — a separate decision on its own evidence.
