### PR TITLE
Make a held seek key follow the picture, and fit its stride to the file

### DIFF
--- a/app/src/main/java/com/brouken/player/PlayerActivity.java
+++ b/app/src/main/java/com/brouken/player/PlayerActivity.java
@@ -881,6 +881,8 @@ public class PlayerActivity extends Activity {
     // than a step can be aimed at. One step per floor makes a hold the same speed on any box and any
     // remote; clicks arrive further apart than this and are untouched.
     private static final long KEY_HOLD_STEP_FLOOR_MS = 200;
+    // A source that stops delivering frames must not freeze a held key: past this, step anyway.
+    private static final long KEY_HOLD_STEP_CEILING_MS = 600;
     private final Runnable keyScrubCommit = this::commitKeyScrub;
     // A passthrough AudioTrack that has been paused and resumed comes back silent on a fair number of TVs
     // and receivers: the bitstream still leaves the box but nothing downstream re-locks onto it. Video keeps
@@ -3323,7 +3325,15 @@ public class PlayerActivity extends Activity {
     private boolean seekWithKey(boolean forward, boolean held) {
         if (player == null)
             return false;
-        if (held && SystemClock.uptimeMillis() - keyScrubLastMs < KEY_HOLD_STEP_FLOOR_MS)
+        final long now = SystemClock.uptimeMillis();
+        // Not faster than the floor, and — until the last step is on screen — not faster than the
+        // ceiling. The step used to run on a timer alone while the seek behind it was dropped whenever
+        // no frame had come back, so on heavy material off a network source the readout kept a 210 ms
+        // stride while the picture managed 270-330 ms, and by the end of a hold the number promised a
+        // position nothing had drawn yet. Aiming is done by watching the picture, so the hold has to
+        // keep the slower of the two rates.
+        if (held && now - keyScrubLastMs
+                < (frameRendered ? KEY_HOLD_STEP_FLOOR_MS : KEY_HOLD_STEP_CEILING_MS))
             return true;
         playerView.removeCallbacks(playerView.textClearRunnable);
         // The bar the touch gestures raise is what lets their readout carry only the delta; the one path
@@ -3341,10 +3351,12 @@ public class PlayerActivity extends Activity {
             final long seekTo = Math.max(0, pos + (forward ? 3_000 : -3_000));
             player.setSeekParameters(forward ? SeekParameters.NEXT_SYNC : SeekParameters.PREVIOUS_SYNC);
             player.seekTo(seekTo);
+            // Without this the two limits above never bite here — the last-step stamp would stay at
+            // whatever some earlier media left it, and a held key would seek once per key repeat.
+            keyScrubLastMs = now;
             showKeySeekMessage(seekTo);
             return true;
         }
-        final long now = SystemClock.uptimeMillis();
         // A reversal is the correction after an overshoot, so the ladder starts over: the step that
         // carried past the mark must not carry back past it just as fast.
         keyScrubSteps = forward == keyScrubForward && (held || now - keyScrubLastMs < 450) ? keyScrubSteps + 1 : 0;
@@ -3354,8 +3366,9 @@ public class PlayerActivity extends Activity {
         final long step = keyScrubStep(duration);
         keyScrubTarget = Math.max(0, Math.min(duration, from + (forward ? step : -step)));
         showKeySeekMessage(keyScrubTarget);
-        // Seek now if the previous seek has landed, so the picture and the bar follow the presses. A held
-        // key outruns the gate, so the commit below still lands on the target once the presses stop.
+        // Seek now if the previous seek has landed, so the picture and the bar follow the presses. A step
+        // taken on the ceiling finds the gate still shut, so the commit below lands on the target once
+        // the presses stop.
         setKeySeekDirection(keyScrubTarget);
         if (seekIfLanded(keyScrubTarget)) {
             keyScrubSeeked = keyScrubTarget;

--- a/app/src/main/java/com/brouken/player/PlayerActivity.java
+++ b/app/src/main/java/com/brouken/player/PlayerActivity.java
@@ -3398,16 +3398,23 @@ public class PlayerActivity extends Activity {
      * biggest stride that can still be stood on: seeking from the picture is the fine adjustment, the
      * long jump across a film is the bar's job (a minute per press there), so the ladder stops short of
      * the bar's territory instead of climbing to a share of the duration that has no position between
-     * two presses. The share only keeps a rung from outgrowing a short file.
+     * two presses. The share keeps every rung from outgrowing a short file.
      */
     private long keyScrubStep(long duration) {
+        // The share caps every rung, not just the last one. With only the top rung scaled, the eight
+        // fixed rungs (146 s in total) outgrow any short file — a 2:00 clip was crossed in eight steps
+        // at a 30 s stride — and where the file was long enough to reach the scaled rung, that rung came
+        // out smaller than the fixed one before it, so the ladder turned back on itself. The lower bound
+        // keeps the cap from falling under what a single click is worth, which is also why the first
+        // rung needs no capping.
+        final long cap = Math.min(60_000, Math.max(3_000, duration / 10));
         if (keyScrubSteps < 2)
             return 3_000;
         if (keyScrubSteps < 4)
-            return 10_000;
+            return Math.min(10_000, cap);
         if (keyScrubSteps < 8)
-            return 30_000;
-        return Math.min(60_000, duration / 10);
+            return Math.min(30_000, cap);
+        return cap;
     }
 
     private void showKeySeekMessage(long target) {


### PR DESCRIPTION
Two reports about the same held key, from opposite ends: the readout runs ahead of the picture on
heavy material, and the ladder behind it does not fit a short file.

### A rendered frame now gates the step, not just the seek

The target and the readout moved on a timer alone — one step per `KEY_HOLD_STEP_FLOOR_MS` — while
the seek behind each step went out only if the previous one had rendered a frame, and was silently
dropped otherwise. Two independent clocks, and on a 4K Dolby Vision file off a NAS they diverge:
a 210 ms stride on the readout against 270–330 ms on the picture, half the intervals over a quarter
second, so a four-second hold ends with the number several steps ahead of anything drawn.

The gate is right — queueing seeks a decoder cannot service would be worse — so a rendered frame
became a reason to *wait for* the next step rather than only a reason to drop a seek. With a frame on
screen the floor is the limit; without one the ceiling is, and the ceiling (600 ms, about 1.5 steps a
second at worst) is the safety valve so a source that stops delivering frames slows the hold down
instead of stopping it dead.

A local file is unchanged: the frame is back in 40–80 ms, long before the floor expires. On 4K over
the network the hold drops from roughly five steps a second to three, and a four-second blind hold
covers about eight minutes instead of fourteen — the deliberate half of the trade, leaning on the
same division of labour as the ladder itself.

The live and unknown-duration branch never stamped `keyScrubLastMs`, so neither limit could bite
there and a held key seeked once per key repeat. Found while reading, fixed in the same commit.

### The file's share caps every rung

Eight fixed rungs (3, 3, 10, 10 and four of 30 seconds, 146 s in all) and only the last one scaled.
A 2:00 clip was therefore crossed in eight steps at a 30 s stride, a 0:25 clip in four; and where a
file was long enough to reach the scaled rung but under five minutes, that rung came out *smaller*
than the fixed one before it, so the acceleration reversed. Capping every rung by `duration / 10`
makes the ladder monotonic at every duration by construction, and its lower bound restores the floor
the ladder has been missing.

Films and episodes are untouched — the share only bites below ten minutes, and only reaches the lower
rungs below five.

### Verified

Built `assembleLatestUniversalDebug` (JDK 17, as CI does).

The ladder was measured on `tv_720p` against generated `testsrc` clips with a one-second GOP
(a short GOP is required: `SeekParameters.NEXT_SYNC` rounds every small step up to the next sync
sample, and the lower rungs cannot be observed on a sparse-keyframe file). Steps were delivered as
`MEDIA_FAST_FORWARD`, which reaches `seekWithKey` regardless of whether the controls are up, and the
offset was read off a `screencap` taken in the same shell invocation.

| Clip | Steps | Measured | Arithmetic | Before |
|---|---|---|---|---|
| 3:00 | 8 | **+01:38** = 98 s | 3+3+10+10+18×4 | 146 s |
| 3:00 | 9 | **+01:56** = 116 s | 98 + 18 | 164 s — the 9th rung was 18 s after four of 30 |
| 2:00 | 8 | **+01:14** = 74 s, 62 % | 3+3+10+10+12×4 | 146 s, clamped at the end |
| 0:25 | 4 | **+00:12** = 12 s, 54 % | 3×4 | 26 s, clamped at the end |
| 4:00 | 9 | **+02:26** = 146 s | 3+3+10+10+24×5 | 170 s |

The 3:00 pair is the reversal, gone: the ninth increment is now equal to the eighth rather than
smaller. Every figure matches the arithmetic exactly.

The held path could not be checked there — `input keyevent` always sends DOWN and UP together, so
`getRepeatCount()` stays 0, `held` is never true and the new guard is not reached; `emu event send`
does not reach the app and `sendevent` is blocked by SELinux on a production build. A genuine
multi-second hold on 4K Dolby Vision from a NAS still wants a real remote.

`./gradlew lint` was not run: it crashes on JDK 17 in this environment for reasons unrelated to this
change.

Closes #194
Closes #196
