### PR TITLE
The error screen joins the design system, and a field dialog stops squeezing

### DIFF
--- a/app/src/main/java/com/brouken/player/EmptyState.java
+++ b/app/src/main/java/com/brouken/player/EmptyState.java
@@ -229,9 +229,8 @@ class EmptyState {
             input.setText(pasted.toString());
             input.setSelection(input.getText().length());
         }
-        Utils.keyboardResizes(new MaterialAlertDialogBuilder(dialogContext)
+        Utils.keyboardResizes(Utils.fieldDialog(dialogContext, fields)
                 .setTitle(R.string.empty_state_link)
-                .setView(fields)
                 .setPositiveButton(android.R.string.ok,
                         (dialog, which) -> openLink(input.getText().toString()))
                 .setNegativeButton(android.R.string.cancel, null)

--- a/app/src/main/java/com/brouken/player/ErrorActivity.java
+++ b/app/src/main/java/com/brouken/player/ErrorActivity.java
@@ -8,7 +8,6 @@ import android.content.Intent;
 import android.content.res.Configuration;
 import android.content.res.Resources;
 import android.graphics.Bitmap;
-import android.graphics.BitmapFactory;
 import android.hardware.display.DisplayManager;
 import android.os.Build;
 import android.os.Bundle;
@@ -16,25 +15,24 @@ import android.os.Process;
 import android.os.StatFs;
 import android.os.SystemClock;
 import android.preference.PreferenceManager;
-import android.provider.Settings;
 import android.util.DisplayMetrics;
+import android.util.TypedValue;
 import android.view.Display;
 import android.view.View;
 import android.widget.ImageView;
-import android.widget.ProgressBar;
 import android.widget.TextView;
-import android.widget.Toast;
 
 import androidx.appcompat.app.AppCompatActivity;
+
+import com.google.android.material.button.MaterialButton;
+import com.google.android.material.progressindicator.LinearProgressIndicator;
+import com.google.android.material.snackbar.Snackbar;
 
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.PrintWriter;
 import java.io.StringWriter;
-import java.net.HttpURLConnection;
 import java.net.Socket;
-import java.net.URL;
-import java.net.URLEncoder;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.Locale;
@@ -59,8 +57,8 @@ public class ErrorActivity extends AppCompatActivity {
     private String report;
     private String uploadedUrl;
 
-    private View btnUpload;
-    private ProgressBar uploadProgress;
+    private MaterialButton btnUpload;
+    private LinearProgressIndicator uploadProgress;
     private View uploadResult;
     private TextView uploadUrl;
     private ImageView qrImage;
@@ -101,9 +99,10 @@ public class ErrorActivity extends AppCompatActivity {
         uploadUrl = findViewById(R.id.uploadUrl);
         qrImage = findViewById(R.id.qrImage);
 
-        // The four actions wear the contour every chrome control wears on a remote, not the theme's wash.
+        // Every action is a Material button now, so each one takes the contour the rest of the app's
+        // buttons take on a remote: the filled one's edge appears, the outlined ones' widens 1dp -> 2dp.
         for (final int id : new int[]{R.id.btnCopy, R.id.btnShare, R.id.btnUpload, R.id.btnClose}) {
-            findViewById(id).setForeground(Utils.chromeForeground(this, 0));
+            Utils.focusRing(findViewById(id));
         }
         findViewById(R.id.btnCopy).setOnClickListener(v -> copy(report));
         // Nothing on a TV box can empty the clipboard — no keyboard, no text app — so Copy is a dead end
@@ -113,12 +112,30 @@ public class ErrorActivity extends AppCompatActivity {
         }
         findViewById(R.id.btnShare).setOnClickListener(v -> share(report));
         btnUpload.setOnClickListener(v -> upload());
-        uploadUrl.setOnClickListener(v -> copy(uploadUrl.getText().toString()));
         findViewById(R.id.btnClose).setOnClickListener(v -> finish());
 
+        // A set is read from three metres: the TV column of the type scale (DESIGN.md 4) rather than the
+        // phone's, which is what the fixed sizes in the layout are.
+        if (Utils.isTvBox(this)) {
+            textSize(R.id.errorTitle, 26f);
+            textSize(R.id.errorMessage, 17f);
+            textSize(R.id.errorDetails, 15f);
+        }
+
+        // Close, not the filled button: sending the report publishes it, and the first press of a remote
+        // on a screen the viewer did not ask for should not be the one that does that.
         findViewById(R.id.btnClose).requestFocus();
 
         animateIn();
+    }
+
+    private void textSize(final int id, final float sp) {
+        ((TextView) findViewById(id)).setTextSize(TypedValue.COMPLEX_UNIT_SP, sp);
+    }
+
+    /** What a toast used to say here. A snackbar is the one notice surface the app has (DESIGN.md 8). */
+    private void notice(final int textRes) {
+        Snackbar.make(findViewById(android.R.id.content), textRes, Snackbar.LENGTH_SHORT).show();
     }
 
     /**
@@ -286,9 +303,7 @@ public class ErrorActivity extends AppCompatActivity {
 
     private void animateIn() {
         // A subtle rise+fade so the screen doesn't slam in; skipped when the user disables animations.
-        final float scale = Settings.Global.getFloat(getContentResolver(),
-                Settings.Global.ANIMATOR_DURATION_SCALE, 1f);
-        if (scale == 0f) {
+        if (Utils.isReducedMotion(this)) {
             return;
         }
         final View root = findViewById(android.R.id.content);
@@ -301,7 +316,7 @@ public class ErrorActivity extends AppCompatActivity {
         final ClipboardManager cm = (ClipboardManager) getSystemService(CLIPBOARD_SERVICE);
         if (cm != null) {
             cm.setPrimaryClip(ClipData.newPlainText("Just+ Player error", text));
-            Toast.makeText(this, R.string.error_copied, Toast.LENGTH_SHORT).show();
+            notice(R.string.error_copied);
         }
     }
 
@@ -313,26 +328,35 @@ public class ErrorActivity extends AppCompatActivity {
         startActivity(Intent.createChooser(intent, getString(R.string.error_share)));
     }
 
+    /**
+     * The screen's one forward action, in its three states: send, sending, sent. Once the report is up
+     * the button's job changes to handing over the link it earned — which is also how a television
+     * reaches that link at all, the URL itself being unfocusable text.
+     */
     private void upload() {
         if (uploadedUrl != null) {
-            showUploaded(uploadedUrl);
+            copy(uploadedUrl);
             return;
         }
         btnUpload.setEnabled(false);
-        uploadProgress.setVisibility(View.VISIBLE);
+        btnUpload.setText(R.string.error_uploading);
+        uploadProgress.show();
         new Thread(() -> {
             final String url = uploadToTermbin(report);
             runOnUiThread(() -> {
                 if (isFinishing()) {
                     return;
                 }
-                uploadProgress.setVisibility(View.GONE);
+                uploadProgress.hide();
                 btnUpload.setEnabled(true);
                 if (url != null) {
                     uploadedUrl = url;
+                    btnUpload.setText(R.string.error_copy_link);
+                    btnUpload.setIconResource(R.drawable.ic_link_24dp);
                     showUploaded(url);
                 } else {
-                    Toast.makeText(this, R.string.error_upload_failed, Toast.LENGTH_SHORT).show();
+                    btnUpload.setText(R.string.error_upload);
+                    notice(R.string.error_upload_failed);
                 }
             });
         }).start();
@@ -343,18 +367,14 @@ public class ErrorActivity extends AppCompatActivity {
         findViewById(R.id.errorDetails).setVisibility(View.GONE);
         uploadUrl.setText(url);
         uploadResult.setVisibility(View.VISIBLE);
-        loadQr(url);
-    }
-
-    private void loadQr(final String url) {
-        new Thread(() -> {
-            final Bitmap bitmap = fetchQr(url);
-            runOnUiThread(() -> {
-                if (!isFinishing() && bitmap != null) {
-                    qrImage.setImageBitmap(bitmap);
-                }
-            });
-        }).start();
+        // Drawn here rather than fetched from api.qrserver.com, which is what this screen used to do: the
+        // app already encodes its invite codes with zxing (Utils.qrBitmap), and a report's URL is not
+        // something to hand to a third service on the way to showing it.
+        // Encoded at the view's own pixel size, so nothing is scaled: an upscaled code is a blurred one.
+        final Bitmap qr = Utils.qrBitmap(url, qrImage.getLayoutParams().width);
+        if (qr != null) {
+            qrImage.setImageBitmap(qr);
+        }
     }
 
     // Raw-socket paste to termbin.com:9999 — it echoes back the public URL of the pasted text.
@@ -378,23 +398,4 @@ public class ErrorActivity extends AppCompatActivity {
         }
     }
 
-    private static Bitmap fetchQr(final String url) {
-        HttpURLConnection connection = null;
-        try {
-            final String api = "https://api.qrserver.com/v1/create-qr-code/?size=300x300&data="
-                    + URLEncoder.encode(url, "UTF-8");
-            connection = (HttpURLConnection) new URL(api).openConnection();
-            connection.setConnectTimeout(10000);
-            connection.setReadTimeout(10000);
-            try (InputStream in = connection.getInputStream()) {
-                return BitmapFactory.decodeStream(in);
-            }
-        } catch (Exception e) {
-            return null;
-        } finally {
-            if (connection != null) {
-                connection.disconnect();
-            }
-        }
-    }
 }

--- a/app/src/main/java/com/brouken/player/PlayerActivity.java
+++ b/app/src/main/java/com/brouken/player/PlayerActivity.java
@@ -10021,9 +10021,8 @@ public class PlayerActivity extends Activity {
         // not exist.
         input.setText(mPrefs.togetherPassword);
         input.setSelection(input.getText().length());
-        showFieldDialog(new MaterialAlertDialogBuilder(dialogContext)
+        showFieldDialog(Utils.fieldDialog(dialogContext, fields)
                 .setTitle(code)
-                .setView(fields)
                 .setPositiveButton(android.R.string.ok,
                         (dialog, which) -> joinRoom(code, input.getText().toString()))
                 .setNegativeButton(android.R.string.cancel, null)
@@ -10077,9 +10076,8 @@ public class PlayerActivity extends Activity {
         fields.addView(listed);
         fields.addView(note);
 
-        final AlertDialog dialog = new MaterialAlertDialogBuilder(dialogContext)
+        final AlertDialog dialog = Utils.fieldDialog(dialogContext, fields)
                 .setTitle(getString(R.string.together_create_title, code))
-                .setView(fields)
                 .setPositiveButton(android.R.string.ok, (d, which) -> {
                     mPrefs.updateTogetherPublic(listed.isChecked());
                     openRoom(code,
@@ -10142,9 +10140,8 @@ public class PlayerActivity extends Activity {
         // truthfully and quite uselessly, that no such room exists.
         final EditText password = Utils.textField(fields, getString(R.string.together_password));
 
-        showFieldDialog(new MaterialAlertDialogBuilder(dialogContext)
+        showFieldDialog(Utils.fieldDialog(dialogContext, fields)
                 .setTitle(R.string.together_join)
-                .setView(fields)
                 .setPositiveButton(android.R.string.ok, (dialog, which) -> {
                     final String entered = code.getText().toString().trim().toUpperCase(Locale.US);
                     if (Room.isCode(entered)) {

--- a/app/src/main/java/com/brouken/player/Utils.java
+++ b/app/src/main/java/com/brouken/player/Utils.java
@@ -63,6 +63,7 @@ import android.widget.EditText;
 import android.widget.FrameLayout;
 import android.widget.ImageButton;
 import android.widget.LinearLayout;
+import android.widget.ScrollView;
 
 import androidx.annotation.RequiresApi;
 import androidx.core.text.HtmlCompat;
@@ -79,6 +80,7 @@ import androidx.core.content.ContextCompat;
 import com.google.android.material.button.MaterialButton;
 import com.google.android.material.animation.AnimationUtils;
 import com.google.android.material.color.MaterialColors;
+import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 import com.google.android.material.shape.MaterialShapeDrawable;
 import com.google.android.material.shape.ShapeAppearanceModel;
 
@@ -1421,6 +1423,32 @@ class Utils {
         final int pad = dpToPx(24);
         fields.setPadding(pad, 0, pad, 0);
         return fields;
+    }
+
+    /**
+     * A dialog that carries a strip of {@link #textField} rows, sized for a window a keyboard has taken
+     * most of. Two things had to give on a 360x800dp phone whose keyboard leaves 385dp:
+     *
+     * <p>The strip goes in a scroller. An alert dialog gives its custom panel whatever room is left once
+     * the title and the buttons have taken theirs and measures it at exactly that, and a bare strip
+     * answers that by squeezing its last field to a 20dp sliver — a scroller answers it by scrolling,
+     * and carries the focused field into view with it.
+     *
+     * <p>And the card is allowed to use the window: Material keeps 80dp clear above and below an alert,
+     * which is 160dp of a short window spent on air. 24dp is what Material itself leaves around a picker
+     * dialog, and it is the difference between both fields standing there and one of them below the fold.
+     * The insets only cap the card, so nothing moves on a screen where it already fits.
+     */
+    static MaterialAlertDialogBuilder fieldDialog(final Context context, final View fields) {
+        final ScrollView scroll = new ScrollView(context);
+        // The same hairline the dialog draws over its own message when that scrolls, for the same
+        // reason: a field cut off at the edge of the panel has to look cut off rather than broken.
+        scroll.setScrollIndicators(View.SCROLL_INDICATOR_TOP | View.SCROLL_INDICATOR_BOTTOM);
+        scroll.addView(fields);
+        return new MaterialAlertDialogBuilder(context)
+                .setView(scroll)
+                .setBackgroundInsetTop(dpToPx(24))
+                .setBackgroundInsetBottom(dpToPx(24));
     }
 
     /**

--- a/app/src/main/res/layout-land/activity_error.xml
+++ b/app/src/main/res/layout-land/activity_error.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- Landscape (TV, tablets/phones in landscape): explanation + actions left, code panel right.
-     The right panel matches the left block's height for symmetry, and is replaced by the QR on upload. -->
+<!-- Landscape (TV, tablets/phones in landscape): what happened and what to do about it on the left, the
+     report on the right. The right panel matches the left block's height, and its content is swapped for
+     the link and its QR once the report is sent. Same components and the same type roles as the portrait
+     layout — only the two columns differ. -->
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
@@ -48,9 +50,8 @@
                 android:layout_marginTop="16dp"
                 android:gravity="center"
                 android:text="@string/error_screen_title"
-                android:textColor="@color/white"
-                android:textSize="22sp"
-                android:textStyle="bold" />
+                android:textAppearance="@style/TextAppearance.Material3.HeadlineSmall"
+                android:textColor="@color/white" />
 
             <TextView
                 android:id="@+id/errorMessage"
@@ -61,35 +62,27 @@
                 android:lineSpacingMultiplier="1.2"
                 android:maxWidth="460dp"
                 android:text="@string/error_screen_message"
-                android:textColor="@color/error_ink_muted"
-                android:textSize="14sp" />
+                android:textAppearance="@style/TextAppearance.Material3.BodyMedium"
+                android:textColor="@color/error_ink_muted" />
 
             <include layout="@layout/error_actions" />
-
-            <ProgressBar
-                android:id="@+id/uploadProgress"
-                style="?android:attr/progressBarStyleHorizontal"
-                android:layout_width="200dp"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="4dp"
-                android:indeterminate="true"
-                android:indeterminateTint="?attr/colorPrimary"
-                android:visibility="gone"
-                tools:visibility="visible" />
         </LinearLayout>
 
-        <!-- Right: code panel, stretched to the left block's height; swapped for the QR on upload. -->
+        <!-- Right: the report, stretched to the left block's height. -->
         <FrameLayout
             android:layout_width="0dp"
             android:layout_height="match_parent"
             android:layout_weight="1"
             android:background="@drawable/bg_error_panel">
 
+            <!-- See the portrait layout: not focusable, not selectable, capped in lines. -->
             <TextView
                 android:id="@+id/errorDetails"
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
+                android:ellipsize="end"
                 android:fontFamily="monospace"
+                android:maxLines="10"
                 android:padding="16dp"
                 android:textColor="@color/error_ink_muted"
                 android:textSize="13sp"
@@ -109,19 +102,27 @@
                     android:id="@+id/qrImage"
                     android:layout_width="180dp"
                     android:layout_height="180dp"
-                    android:background="@color/white"
                     android:contentDescription="@string/error_qr_description"
-                    android:padding="10dp" />
+                    android:scaleType="fitCenter" />
 
                 <TextView
                     android:id="@+id/uploadUrl"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_marginTop="12dp"
+                    android:focusable="false"
+                    android:textAppearance="@style/TextAppearance.Material3.BodyMedium"
                     android:textColor="?attr/colorPrimary"
-                    android:textSize="15sp"
-                    android:textStyle="bold"
                     tools:text="https://termbin.com/abcd" />
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="4dp"
+                    android:gravity="center"
+                    android:text="@string/error_upload_hint"
+                    android:textAppearance="@style/TextAppearance.Material3.BodySmall"
+                    android:textColor="@color/error_ink_muted" />
             </LinearLayout>
         </FrameLayout>
 

--- a/app/src/main/res/layout/activity_error.xml
+++ b/app/src/main/res/layout/activity_error.xml
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- Portrait / stacked (phones, tablets in portrait). Compact, vertically centered. -->
+<!-- Portrait / stacked (phones, tablets in portrait). One screen, no page scroll: halo, what happened,
+     the report actions, then the report itself. Type comes from the Material 3 roles rather than literal
+     sizes — Headline Small for the title, Body Medium for the copy — and the code panel keeps its own
+     monospace, which is outside the type scale on purpose. -->
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
@@ -32,9 +35,8 @@
         android:layout_marginTop="18dp"
         android:gravity="center"
         android:text="@string/error_screen_title"
-        android:textColor="@color/white"
-        android:textSize="22sp"
-        android:textStyle="bold" />
+        android:textAppearance="@style/TextAppearance.Material3.HeadlineSmall"
+        android:textColor="@color/white" />
 
     <TextView
         android:id="@+id/errorMessage"
@@ -45,35 +47,29 @@
         android:lineSpacingMultiplier="1.2"
         android:maxWidth="460dp"
         android:text="@string/error_screen_message"
-        android:textColor="@color/error_ink_muted"
-        android:textSize="14sp" />
+        android:textAppearance="@style/TextAppearance.Material3.BodyMedium"
+        android:textColor="@color/error_ink_muted" />
 
     <include layout="@layout/error_actions" />
 
-    <ProgressBar
-        android:id="@+id/uploadProgress"
-        style="?android:attr/progressBarStyleHorizontal"
-        android:layout_width="200dp"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="4dp"
-        android:indeterminate="true"
-        android:indeterminateTint="?attr/colorPrimary"
-        android:visibility="gone"
-        tools:visibility="visible" />
-
-    <!-- Code panel; its content is swapped for the QR on upload. -->
+    <!-- The report; its content is swapped for the link and its QR once the report is sent. -->
     <FrameLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginTop="16dp"
         android:background="@drawable/bg_error_panel">
 
+        <!-- Neither focusable nor selectable: on a television that pulled the D-pad into the text with
+             an invisible highlight and trapped it there. Copying is the Copy button's job. Capped in
+             lines rather than height so a long cause ends in an ellipsis — something is missing is worth
+             seeing, and the whole of it leaves by Copy, Share or the report itself. -->
         <TextView
             android:id="@+id/errorDetails"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:ellipsize="end"
             android:fontFamily="monospace"
-            android:maxHeight="200dp"
+            android:maxLines="8"
             android:padding="16dp"
             android:textColor="@color/error_ink_muted"
             android:textSize="13sp"
@@ -90,23 +86,33 @@
             android:visibility="gone"
             tools:visibility="visible">
 
+            <!-- Drawn by Utils.qrBitmap, opaque black on white with its own two-module quiet zone, so
+                 the view adds no plate of its own. -->
             <ImageView
                 android:id="@+id/qrImage"
                 android:layout_width="160dp"
                 android:layout_height="160dp"
-                android:background="@color/white"
                 android:contentDescription="@string/error_qr_description"
-                android:padding="8dp" />
+                android:scaleType="fitCenter" />
 
             <TextView
                 android:id="@+id/uploadUrl"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="10dp"
+                android:focusable="false"
+                android:textAppearance="@style/TextAppearance.Material3.BodyMedium"
                 android:textColor="?attr/colorPrimary"
-                android:textSize="15sp"
-                android:textStyle="bold"
                 tools:text="https://termbin.com/abcd" />
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="4dp"
+                android:gravity="center"
+                android:text="@string/error_upload_hint"
+                android:textAppearance="@style/TextAppearance.Material3.BodySmall"
+                android:textColor="@color/error_ink_muted" />
         </LinearLayout>
     </FrameLayout>
 

--- a/app/src/main/res/layout/error_actions.xml
+++ b/app/src/main/res/layout/error_actions.xml
@@ -1,44 +1,85 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- Shared player-style icon action row (Copy / Share / Upload log / Close). -->
+<!--
+    The action block of the error screen, shared by both orientations: the report on its own line, then
+    the three that do not send it.
+
+    Sending the report is what this screen exists for once the video has already failed, so it is the one
+    filled button on the surface (§7: at most one) and the only one carrying a glyph; the other three are
+    outlined and lettered in the surface's quieter ink, so the brand is not spent on Close. All four are
+    real buttons with an edge and the 2dp focus contour Utils.focusRing widens on a remote — the row this
+    replaces was four unframed glyphs (background="@null") with no focus mark at all, which is R4 and R5
+    and the one correctness item DESIGN.md §10 had open against this screen.
+
+    Gaps trail rather than lead, so hiding Copy on a television — where a clipboard has no way out —
+    leaves the remaining two centred rather than 8dp off.
+-->
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
     android:layout_marginTop="20dp"
-    android:gravity="center"
-    android:orientation="horizontal">
+    android:gravity="center_horizontal"
+    android:orientation="vertical">
 
-    <ImageButton
-        android:id="@+id/btnCopy"
-        style="@style/ErrorActionButton"
-        android:layout_marginEnd="6dp"
-        android:contentDescription="@string/error_copy"
-        android:nextFocusRight="@+id/btnShare"
-        android:src="@drawable/ic_content_copy_24dp" />
-
-    <ImageButton
-        android:id="@+id/btnShare"
-        style="@style/ErrorActionButton"
-        android:layout_marginEnd="6dp"
-        android:contentDescription="@string/error_share"
-        android:nextFocusLeft="@id/btnCopy"
-        android:nextFocusRight="@+id/btnUpload"
-        android:src="@drawable/ic_share_24dp" />
-
-    <ImageButton
+    <com.google.android.material.button.MaterialButton
         android:id="@+id/btnUpload"
-        style="@style/ErrorActionButton"
-        android:layout_marginEnd="6dp"
-        android:contentDescription="@string/error_upload"
-        android:nextFocusLeft="@id/btnShare"
-        android:nextFocusRight="@+id/btnClose"
-        android:src="@drawable/ic_cloud_upload_24dp" />
+        style="@style/Widget.JustPlus.Button.Filled"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:nextFocusDown="@+id/btnClose"
+        android:text="@string/error_upload"
+        app:icon="@drawable/ic_cloud_upload_24dp" />
 
-    <ImageButton
-        android:id="@+id/btnClose"
-        style="@style/ErrorActionButton"
-        android:contentDescription="@string/error_close"
-        android:nextFocusLeft="@id/btnUpload"
-        android:src="@drawable/ic_close_24dp"
-        android:tint="?attr/colorPrimary" />
+    <!-- Indeterminate because termbin answers with the URL and nothing before it: there is no progress
+         to report, only work in hand. Material's own indicator, in place of the platform ProgressBar
+         the screen used to draw. -->
+    <com.google.android.material.progressindicator.LinearProgressIndicator
+        android:id="@+id/uploadProgress"
+        android:layout_width="200dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
+        android:indeterminate="true"
+        android:visibility="gone"
+        tools:visibility="visible" />
+
+    <LinearLayout
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
+        android:gravity="center"
+        android:orientation="horizontal">
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/btnCopy"
+            style="@style/Widget.JustPlus.Button.Dialog.Outlined.Flush"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginEnd="8dp"
+            android:nextFocusUp="@id/btnUpload"
+            android:nextFocusRight="@+id/btnShare"
+            android:text="@string/error_copy" />
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/btnShare"
+            style="@style/Widget.JustPlus.Button.Dialog.Outlined.Flush"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginEnd="8dp"
+            android:nextFocusUp="@id/btnUpload"
+            android:nextFocusLeft="@id/btnCopy"
+            android:nextFocusRight="@+id/btnClose"
+            android:text="@string/error_share" />
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/btnClose"
+            style="@style/Widget.JustPlus.Button.Dialog.Outlined.Flush"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:nextFocusUp="@id/btnUpload"
+            android:nextFocusLeft="@id/btnShare"
+            android:text="@string/error_close" />
+
+    </LinearLayout>
 
 </LinearLayout>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -23,6 +23,7 @@
     <string name="error_uploading">Отправка…</string>
     <string name="error_upload_failed">Не удалось отправить — нажмите, чтобы повторить</string>
     <string name="error_upload_hint">Отсканируйте код или откройте ссылку, чтобы поделиться этим отчётом.</string>
+    <string name="error_copy_link">Копировать ссылку</string>
     <string name="error_qr_description">QR-код со ссылкой на отправленный отчёт</string>
     <string name="error_close">Закрыть</string>
     <string name="open_subtitles">Загрузить субтитры</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -35,6 +35,7 @@
     <string name="error_uploading">Надсилання…</string>
     <string name="error_upload_failed">Не вдалося надіслати — торкніться, щоб повторити</string>
     <string name="error_upload_hint">Відскануйте код або відкрийте посилання, щоб поділитися цим звітом.</string>
+    <string name="error_copy_link">Копіювати посилання</string>
     <string name="error_qr_description">QR-код із посиланням на надісланий звіт</string>
     <string name="error_close">Закрити</string>
     <string name="request_scope">Щоб автоматично завантажити субтитри, або увімкнути перехід до наступного файлу в теці, надайте %s доступ до головної теки з вашими відеофайлами (наприклад \"Відео\").</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -36,6 +36,7 @@
     <string name="error_uploading">Uploading…</string>
     <string name="error_upload_failed">Upload failed — tap to retry</string>
     <string name="error_upload_hint">Scan the code or open the link to share this report.</string>
+    <string name="error_copy_link">Copy link</string>
     <string name="error_qr_description">QR code linking to the uploaded report</string>
     <string name="error_close">Close</string>
     <string name="request_scope">To automatically load external subtitles or enable skipping to next file in a directory, grant %s access to the topmost folder containing your videos (e.g. Movies).</string>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -61,16 +61,6 @@
     </style>
 
     <!-- Player-style icon action button: transparent, borderless ripple, tinted glyph. -->
-    <style name="ErrorActionButton">
-        <item name="android:layout_width">54dp</item>
-        <item name="android:layout_height">54dp</item>
-        <item name="android:padding">14dp</item>
-        <item name="android:scaleType">fitCenter</item>
-        <item name="android:background">@null</item>
-        <item name="android:tint">@color/white</item>
-        <item name="android:focusable">true</item>
-    </style>
-
     <style name="BaseTheme.Error" parent="Theme.Material3.Dark.NoActionBar">
         <!-- The accent as roles (attrs.xml). These are the coral overlay's dark values, so every
              ?attr/accent* below resolves even where no overlay was applied; the overlay itself is put


### PR DESCRIPTION
Two things, both found by looking at the built app on a phone.

## A field dialog scrolls rather than squeezing its last field

Join a room, on a 1080x2412 phone at 480dpi with the keyboard up: the Code field stood **167px** tall and the Password field under it **60px** — 20dp, with its own top and bottom stroke. A complete box a third of the height it should be, measured that small rather than clipped.

Two numbers were against it:

- an alert dialog measures its custom panel at **exactly** the room left over, and `AlertController` adds the custom view as `MATCH_PARENT`, so a vertical strip of fields hands each child only what the ones above it left — and the last `TextInputLayout` clamps itself to the remainder;
- Material keeps **80dp above and 80dp below** an alert (`mtrl_alert_dialog_background_inset_top/bottom`), which is 160dp of window the card may not use. The dialog measures 400dp; a phone whose keyboard is 1126px tall leaves 385dp. `dumpsys window` said it plainly: `Requested h=1273` against a parent frame of 1110px.

So the strip goes in a scroller, and the card's background insets come down to **24dp** — the value Material itself leaves around a picker dialog. One helper, `Utils.fieldDialog`, for the four dialogs that carry fields.

Reproduced on `ddd_test` at `wm density 480` + `wm size 1080x2120` (the same 1110px window): before, the second field measured 4px of visible box; after, the panel is 414px with **both fields at 167px** and the action row at 144px, so there is nothing left to scroll. The scroller and its indicators still stand behind that for a taller keyboard or a third field.

## A report is sent with a button, not a bare glyph

The error screen was the one surface left outside the design system, and it showed in the row it ended with: four `ImageButton`s with `background="@null"`, **no frame and no focus mark at all** — the open correctness item against this screen.

Sending the report is what the screen is for once the video has already failed, so that action is the **one filled button** on the surface and the only one carrying a glyph; Copy, Share and Close are outlined and lettered `colorOnSurfaceVariant`. Every one is a real button with `Utils.focusRing`: measured on `tv_720p`, the focused edge is **2dp #E6E0E9 at 15.23:1** against the wash, where it rests at **1dp #938F99 and 6.23:1**.

With it: literal 22/14sp → Headline Small and Body Medium, and a set takes the TV column of the type scale (26/17/15sp) · platform `ProgressBar` → `LinearProgressIndicator` · both toasts → the snackbar the rest of the app uses · the QR drawn by `Utils.qrBitmap` instead of fetched from `api.qrserver.com`, which had been handing the report's URL to a third service on the way to showing it · the filled button then carries the link it earned, so a television can reach a URL that is deliberately unfocusable text · the code panel capped in lines with an ellipsis rather than in height, where a long cause used to be cut with nothing to say so.

Measured at 420dpi: filled button 142x48dp, the three outlined 80/85/84 by 48dp, **8dp** between them, the row **265dp** — one line inside a 360dp phone's 304dp of usable width. Gaps trail rather than lead, so hiding Copy on a television leaves the remaining two centred.

## Checked

Both orientations on `ddd_test` (420 and 480dpi) and on `tv_720p`, with a real report sent to termbin; the error screen reached through `am crash`. `./gradlew assembleLatestUniversalDebug` clean on this branch.